### PR TITLE
feat: Tag jobs with submission source via SLURM --comment

### DIFF
--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -21,6 +21,17 @@ client.on("error", function(err) {
   logger.error("Redis hyphyjob client error: " + err.message);
 });
 
+// Prepend a scheduler --comment flag carrying the submission source so SLURM
+// accounting (sacct/scontrol) records which path submitted the job. Grafana
+// reads this to break out per-source metrics.
+function injectSubmissionSource(qsub_params, source, submit_type) {
+  if (!source || submit_type === "local") return qsub_params;
+  if (submit_type === "qsub") {
+    return ["-W", "comment=source=" + source].concat(qsub_params);
+  }
+  return ["--comment=source=" + source].concat(qsub_params);
+}
+
 var hyphyJob = function() {};
 
 hyphyJob.prototype.log = function(notification, complementary_info) {
@@ -79,6 +90,11 @@ hyphyJob.prototype.spawn = function() {
   var self = this;
 
   self.log("spawning");
+
+  var source = (self.params && self.params.submission_source)
+            || (self.params && self.params.analysis && self.params.analysis.submission_source)
+            || "unknown";
+  self.qsub_params = injectSubmissionSource(self.qsub_params, source, config.submit_type);
 
   // A class that spawns the process and emits status events
   logger.info(`[JOB START] Job ${self.id}: Creating job runner`);

--- a/lib/mcp/spawn-helpers.js
+++ b/lib/mcp/spawn-helpers.js
@@ -275,7 +275,7 @@ function spawnAnalysis(type, alignment, tree, analysisParams) {
   //
   // hivtrace is special: it uses params._id directly.
   if (type === "hivtrace") {
-    var params = Object.assign({ _id: jobId }, analysisParams || {});
+    var params = Object.assign({ _id: jobId, submission_source: "mcp" }, analysisParams || {});
     new Constructor(socket, alignment, params);
   } else {
     // If no tree provided, try to extract from NEXUS TREES block
@@ -292,7 +292,8 @@ function spawnAnalysis(type, alignment, tree, analysisParams) {
     };
     var params = {
       analysis: Object.assign({ _id: jobId, msa: [msaEntry] }, analysisParams || {}),
-      msa: [msaEntry]
+      msa: [msaEntry],
+      submission_source: "mcp"
     };
     params.tree = tree || "";
     if (analysisParams && analysisParams.genetic_code) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -59,6 +59,9 @@ io.prototype.route = function(route, next) {
             }
           }
           
+          if (data && typeof data === "object" && !data.submission_source) {
+            data.submission_source = "web";
+          }
           logger.info(`Received event ${key} with data: ${JSON.stringify(data)}`);
           try {
             callback(stream, data);


### PR DESCRIPTION
## Summary
- Distinguishes MCP-submitted jobs from browser-submitted jobs in SLURM accounting so existing Grafana tooling (which reads `sacct`/`scontrol`) can break out per-source metrics.
- Stamps `submission_source` on params at both entry points (`lib/mcp/spawn-helpers.js` for MCP, `lib/router.js` for WebSocket) and prepends `--comment=source=<value>` to the scheduler argv from the shared `hyphyJob.spawn()` path. Single helper handles both `sbatch` and `qsub`; `local` mode is a no-op.
- Internal observability only — no MCP tool surface changes, no per-analysis `qsub_params` edits.

## Test plan
- [x] Unit tests: `npx mocha --exit test/mcp/mcp.test.js` — 53/53 passing; logged params now show `submission_source:"mcp"` flowing through.
- [ ] On the cluster, submit one MCP job and one browser job, then run `sacct -j <slurm_job_id> -o JobID,Comment%40` and confirm the `Comment` column reads `source=mcp` and `source=web` respectively.
- [ ] (Optional) `scontrol show job <slurm_job_id>` for an active job should include `Comment=source=...`.