### PR TITLE
fix: Restore MPI for GARD by pinning LD_LIBRARY_PATH into srun task (2.6.x)

### DIFF
--- a/app/gard/gard.sh
+++ b/app/gard/gard.sh
@@ -42,11 +42,20 @@ RUN_MODE=$run_mode
 PROCS=$procs
 
 HYPHY=$CWD/../../.hyphy/HYPHYMPI
+HYPHY_NON_MPI=$CWD/../../.hyphy/HYPHYMP
 HYPHY_PATH=$CWD/../../.hyphy/res/
 
 # Needs an MPI environment
 GARD=$HYPHY_PATH/TemplateBatchFiles/GARD.bf
 MODEL="JTT"
+
+# OpenMPI/UCX library directories required by HYPHYMPI at load time.
+# These are NOT on the system loader path (no ld.so.conf.d entry), and srun does
+# not reliably propagate the launching shell's LD_LIBRARY_PATH into the task
+# environment on every node. When it doesn't, HYPHYMPI dies at dlopen with
+# "libmpi.so.40: cannot open shared object file" (exit 127) before parsing any
+# arguments. We therefore pin these paths into the srun task via an env wrapper.
+MPI_LIB_PATH=/opt/ohpc/pub/mpi/openmpi5-gnu14/5.0.7/lib:/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib
 
 #RATE_VARIATIONS
 # 1: None
@@ -72,22 +81,19 @@ echo "SLURM_JOB_ID: $SLURM_JOB_ID"
 echo "slurm_mpi_type: $slurm_mpi_type"
 
 if [ -n "$SLURM_JOB_ID" ]; then
-  # Using SLURM srun with dedicated arguments
-  # Try the non-MPI version as a fallback since we're having library issues with MPI
-  echo "Running HYPHY in non-MPI mode as a fallback due to library issues..."
-  
-  HYPHY_NON_MPI=$CWD/../../.hyphy/HYPHYMP
-  
-  if [ -f "$HYPHY_NON_MPI" ]; then
-    echo "Using non-MPI HYPHY: $HYPHY_NON_MPI"
-    echo "$HYPHY_NON_MPI LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
-    export TOLERATE_NUMERICAL_ERRORS=1
-    $HYPHY_NON_MPI LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
+  # Run GARD under MPI via srun. The env wrapper below pins LD_LIBRARY_PATH into
+  # the task environment on the compute node so HYPHYMPI can resolve libmpi.so.40
+  # regardless of whether srun propagated the launching shell's environment.
+  export TOLERATE_NUMERICAL_ERRORS=1
+
+  if [ -f "$HYPHY" ]; then
+    echo "Using MPI HYPHY under srun: $HYPHY"
+    echo "srun --mpi=$MPI_TYPE -n $PROCS env LD_LIBRARY_PATH=$MPI_LIB_PATH:\$LD_LIBRARY_PATH $HYPHY LIBPATH=$HYPHY_PATH ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
+    srun --mpi=$MPI_TYPE -n $PROCS /usr/bin/env LD_LIBRARY_PATH="$MPI_LIB_PATH:$LD_LIBRARY_PATH" $HYPHY LIBPATH=$HYPHY_PATH ENV="TOLERATE_NUMERICAL_ERRORS=1;" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
   else
-    echo "Non-MPI HYPHY not found at $HYPHY_NON_MPI, attempting to use MPI version"
-    echo "srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
-    export TOLERATE_NUMERICAL_ERRORS=1
-    srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
+    echo "MPI HYPHY not found at $HYPHY, falling back to non-MPI HYPHY: $HYPHY_NON_MPI"
+    echo "$HYPHY_NON_MPI LIBPATH=$HYPHY_PATH ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
+    $HYPHY_NON_MPI LIBPATH=$HYPHY_PATH ENV="TOLERATE_NUMERICAL_ERRORS=1;" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
   fi
 else
   # Using mpirun for non-SLURM environments


### PR DESCRIPTION
Backport of #388 to the **2.6.x** release line (production v2 = `release/2.6.x`, v2.6.6).

## Problem

Same as #388: GARD jobs under SLURM fail intermittently with exit 127 and `libmpi.so.40: cannot open shared object file`. The binary dies in the dynamic linker before parsing any arguments (0-second death) — this was previously misdiagnosed as a HyPhy keyword-parsing/build bug. It is neither.

## Root cause

OpenMPI/UCX lib dirs are not on the compute nodes' system loader path. `HYPHYMPI` only loads when `srun` happens to propagate `LD_LIBRARY_PATH` into the task; when it doesn't (node/allocation-dependent), the job dies instantly. This is the failure behind job `968954` (node14).

This 2.6.x line was **doubly exposed**: its `LD_LIBRARY_PATH` referenced a non-existent UCX `1.17.0` path and never added the OpenMPI lib dir at all.

## Fix

Run `HYPHYMPI` under `srun` wrapped in `env LD_LIBRARY_PATH=...` pinning OpenMPI 5.0.7 + UCX 1.18.0 into the task environment regardless of srun propagation. Falls back to non-MPI only if the MPI binary is absent. Also drops the stray `-z` flag from the command line (visible in job 968954's log).

## Verification (end-to-end)

Ran the edited `gard.sh` via `sbatch` with `LD_LIBRARY_PATH` deliberately emptied — reproducing the exact node14 failure condition — against the deployed **2.6.6 HYPHYMPI (2.5.98)**:

- Took the MPI srun path with the env-wrapper (openmpi5-gnu14/5.0.7 + ucx-ohpc/1.18.0)
- **No `libmpi.so.40` error**
- Loaded the alignment, completed single-breakpoint analysis (best break @ 444, matching the v3 run), ran the multi-breakpoint GA across 4 ranks, produced valid GARD JSON

Note: the arg-parsing differs from v3 (2.6.x reads inputs from environment variables, not `arg=value` positionals), so the fix was ported rather than cherry-picked.