### PR TITLE
feat: Support OOB redirect URI in OAuth /authorize for headless clients (#383)

### DIFF
--- a/lib/mcp/index.js
+++ b/lib/mcp/index.js
@@ -162,7 +162,43 @@ function startMcpServer(config, redisClient) {
     });
   });
 
-  // Authorization Endpoint — auto-approves all requests
+  // Authorization Endpoint — auto-approves all requests.
+  // Supports the standard out-of-band redirect URI urn:ietf:wg:oauth:2.0:oob
+  // for headless clients (SSH boxes where http://localhost callbacks aren't
+  // reachable from the user's browser): the code is rendered as HTML for the
+  // user to copy-paste back into their client, instead of 302-redirected.
+  var OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function renderOobPage(code) {
+    var safeCode = escapeHtml(code);
+    return "<!doctype html>\n" +
+      "<html lang=\"en\"><head><meta charset=\"utf-8\">" +
+      "<title>Datamonkey MCP — authorization code</title>" +
+      "<style>" +
+      "body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;" +
+      "max-width:640px;margin:4rem auto;padding:0 1.5rem;color:#1a1a1a;line-height:1.5}" +
+      "h1{font-size:1.25rem;margin-bottom:1rem}" +
+      "code{font-family:'SF Mono',Menlo,Consolas,monospace;background:#f4f4f5;" +
+      "padding:.75rem 1rem;border-radius:6px;display:block;word-break:break-all;" +
+      "font-size:1rem;user-select:all}" +
+      "p{color:#52525b}" +
+      "</style></head><body>" +
+      "<h1>Authorization code</h1>" +
+      "<code id=\"code\">" + safeCode + "</code>" +
+      "<p>Paste this code back into your MCP client to complete authorization. " +
+      "The code is valid for 10 minutes.</p>" +
+      "</body></html>";
+  }
+
   app.get("/authorize", function (req, res) {
     var redirectUri = req.query.redirect_uri;
     var state = req.query.state || "";
@@ -184,6 +220,13 @@ function startMcpServer(config, redisClient) {
       resource: req.query.resource, // RFC 8707 — audience binding for the issued token
       expires: Date.now() + 600000 // 10 minutes
     };
+
+    if (redirectUri === OOB_REDIRECT_URI) {
+      logger.info("MCP OAuth authorize: issued code, rendering OOB page");
+      res.set("Content-Type", "text/html; charset=utf-8");
+      res.send(renderOobPage(code));
+      return;
+    }
 
     logger.info("MCP OAuth authorize: issued code, redirecting");
     var sep = redirectUri.indexOf("?") === -1 ? "?" : "&";


### PR DESCRIPTION
## Summary

- Adds support for the standard out-of-band redirect URI `urn:ietf:wg:oauth:2.0:oob` in the MCP server's `/authorize` endpoint
- When OOB is requested, returns an HTML page rendering the auth code for the user to copy back into their MCP client, instead of 302-redirecting to a localhost callback
- Existing `http://localhost:<port>/callback` flow is unchanged

## Why

Per #383, the current OAuth flow fails on headless / remote-SSH boxes: the CLI binds its callback listener to localhost on the remote host, but the user's browser is on a different machine, so the redirect to `http://localhost:<port>/callback` lands on the wrong host and dies (`Safari Can't Connect to the Server`).

OOB unblocks any MCP client that supports the standard OOB redirect URI, and gives users a manual `curl /register` + open `/authorize` + `curl /token` path they can drive by hand from a headless box.

> **Caveat:** Claude Code's CLI uses localhost-only callbacks, so it won't trigger the OOB path on its own. This PR provides the server-side capability; a separate docs change (different repo) will walk users through the manual flow.

## Test plan

- [x] `npm run test-mcp` — all 53 existing MCP tests pass
- [x] End-to-end OOB round-trip verified locally: `/register` → `/authorize?redirect_uri=urn:ietf:wg:oauth:2.0:oob` returns 200 + HTML with code → `/token` (with PKCE verifier) returns valid `access_token`
- [x] Standard localhost-callback flow still returns 302 with the original callback URL (no regression)
- [ ] Reviewer: verify HTML escaping for the rendered code (the code is a UUID, but `escapeHtml` is applied defensively)