### PR TITLE
Add job:status Socket.IO event for job reconnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datamonkey-js-server",
   "description": "",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "engines": {
     "node": ">=13"
   },


### PR DESCRIPTION
## Summary
- Add `job:status` Socket.IO event handler to query job status by ID
- Enables frontend to check job state after page refresh/reconnection before re-subscribing to events
- Minimal implementation (~30 lines) - no new data structures or cleanup mechanisms

## Usage
```javascript
socket.emit('job:status', { jobId: 'fel-1234567890-abc123' }, (response) => {
  // response: { status: 'running'|'completed'|'not_found', results?: {...}, error?: '...' }
});
```

## Test plan
- [ ] Verify `job:status` returns `not_found` for non-existent job IDs
- [ ] Verify `job:status` returns correct status for queued/running jobs
- [ ] Verify `job:status` returns results for completed jobs
- [ ] Verify existing `{analysis}:resubscribe` still works for re-subscribing to running jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)