### PR TITLE
fix: Auto-detect {FG} branch tags for aBSREL and FEL

### DIFF
--- a/app/absrel/absrel.js
+++ b/app/absrel/absrel.js
@@ -68,6 +68,11 @@ var absrel = function(socket, stream, params) {
       self.srv = analysisParams.srv || "Yes";
       self.blb = analysisParams.blb || 1.0;
       self.branches = analysisParams.branches || "All";
+      // If we have a tagged tree with {FG} annotations, use Foreground branches
+      if (self.nwk && self.nwk.indexOf("{FG}") !== -1 && self.branches === "All") {
+        logger.info(`ABSREL job: Tagged tree contains {FG} annotations, setting branches to Foreground`);
+        self.branches = "FG";
+      }
     } else {
       self.id = (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
       self.nwk = self.params.nwk_tree || self.params.tree || "";
@@ -75,6 +80,11 @@ var absrel = function(socket, stream, params) {
       self.srv = self.params.srv || "Yes";
       self.blb = self.params.blb || 1.0;
       self.branches = self.params.branches || "All";
+      // If we have a tagged tree with {FG} annotations, use Foreground branches
+      if (self.nwk && self.nwk.indexOf("{FG}") !== -1 && self.branches === "All") {
+        logger.info(`ABSREL job: Tagged tree contains {FG} annotations, setting branches to Foreground`);
+        self.branches = "FG";
+      }
     }
     
     // parameter-derived attributes

--- a/app/fel/fel.js
+++ b/app/fel/fel.js
@@ -79,6 +79,12 @@ var fel = function (socket, stream, params) {
       self.rate_variation = self.params.rate_variation || "No";
       self.ci = self.params.ci || "No";
     }
+
+    // If we have a tagged tree with {FG} annotations, use Foreground branches
+    if (self.nwk_tree && self.nwk_tree.indexOf("{FG}") !== -1 && self.branches === "All") {
+      logger.info(`FEL job: Tagged tree contains {FG} annotations, setting branches to Foreground`);
+      self.branches = "FG";
+    }
     
     // parameter-derived attributes
     self.fn = __dirname + "/output/" + self.id;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datamonkey-js-server",
   "description": "",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "engines": {
     "node": ">=13"
   },


### PR DESCRIPTION
## Summary

- When users select foreground branches in the UI, the tree is correctly annotated with `{FG}` tags and saved as `tagged_nwk_tree`
- However, the `--branches` parameter passed to HyPhy was defaulting to `"All"`, causing HyPhy to analyze all branches instead of only the user-selected ones
- Now auto-detects `{FG}` annotations in the tree string and sets `--branches FG` so HyPhy restricts analysis to the tagged foreground branches
- Applied to both aBSREL and FEL

Fixes https://github.com/veg/hyphy/issues/1934