### PR TITLE
fix: Pass genetic code to HyPhy in Contrast-FEL shell script (v2.6.x)

### DIFF
--- a/app/contrast-fel/cfel.sh
+++ b/app/contrast-fel/cfel.sh
@@ -71,20 +71,20 @@ if [ -n "$SLURM_JOB_ID" ]; then
   
   if [ -f "$HYPHY_NON_MPI" ]; then
     echo "Using non-MPI HYPHY: $HYPHY_NON_MPI"
-    echo "$HYPHY_NON_MPI LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE"
+    echo "$HYPHY_NON_MPI LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE"
     export TOLERATE_NUMERICAL_ERRORS=1
-    $HYPHY_NON_MPI LIBPATH=$HYPHY_PATH $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE
+    $HYPHY_NON_MPI LIBPATH=$HYPHY_PATH $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE
   else
     echo "Non-MPI HYPHY not found at $HYPHY_NON_MPI, attempting to use MPI version"
-    echo "srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE"
+    echo "srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE"
     export TOLERATE_NUMERICAL_ERRORS=1
-    srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE
+    srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE
   fi
 else
   # Using mpirun for non-SLURM environments
-  echo "mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE"
+  echo "mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE"
   export TOLERATE_NUMERICAL_ERRORS=1
-  mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE
+  mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH $HYPHY_PATH/TemplateBatchFiles/SelectionAnalyses/FEL-contrast.bf --alignment $FN --tree $TREE_FN --code $GENETIC_CODE $BRANCH_SETS --output $RESULTS_FILE >> $PROGRESS_FILE
 fi
 
 echo "Completed" > $STATUS_FILE


### PR DESCRIPTION
## Summary
- Add `--code $GENETIC_CODE` to all HyPhy invocations in `app/contrast-fel/cfel.sh`
- Covers all 3 execution paths (non-MPI fallback, SLURM srun, and mpirun) including both echo debug lines and actual execution lines
- Without this flag, HyPhy defaults to the Universal genetic code, which silently produces incorrect results for mitochondrial sequences (e.g., TGA codes for Tryptophan instead of Stop)

## Test plan
- [ ] Run Contrast-FEL analysis with a non-Universal genetic code (e.g., Vertebrate Mitochondrial) and verify HyPhy receives the `--code` flag
- [ ] Verify standard Universal code analyses still work correctly
- [ ] Check SLURM and non-SLURM execution paths

Fixes veg/datamonkey-js#846

🤖 Generated with [Claude Code](https://claude.com/claude-code)