### PR TITLE
fix: Convert datatype through lookup table in GARD else branch

### DIFF
--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -96,7 +96,7 @@ var gard = function(socket, stream, params) {
       self.rate_variation = variation_map[self.site_to_site_variation] || "None";
       self.rate_classes = parseInt(self.params.rate_classes || self.params.classes || 2);
       self.run_mode = self.params.run_mode === "1" || self.params.run_mode === "Faster" ? "Faster" : "Normal";
-      self.datatype = self.params.datatype || "codon";
+      self.datatype = datatypes[self.params.datatype] || self.params.datatype || "codon";
       self.max_breakpoints = parseInt(self.params.max_breakpoints || 10000);
       self.model = self.params.model || "JTT";
     }


### PR DESCRIPTION
## Summary
- Fix critical bug where GARD job runner didn't convert datatype through the lookup table in the else branch
- When `self.params.datatype` is "protein", it was passed directly to the shell script without converting to "amino-acid" (which HyPhy expects)
- Now matches the pattern used on line 89 for the `analysisParams` path

## Test plan
- [ ] Submit a GARD job with protein datatype and verify it runs correctly
- [ ] Verify amino-acid conversion happens in shell script parameters