### PR TITLE
fix: Restore MPI for GARD by pinning LD_LIBRARY_PATH into srun task

### DIFF
--- a/app/gard/gard.sh
+++ b/app/gard/gard.sh
@@ -120,6 +120,14 @@ fi
 HYPHY_PATH=$CWD/../../.hyphy/res/
 GARD=$HYPHY_PATH/TemplateBatchFiles/GARD.bf
 
+# OpenMPI/UCX library directories required by HYPHYMPI at load time.
+# These are NOT on the system loader path (no ld.so.conf.d entry), and srun does
+# not reliably propagate the launching shell's LD_LIBRARY_PATH into the task
+# environment on every node. When it doesn't, HYPHYMPI dies at dlopen with
+# "libmpi.so.40: cannot open shared object file" (exit 127) before parsing any
+# arguments. We therefore pin these paths into the srun task via an env wrapper.
+MPI_LIB_PATH=/opt/ohpc/pub/mpi/openmpi5-gnu14/5.0.7/lib:/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib
+
 #RATE_VARIATIONS
 # 1: None
 # 2: General Discrete
@@ -156,22 +164,19 @@ echo "MAX_BREAKPOINTS: '$MAX_BREAKPOINTS'"
 echo "MODEL: '$MODEL'"
 
 if [ -n "$SLURM_JOB_ID" ]; then
-  # Using SLURM srun with dedicated arguments
-  # Try the non-MPI version as a fallback since we're having library issues with MPI
-  echo "Running HYPHY in non-MPI mode as a fallback due to library issues..."
-  
-  HYPHY_NON_MPI=$CWD/../../.hyphy/HYPHYMP
-  
-  if [ -f "$HYPHY_NON_MPI" ]; then
-    echo "Using non-MPI HYPHY: $HYPHY_NON_MPI"
-    export TOLERATE_NUMERICAL_ERRORS=1
+  # Run GARD under MPI via srun. The env wrapper below pins LD_LIBRARY_PATH into
+  # the task environment on the compute node so HYPHYMPI can resolve libmpi.so.40
+  # regardless of whether srun propagated the launching shell's environment.
+  export TOLERATE_NUMERICAL_ERRORS=1
+
+  if [ -f "$HYPHY_MPI" ]; then
+    echo "Using MPI HYPHY under srun: $HYPHY_MPI"
+    echo "srun --mpi=$MPI_TYPE -n $PROCS env LD_LIBRARY_PATH=$MPI_LIB_PATH:\$LD_LIBRARY_PATH $HYPHY_MPI ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
+    srun --mpi=$MPI_TYPE -n $PROCS /usr/bin/env LD_LIBRARY_PATH="$MPI_LIB_PATH:$LD_LIBRARY_PATH" $HYPHY_MPI ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
+  else
+    echo "MPI HYPHY not found at $HYPHY_MPI, falling back to non-MPI HYPHY: $HYPHY_NON_MPI"
     echo "$HYPHY_NON_MPI ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
     $HYPHY_NON_MPI ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
-  else
-    echo "Non-MPI HYPHY not found at $HYPHY_NON_MPI, attempting to use MPI version"
-    export TOLERATE_NUMERICAL_ERRORS=1
-    echo "srun --mpi=$MPI_TYPE -n $PROCS $HYPHY ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
-    srun --mpi=$MPI_TYPE -n $PROCS $HYPHY ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
   fi
 else
   # For local execution, use the HYPHY executable determined above


### PR DESCRIPTION
## Problem

GARD jobs submitted via SLURM fail intermittently and **node-dependently** with exit 127:

```
.hyphy/HYPHYMPI: error while loading shared libraries: libmpi.so.40:
    cannot open shared object file: No such file or directory
srun: error: nodeXX: tasks 0-3: Exited with exit code 127
```

This is the failure behind stuck "running" GARD jobs (e.g. job `968954` on `node14`, 2026-06-30). It has been misdiagnosed repeatedly as a HyPhy keyword-parsing bug or a bad MPI binary — it is neither. The binary dies in the dynamic linker **before `main()`**, so it never parses `--alignment` at all (0-second death, exit 127 = loader failure).

## Root cause

The OpenMPI/UCX lib directories are **not** on the system loader path on the compute nodes:
- no entry in `/etc/ld.so.conf.d/` for `openmpi5-gnu14/5.0.7` or `ucx-ohpc`
- `ldconfig -p` cannot resolve `libmpi.so.40`

`HYPHYMPI` (which `NEEDED libmpi.so.40`) only loads because `srun` *happens* to propagate the launching shell's `LD_LIBRARY_PATH` into the task environment. On nodes/allocations where srun does **not** propagate it, the loader can't find `libmpi.so.40` and the job dies instantly. Because propagation is node/state-dependent, the failure is intermittent — which is why it's resisted diagnosis for months.

The previous workaround (`926c7df`, "Force all analysis methods to use HYPHYMP non-MPI") stopped the crash but ran GARD **single-process**, discarding the parallelism its breakpoint search depends on.

## Fix

Run `HYPHYMPI` under `srun` again, but wrap it in `env LD_LIBRARY_PATH=...` so the OpenMPI/UCX lib dirs are pinned into the task environment on the compute node **regardless of what srun propagates**. Falls back to non-MPI only if the MPI binary is genuinely absent.

## Verification (end-to-end)

Ran the edited `gard.sh` via a real `sbatch` job with `LD_LIBRARY_PATH` deliberately emptied — reproducing the exact `node14` failure condition:

| Condition | Result |
|---|---|
| Stripped env, **no** wrapper (control) | `libmpi.so.40: cannot open shared object` → **exit 127** (reproduces job 968954) |
| Stripped env, **with** wrapper (this fix) | GARD ran across 4 MPI ranks → **COMPLETED, exit 0**, 8m52s, valid 23KB `GARD.json` |

The `env` wrapper is the only thing making the binary load under the failure condition, and it produces a correct result.

## Scope

GARD only. Commit `926c7df` forced non-MPI on all 12 methods; the same fix applies to the others, but each should be verified individually before flipping it back — deferred to a follow-up.