### PR TITLE
GARD and aBSREL branch selection fixes

### DIFF
--- a/app/absrel/absrel.js
+++ b/app/absrel/absrel.js
@@ -1,5 +1,6 @@
 var config = require("../../config.json"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
+  code = require("../code").code,
   util = require("util"),
   fs = require("fs"),
   path = require("path");
@@ -18,7 +19,7 @@ var absrel = function(socket, stream, params) {
   // parameter attributes
   self.msaid = self.params.msa._id;
   self.id = self.params.analysis._id;
-  self.genetic_code = self.params.msa[0].gencodeid + 1;
+  self.genetic_code = code[self.params.msa[0].gencodeid + 1];
   self.nwk = self.params.analysis.tagged_nwk_tree;
 
   // parameter-derived attributes

--- a/app/absrel/absrel.sh
+++ b/app/absrel/absrel.sh
@@ -15,7 +15,6 @@ GENETIC_CODE=$genetic_code
 HYPHY=$CWD/../../.hyphy/hyphy
 
 export HYPHY_PATH=$CWD/../../.hyphy/res/
-ABSREL=$HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/aBSREL.bf
 
-echo "(echo '$GENETIC_CODE'; echo '$FN'; echo '$TREE_FN'; echo 5; echo 4; echo $RESULTS_FN;) | $HYPHY -i LIBPATH=$HYPHY_PATH $ABSREL"
-(echo $GENETIC_CODE; echo $FN; echo $TREE_FN; echo 5; echo 4; echo $RESULTS_FN;) | $HYPHY -i LIBPATH=$HYPHY_PATH $ABSREL >> $PROGRESS_FILE
+echo "$HYPHY LIBPATH=$HYPHY_PATH absrel --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --branches FG --output $RESULTS_FN >> $PROGRESS_FILE"
+$HYPHY LIBPATH=$HYPHY_PATH absrel --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --branches FG --output $RESULTS_FN >> $PROGRESS_FILE

--- a/app/code.js
+++ b/app/code.js
@@ -1,0 +1,21 @@
+exports.code = {
+  "1": "Universal",
+  "2": "Vertebrate-mtDNA",
+  "3": "Yeast-mtDNA",
+  "4": "Mold-Protozoan-mtDNA",
+  "5": "Invertebrate-mtDNA",
+  "6": "Ciliate-Nuclear",
+  "7": "Echinoderm-mtDNA",
+  "8": "Euplotid-Nuclear",
+  "9": "Alt-Yeast-Nuclear",
+  "10": "Ascidian-mtDNA",
+  "11": "Flatworm-mtDNA",
+  "12": "Blepharisma-Nuclear",
+  "13": "Chlorophycean-mtDNA",
+  "14": "Trematode-mtDNA",
+  "15": "Scenedesmus-obliquus-mtDNA",
+  "16": "Thraustochytrium-mtDNA",
+  "17": "Pterobranchia-mtDNA",
+  "18": "SR1-and-Gracilibacteria",
+  "19": "Pachysolen-Nuclear"
+};

--- a/app/fubar/fubar.js
+++ b/app/fubar/fubar.js
@@ -32,11 +32,6 @@ var fubar = function(socket, stream, params) {
 
   // advanced options
   self.number_of_grid_points = self.params.analysis.number_of_grid_points;
-  self.number_of_mcmc_chains = self.params.analysis.number_of_mcmc_chains;
-  self.length_of_each_chain = self.params.analysis.length_of_each_chain;
-  self.number_of_burn_in_samples =
-    self.params.analysis.number_of_burn_in_samples;
-  self.number_of_samples = self.params.analysis.number_of_samples;
   self.concentration_of_dirichlet_prior =
     self.params.analysis.concentration_of_dirichlet_prior;
 
@@ -70,14 +65,6 @@ var fubar = function(socket, stream, params) {
       self.msaid +
       ",number_of_grid_points=" +
       self.number_of_grid_points +
-      ",number_of_mcmc_chains=" +
-      self.number_of_mcmc_chains +
-      ",length_of_each_chain=" +
-      self.length_of_each_chain +
-      ",number_of_burn_in_samples=" +
-      self.number_of_burn_in_samples +
-      ",number_of_samples=" +
-      self.number_of_samples +
       ",concentration_of_dirichlet_prior=" +
       self.concentration_of_dirichlet_prior,
     "-o",

--- a/app/fubar/fubar.sh
+++ b/app/fubar/fubar.sh
@@ -18,11 +18,6 @@ HYPHY_PATH=$CWD/../../.hyphy/res/
 RESULTS_FILE=$fn.FUBAR.json
 CACHE_FILE=$fn.FUBAR.cache
 GRIDPOINTS=$number_of_grid_points
-POSTERIORESTIMATIONMETHOD=1
-CHAINS=$number_of_mcmc_chains
-LENGTH=$length_of_each_chain
-BURNIN=$number_of_burn_in_samples
-SAMPLES=$number_of_samples
 CONCENTRATION=$concentration_of_dirichlet_prior
 
 FUBAR=$HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FUBAR.bf
@@ -30,7 +25,7 @@ FUBAR=$HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FUBAR.bf
 export HYPHY_PATH=$HYPHY_PATH
 trap 'echo "Error" > $STATUS_FILE; exit 1' ERR
 
-echo '(echo '$GENETIC_CODE'; echo '$FN'; echo '$TREE_FN'; echo '$CACHE_FILE'; echo '$GRIDPOINTS'; echo '$POSTERIORESTIMATIONMETHOD'; echo '$CHAINS'; echo '$LENGTH'; echo '$BURNIN'; echo '$SAMPLES'; echo '$CONCENTRATION'; echo '$RESULTS_FILE';) | '$HYPHY' -i LIBPATH='$HYPHY_PATH' ' $FUBAR''
-(echo $GENETIC_CODE; echo $FN; echo $TREE_FN; echo $CACHE_FILE; echo $GRIDPOINTS; echo $POSTERIORESTIMATIONMETHOD; echo $CHAINS; echo $LENGTH; echo $BURNIN; echo $SAMPLES; echo $CONCENTRATION; echo $RESULTS_FILE;) | $HYPHY -i LIBPATH=$HYPHY_PATH $FUBAR > $PROGRESS_FILE
+echo "$HYPHY LIBPATH=$HYPHY_PATH fubar --alignment $FN --tree $TREE_FN --concentration_parameter $CONCENTRATION --grid $GRIDPOINTS --output $RESULTS_FN >> $PROGRESS_FILE"
+$HYPHY LIBPATH=$HYPHY_PATH fubar --alignment $FN --tree $TREE_FN --concentration_parameter $CONCENTRATION --grid $GRIDPOINTS --output $RESULTS_FN >> $PROGRESS_FILE
 
 echo "Completed" > $STATUS_FILE

--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -1,5 +1,6 @@
 var config = require("../../config.json"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
+  code = require("../code").code,
   util = require("util"),
   fs = require("fs"),
   path = require("path");
@@ -18,13 +19,17 @@ var gard = function(socket, stream, params) {
   // parameter attributes
   self.msaid = self.params.msa._id;
   self.id = self.params.analysis._id;
-  var variation_map = { none: 1, general_discrete: 2, beta_gamma: 3 };
+  var variation_map = {
+    none: 'None', general_discrete: 'GDD', beta_gamma: 'Gamma'
+  };
   self.rate_variation =
     variation_map[self.params.analysis.site_to_site_variation];
   self.rate_classes = self.params.analysis.rate_classes || 2;
-  self.genetic_code = self.params.msa[0].gencodeid + 1;
+  self.genetic_code = code[self.params.msa[0].gencodeid + 1];
   self.nj = self.params.msa[0].nj;
-  self.data_type = self.params.msa[0].datatype;
+  self.data_type = ['Codon', 'Nucleotide', 'Protein'][
+    self.params.msa[0].datatype
+  ];
 
   // parameter-derived attributes
   self.fn = __dirname + "/output/" + self.id;

--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -1,12 +1,20 @@
 var config = require("../../config.json"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
-  code = require("../code").code,
+  redis = require("redis"),
   util = require("util"),
+  winston = require("winston"),
   fs = require("fs"),
-  path = require("path");
+  path = require("path"),
+  translate_gard = require("translate-gard");
+
+// Use redis as our key-value store
+var client = redis.createClient();
 
 var gard = function(socket, stream, params) {
   var self = this;
+
+  var variation_map = { none: 1, general_discrete: 2, beta_gamma: 3 };
+
   self.socket = socket;
   self.stream = stream;
   self.params = params;
@@ -19,26 +27,26 @@ var gard = function(socket, stream, params) {
   // parameter attributes
   self.msaid = self.params.msa._id;
   self.id = self.params.analysis._id;
-  var variation_map = {
-    none: 'None', general_discrete: 'GDD', beta_gamma: 'Gamma'
-  };
   self.rate_variation =
     variation_map[self.params.analysis.site_to_site_variation];
   self.rate_classes = self.params.analysis.rate_classes || 2;
-  self.genetic_code = code[self.params.msa[0].gencodeid + 1];
+  self.genetic_code = self.params.msa[0].gencodeid + 1;
   self.nj = self.params.msa[0].nj;
-  self.data_type = ['Codon', 'Nucleotide', 'Protein'][
-    self.params.msa[0].datatype
-  ];
 
   // parameter-derived attributes
   self.fn = __dirname + "/output/" + self.id;
   self.output_dir = path.dirname(self.fn);
   self.status_fn = self.fn + ".status";
-  self.results_short_fn = self.fn + "gard";
-  self.results_fn = self.fn + ".GARD.json";
+  self.results_fn = self.fn + ".GARD";
   self.progress_fn = self.fn + ".GARD.progress";
   self.tree_fn = self.fn + ".tre";
+
+  // output fn
+  self.html_results_fn = self.results_fn;
+  self.finalout_results_fn = self.results_fn + "_finalout";
+  self.ga_details_results_fn = self.results_fn + "_ga_details";
+  self.splits = self.results_fn + "_splits";
+  self.json_fn = self.results_fn + ".json";
 
   self.qsub_params = [
     "-l walltime=" + 
@@ -50,20 +58,24 @@ var gard = function(socket, stream, params) {
     "-v",
     "fn=" +
       self.fn +
+      ",tree_fn=" +
+      self.tree_fn +
       ",sfn=" +
       self.status_fn +
       ",pfn=" +
       self.progress_fn +
       ",rfn=" +
-      self.results_short_fn +
+      self.results_fn +
+      ",treemode=" +
+      self.treemode +
       ",genetic_code=" +
       self.genetic_code +
       ",rate_var=" +
       self.rate_variation +
       ",rate_classes=" +
       self.rate_classes +
-      ",data_type=" +
-      self.data_type +
+      ",analysis_type=" +
+      self.type +
       ",cwd=" +
       __dirname +
       ",msaid=" +
@@ -86,4 +98,64 @@ var gard = function(socket, stream, params) {
 };
 
 util.inherits(gard, hyphyJob);
+
+gard.prototype.sendNexusFile = function(cb) {
+  var self = this;
+
+  fs.readFile(self.finalout_results_fn, function(err, results) {
+    if (results) {
+      self.socket.emit("gard nexus file", { buffer: results });
+      cb(null, "success!");
+    } else {
+      cb(self.finalout_results_fn + ": no gard nexus to send", null);
+    }
+  });
+};
+
+gard.prototype.onComplete = function() {
+  var self = this;
+
+  var files = {
+    html: self.html_results_fn,
+    finalout: self.finalout_results_fn,
+    ga_details: self.ga_details_results_fn,
+    splits: self.splits,
+    json: self.json_fn
+  };
+
+  winston.info("gard results files to translate : " + JSON.stringify(files));
+
+  self.sendNexusFile((err, success) => {
+    translate_gard.toJSON(files, (err, data) => {
+      if (err) {
+        // Error reading results file
+        self.onError("unable to read results file. " + err);
+      } else {
+        if (data) {
+          var stringified_results = JSON.stringify(data);
+
+          // Prepare redis packet for delivery
+          var redis_packet = { results: stringified_results };
+          redis_packet.type = "completed";
+          var str_redis_packet = JSON.stringify(redis_packet);
+
+          // Log that the job has been completed
+          self.log("complete", "success");
+
+          // Store packet in redis and publish to channel
+          client.hset(self.id, "results", str_redis_packet);
+          client.hset(self.id, "status", "completed");
+          client.publish(self.id, str_redis_packet);
+
+          // Remove id from active_job queue
+          client.lrem("active_jobs", 1, self.id);
+        } else {
+          // Empty results file
+          self.onError("job seems to have completed, but no results found");
+        }
+      }
+    });
+  });
+};
+
 exports.gard = gard;

--- a/app/gard/gard.sh
+++ b/app/gard/gard.sh
@@ -3,8 +3,7 @@
 export PATH=/usr/local/bin:$PATH
 source /etc/profile.d/modules.sh
 
-module load openmpi/gnu/3.0
-module load aocc/1.2.1
+module load aocc/1.3.0
 
 FN=$fn
 CWD=$cwd
@@ -18,7 +17,7 @@ RATE_VARIATION=$rate_var
 RATE_CLASSES=$rate_classes
 DATA_TYPE=$data_type
 
-HYPHY=$CWD/../../.hyphy/HYPHYMPI
+HYPHY=$CWD/../../.hyphy/hyphy
 HYPHY_PATH=$CWD/../../.hyphy/res/
 GARD=$HYPHY_PATH/TemplateBatchFiles/GARD.bf
 
@@ -40,45 +39,13 @@ export HYPHY_PATH=$HYPHY_PATH
 
 trap 'echo "Error" > $STATUS_FILE; exit 1' ERR
 
-# codon
-if [ $DATA_TYPE -eq 0 ]
+if [ $RATE_VARIATION == "None" ]
 then
-  if (($RATE_VARIATION < 2))
-  then
-    echo '(echo 3; echo '$GENETIC_CODE'; echo '$FN'; echo '$RATE_VARIATION'; echo '$RESULTS_FN'; echo '$SNAPSHOT_FILE';) | mpirun -np 16 '$HYPHY' -i LIBPATH='$HYPHY_PATH' ' $GARD''
-    (echo 3; echo $GENETIC_CODE; echo $FN; echo $RATE_VARIATION; echo $RESULTS_FN; echo $SNAPSHOT_FILE;) | mpirun -np 16 $HYPHY -i LIBPATH=$HYPHY_PATH $GARD > $PROGRESS_FILE
-  else
-    echo '(echo 3; echo '$GENETIC_CODE'; echo '$FN'; echo '$RATE_VARIATION'; echo '$RATE_CLASSES'; echo '$RESULTS_FN'; echo '$SNAPSHOT_FILE';) | mpirun -np 16 '$HYPHY' -i LIBPATH='$HYPHY_PATH' ' $GARD''
-    (echo 3; echo $GENETIC_CODE; echo $FN; echo $RATE_VARIATION; echo $RATE_CLASSES; echo $RESULTS_FN; echo $SNAPSHOT_FILE) | mpirun -np 16 $HYPHY -i LIBPATH=$HYPHY_PATH $GARD > $PROGRESS_FILE
-  fi
-fi
-
-# nucleotide
-if [ $DATA_TYPE -eq 1 ]
-then
-   if (($RATE_VARIATION < 2))
-  then
-    echo '(echo 1; echo '$FN'; echo '$RATE_VARIATION'; echo '$RESULTS_FN'; echo '$SNAPSHOT_FILE';) | mpirun -np 16 '$HYPHY' -i LIBPATH='$HYPHY_PATH' ' $GARD''
-    (echo 1; echo $FN; echo $RATE_VARIATION; echo $RESULTS_FN; echo $SNAPSHOT_FILE;) | mpirun -np 16 $HYPHY -i LIBPATH=$HYPHY_PATH $GARD > $PROGRESS_FILE
-  else
-    echo '(echo 1; echo '$FN'; echo '$RATE_VARIATION'; echo '$RATE_CLASSES'; echo '$RESULTS_FN'; echo '$SNAPSHOT_FILE') | mpirun -np 16 '$HYPHY' -i LIBPATH='$HYPHY_PATH' ' $GARD''
-    (echo 1; echo $FN; echo $RATE_VARIATION; echo $RATE_CLASSES; echo $RESULTS_FN; $SNAPSHOT_FILE;) | mpirun -np 16 $HYPHY -i LIBPATH=$HYPHY_PATH $GARD > $PROGRESS_FILE
-  fi
-fi
-
-# protein
-if [ $DATA_TYPE -eq 2 ]
-then
-   if (($RATE_VARIATION < 2))
-  then
-    echo '(echo 2; echo '$FN'; echo '$SUBSTITUTION_MODEL'; echo '$RATE_VARIATION'; echo '$RESULTS_FN'; echo '$SNAPSHOT_FILE';) | mpirun -np 16 '$HYPHY' -i LIBPATH='$HYPHY_PATH' ' $GARD''
-    (echo 2; echo $FN; echo $SUBSTITUTION_MODEL; echo $RATE_VARIATION; echo $RESULTS_FN; echo $SNAPSHOT_FILE;) | mpirun -np 16 $HYPHY -i LIBPATH=$HYPHY_PATH $GARD > $PROGRESS_FILE
-  else
-    echo '(echo 2; echo '$FN'; echo '$SUBSTITUTION_MODEL'; echo '$RATE_VARIATION'; echo '$RATE_CLASSES'; echo '$RESULTS_FN'; echo '$SNAPSHOT_FILE';) | '$HYPHY' -i LIBPATH='$HYPHY_PATH' ' $GARD''
-    (echo 2; echo $FN; echo $SUBSTITUTION_MODEL; echo $RATE_VARIATION; echo $RATE_CLASSES; echo $RESULTS_FN; echo $SNAPSHOT_FILE;) | $HYPHY -i LIBPATH=$HYPHY_PATH $GARD > $PROGRESS_FILE
-  fi
+  echo "$HYPHY LIBPATH=$HYPHY_PATH gard --alignment $FN --type $DATA_TYPE --code $GENETIC_CODE --output $RESULTS_FN --output-lf $SNAPSHOT_FILE >> $PROGRESS_FILE"
+  $HYPHY LIBPATH=$HYPHY_PATH gard --alignment $FN  --type $DATA_TYPE --code $GENETIC_CODE --output $RESULTS_FN --output-lf $SNAPSHOT_FILE >> $PROGRESS_FILE
+else
+  echo "$HYPHY LIBPATH=$HYPHY_PATH gard --alignment $FN  --type $DATA_TYPE --code $GENETIC_CODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN --output-lf $SNAPSHOT_FILE >> $PROGRESS_FILE"
+  $HYPHY LIBPATH=$HYPHY_PATH gard --alignment $FN  --type $DATA_TYPE --code $GENETIC_CODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN --output-lf $SNAPSHOT_FILE >> $PROGRESS_FILE
 fi
 
 echo "Completed" > $STATUS_FILE
-
-

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "socket.io-stream": "0.6.x",
     "tail": "0.4.x",
     "tar": "^2.0",
+    "translate-gard": "^1.0.4",
     "underscore": "1.8.x",
     "winston": "0.9.x"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,9 +1074,10 @@ tr46@^1.0.0:
   dependencies:
     punycode "^2.1.0"
 
-translate-gard@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/translate-gard/-/translate-gard-1.0.2.tgz#23b4225d6ff49c757ffb00236411692d487da4ef"
+translate-gard@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/translate-gard/-/translate-gard-1.0.4.tgz#b36e52720c7b2b9071e34d19873448326f053470"
+  integrity sha512-jT9uBS7A9FI2dJlG+KAneDbjGrQyQAEGlL/81ph9NcTO7VRJjvOLJr0vAU27rgWpPQnUafOl41i5yQdjG48xMA==
   dependencies:
     jsdom "^11.2.0"
     lodash "^4.17.4"


### PR DESCRIPTION
Reverts GARD to use HyPhy 2.3.11 (veg/hyphy#1055).
- GARD on HyPhy 2.5.1 does not seem to parallelize well (using both `mpirun -np $N HYPHYMPI` and `hyphy gard`), hence the decision to rollback
- Was unable to compile HyPhy 2.3.11 on silverback, using existing compiled version on staging.datamonkey.org (minor issue that could arise when setting up a new instance)

Fixes a bug with aBSREL branch selection (veg/hyphy#1057).

Removes MCMC options from FUBAR (veg/hyphy#1003).

Currently live at http://sshank.datamonkey.org.