### PR TITLE
Update GARD for HyPhy 2.5.29.

### DIFF
--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -32,6 +32,7 @@ var gard = function(socket, stream, params) {
     variation_map[self.params.analysis.site_to_site_variation];
   self.rate_classes = self.params.analysis.rate_classes || 2;
   self.genetic_code = self.params.msa[0].gencodeid + 1;
+  self.run_mode = self.params.analysis.run_mode == "1" ? "Faster": "Normal";
   self.datatype = self.params.analysis.datatype || "0";
   self.datatype = datatypes[self.datatype];
   self.nj = self.params.msa[0].nj;
@@ -75,6 +76,8 @@ var gard = function(socket, stream, params) {
       self.rate_classes +
       ",datatype=" +
       self.datatype+
+      ",run_mode=" +
+      self.run_mode+
       ",analysis_type=" +
       self.type +
       ",cwd=" +

--- a/app/gard/gard.sh
+++ b/app/gard/gard.sh
@@ -16,6 +16,7 @@ GENETIC_CODE=$genetic_code
 RATE_VARIATION=$rate_var
 RATE_CLASSES=$rate_classes
 DATATYPE=$datatype
+RUN_MODE=$run_mode
 
 PROCS=$procs
 
@@ -36,8 +37,8 @@ export HYPHY_PATH=$HYPHY_PATH
 
 trap 'echo "Error" > $STATUS_FILE; exit 1' ERR
 
-echo "mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --model $MODEL --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN"
-mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --model $MODEL --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
+echo "mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN"
+mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
 
 echo "Completed" > $STATUS_FILE
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datamonkey-js-server",
   "description": "",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "engines": {
     "node": ">=13"
   },


### PR DESCRIPTION
Consumes run mode option from frontend.