### PR TITLE
fix: Pass genetic code to HyPhy in Contrast-FEL shell script

### DIFF
--- a/app/contrast-fel/cfel.sh
+++ b/app/contrast-fel/cfel.sh
@@ -159,20 +159,20 @@ if [ -n "$SLURM_JOB_ID" ]; then
   if [ -f "$HYPHY_NON_MPI" ]; then
     echo "Using non-MPI HYPHY: $HYPHY_NON_MPI"
     export TOLERATE_NUMERICAL_ERRORS=1
-    echo "$HYPHY_NON_MPI LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > \"$PROGRESS_FILE\""
-    $HYPHY_NON_MPI LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > "$PROGRESS_FILE"
+    echo "$HYPHY_NON_MPI LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > \"$PROGRESS_FILE\""
+    $HYPHY_NON_MPI LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > "$PROGRESS_FILE"
   else
     echo "Non-MPI HYPHY not found at $HYPHY_NON_MPI, attempting to use MPI version"
     export TOLERATE_NUMERICAL_ERRORS=1
-    echo "srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > \"$PROGRESS_FILE\""
-    srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > "$PROGRESS_FILE"
+    echo "srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > \"$PROGRESS_FILE\""
+    srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > "$PROGRESS_FILE"
   fi
 else
   # For local execution, use the HYPHY executable determined above
   echo "Using local HYPHY execution: $HYPHY"
   export TOLERATE_NUMERICAL_ERRORS=1
-  echo "$HYPHY LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > \"$PROGRESS_FILE\""
-  $HYPHY LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > "$PROGRESS_FILE"
+  echo "$HYPHY LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > \"$PROGRESS_FILE\""
+  $HYPHY LIBPATH=$HYPHY_PATH $CONTRAST_FEL --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --srv $RATE_VARIATION --permutations $PERMUTATIONS --p-value $P_VALUE --q-value $Q_VALUE --output $RESULTS_FILE > "$PROGRESS_FILE"
 fi
 
 echo "Completed" > "$STATUS_FILE"


### PR DESCRIPTION
## Summary
- Add `--code $GENETIC_CODE` flag to all three HyPhy execution paths in `app/contrast-fel/cfel.sh` (non-MPI SLURM, MPI SLURM fallback, and local)
- Without this flag, Contrast-FEL defaults to the Universal genetic code, which silently produces incorrect results for mitochondrial sequences where TGA codes for Tryptophan instead of being a stop codon

## Test plan
- [ ] Run a Contrast-FEL analysis with a non-Universal genetic code (e.g., vertebrate mitochondrial) and verify `--code` appears in the logged command
- [ ] Run a Contrast-FEL analysis with the default Universal code and verify it still works correctly
- [ ] Verify the flag is passed in all three execution paths (non-MPI, MPI fallback, local)

Fixes veg/datamonkey-js#846

🤖 Generated with [Claude Code](https://claude.com/claude-code)