### PR TITLE
Proposed resolution for #1115 (broken RELAX)

### DIFF
--- a/app/relax/relax.sh
+++ b/app/relax/relax.sh
@@ -14,7 +14,6 @@ OMEGA_RATE_CLASSES=3
 
 HYPHY=$CWD/../../.hyphy/HYPHYMP
 RESULT_FILE=$fn.RELAX.json
-GETCOUNT=$CWD/../../lib/getAnnotatedCount.bf
 
 export HYPHY_PATH=$CWD/../../.hyphy/res/
 RELAX=$HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/RELAX.bf
@@ -22,11 +21,5 @@ RELAX=$HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/RELAX.bf
 trap 'echo "Error" > $STATUS_FILE; exit 1' ERR
 count=$(echo '(echo '$TREE_FN') | '$HYPHY' '$GETCOUNT'' 2> /dev/null)
 
-if [ $count -eq 2]
-then
-  echo '(echo '$GENETIC_CODE'; echo '$FN'; echo '$TREE_FN'; echo 2; echo '$OMEGA_RATE_CLASSES'; echo '$ANALYSIS_TYPE'; echo '$RESULTS_FILE';) | '$HYPHY' -i LIBPATH='$HYPHY_PATH' '$RELAX''
-  (echo $GENETIC_CODE; echo $FN; echo $TREE_FN; echo 2; echo $OMEGA_RATE_CLASSES; echo $ANALYSIS_TYPE; echo $RESULTS_FILE;) | $HYPHY -i LIBPATH=$HYPHY_PATH $RELAX > $PROGRESS_FILE
-else
-  echo '(echo '$GENETIC_CODE'; echo '$FN'; echo '$TREE_FN'; echo 3; echo 2; echo '$OMEGA_RATE_CLASSES'; echo '$ANALYSIS_TYPE'; echo '$RESULTS_FILE';) | '$HYPHY' -i LIBPATH='$HYPHY_PATH' '$RELAX''
-  (echo $GENETIC_CODE; echo $FN; echo $TREE_FN; echo 3; echo 2; echo $OMEGA_RATE_CLASSES; echo $ANALYSIS_TYPE; echo $RESULTS_FILE;) | $HYPHY -i LIBPATH=$HYPHY_PATH $RELAX > $PROGRESS_FILE
-fi
+echo '(echo '$GENETIC_CODE'; echo '$FN'; echo '$TREE_FN'; echo --test TEST; echo --reference REFERENCE; echo --output $RESULT_FILE; echo '$OMEGA_RATE_CLASSES'; echo '$ANALYSIS_TYPE') | '$HYPHY' -i LIBPATH='$HYPHY_PATH' '$RELAX''
+(echo '$GENETIC_CODE'; echo '$FN'; echo '$TREE_FN'; echo --test TEST; echo --reference REFERENCE; echo --output $RESULT_FILE; echo '$OMEGA_RATE_CLASSES'; echo '$ANALYSIS_TYPE') | '$HYPHY' -i LIBPATH='$HYPHY_PATH' '$RELAX' > $PROGRESS_FILE


### PR DESCRIPTION
Updating command lines; with kwags, it is no longer necessary to check the #of branch classes; assuming they are named TEST and REFERENCE

This is a hot fix for issue 1115. Please test before deployment; I tested from the command (but not the whole script) from the shell, but not in the server environment.