### PR TITLE
fix: Update MPI UCX/OpenMPI module paths for all analysis scripts (2.6.x)

### DIFF
--- a/app/absrel/absrel.sh
+++ b/app/absrel/absrel.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1
@@ -20,11 +20,11 @@ else
 fi
 
 # Make sure UCX libraries are available - these paths are critical for the MPI support
-export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib:$LD_LIBRARY_PATH:/usr/lib64
+export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib:$LD_LIBRARY_PATH:/usr/lib64
 
 # Print library paths and attempt to verify UCX is available
 echo "LD_LIBRARY_PATH after adjustment: $LD_LIBRARY_PATH"
-ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
+ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
 
 FN=$fn
 CWD=$cwd

--- a/app/bgm/bgm.sh
+++ b/app/bgm/bgm.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1

--- a/app/busted/busted_submit.sh
+++ b/app/busted/busted_submit.sh
@@ -7,7 +7,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1

--- a/app/contrast-fel/cfel.sh
+++ b/app/contrast-fel/cfel.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1
@@ -20,11 +20,11 @@ else
 fi
 
 # Make sure UCX libraries are available - these paths are critical for the MPI support
-export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib:$LD_LIBRARY_PATH:/usr/lib64
+export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib:$LD_LIBRARY_PATH:/usr/lib64
 
 # Print library paths and attempt to verify UCX is available
 echo "LD_LIBRARY_PATH after adjustment: $LD_LIBRARY_PATH"
-ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
+ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
 
 FN=$fn
 CWD=$cwd

--- a/app/fade/fade.sh
+++ b/app/fade/fade.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1

--- a/app/fel/fel.sh
+++ b/app/fel/fel.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1
@@ -20,11 +20,11 @@ else
 fi
 
 # Make sure UCX libraries are available - these paths are critical for the MPI support
-export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib:$LD_LIBRARY_PATH:/usr/lib64
+export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib:$LD_LIBRARY_PATH:/usr/lib64
 
 # Print library paths and attempt to verify UCX is available
 echo "LD_LIBRARY_PATH after adjustment: $LD_LIBRARY_PATH"
-ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
+ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
 
 FN=$fn
 CWD=$cwd

--- a/app/fubar/fubar.sh
+++ b/app/fubar/fubar.sh
@@ -7,7 +7,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1

--- a/app/hivtrace/hivtrace_submit.sh
+++ b/app/hivtrace/hivtrace_submit.sh
@@ -10,7 +10,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1
@@ -24,6 +24,7 @@ fi
 # Load modules if they exist (for cluster environments)
 if type module > /dev/null 2>&1; then
   # Try to load common modules that might be available on the system
+  : # no-op; module loads handled above
 fi
 
 # Get environment variables passed from the job submission

--- a/app/meme/meme.sh
+++ b/app/meme/meme.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1
@@ -20,11 +20,11 @@ else
 fi
 
 # Make sure UCX libraries are available - these paths are critical for the MPI support
-export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib:$LD_LIBRARY_PATH:/usr/lib64
+export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib:$LD_LIBRARY_PATH:/usr/lib64
 
 # Print library paths and attempt to verify UCX is available
 echo "LD_LIBRARY_PATH after adjustment: $LD_LIBRARY_PATH"
-ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
+ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
 
 FN=$fn
 CWD=$cwd

--- a/app/multihit/multihit.sh
+++ b/app/multihit/multihit.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1
@@ -20,11 +20,11 @@ else
 fi
 
 # Make sure UCX libraries are available - these paths are critical for the MPI support
-export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib:$LD_LIBRARY_PATH:/usr/lib64
+export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib:$LD_LIBRARY_PATH:/usr/lib64
 
 # Print library paths and attempt to verify UCX is available
 echo "LD_LIBRARY_PATH after adjustment: $LD_LIBRARY_PATH"
-ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
+ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
 
 FN=$fn
 CWD=$cwd

--- a/app/nrm/nrm.sh
+++ b/app/nrm/nrm.sh
@@ -7,7 +7,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1

--- a/app/prime/PRIME_wrapper.sh
+++ b/app/prime/PRIME_wrapper.sh
@@ -17,7 +17,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1
@@ -29,11 +29,11 @@ else
 fi
 
 # Make sure UCX libraries are available - these paths are critical for the MPI support
-export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib:$LD_LIBRARY_PATH:/usr/lib64
+export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib:$LD_LIBRARY_PATH:/usr/lib64
 
 # Print library paths and attempt to verify UCX is available
 echo "LD_LIBRARY_PATH after adjustment: $LD_LIBRARY_PATH"
-ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
+ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
 
 # The first step doesn't use MPI, so use HYPHYMP for it
 (echo $1; echo $2) | HYPHYMP USEPATH=$ABS_DIR/Analyses/PRIME/ ${BASEPATH}PRIME_DOWNLOAD.bf >  ${BASEPATH}hpout 2>&1

--- a/app/prime/prime.sh
+++ b/app/prime/prime.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1

--- a/app/relax/relax.sh
+++ b/app/relax/relax.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1

--- a/app/slac/slac.sh
+++ b/app/slac/slac.sh
@@ -8,7 +8,7 @@ if [ -f /etc/profile.d/modules.sh ]; then
   source /etc/profile.d/modules.sh
   
   # Load the specific OpenMPI module for ARM architecture
-  module load openmpi-arm/5.0.5 2>/dev/null || echo "Failed to load openmpi-arm/5.0.5"
+  module load gnu14/14.2.0 && module load openmpi5/5.0.7 2>/dev/null || echo "Failed to load openmpi5/5.0.7"
   
   # Check if module was loaded successfully
   module list 2>&1
@@ -20,11 +20,11 @@ else
 fi
 
 # Make sure UCX libraries are available - these paths are critical for the MPI support
-export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib:$LD_LIBRARY_PATH:/usr/lib64
+export LD_LIBRARY_PATH=/opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib:$LD_LIBRARY_PATH:/usr/lib64
 
 # Print library paths and attempt to verify UCX is available
 echo "LD_LIBRARY_PATH after adjustment: $LD_LIBRARY_PATH"
-ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.17.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
+ls -l /opt/ohpc/pub/mpi/ucx-ohpc/1.18.0/lib/libucp.so* 2>&1 || echo "UCX libraries not found"
 
 FN=$fn
 CWD=$cwd


### PR DESCRIPTION
## What

Backport to the **2.6.x** line of the UCX/OpenMPI module-path fix that is **already committed on `master`** but was never backported. These exact edits were found running **uncommitted in the 2.6.6 production deployment** (mtime 2026-06-11) — a valid live fix that would be lost on the next deploy/redeploy.

## Changes (all analysis submit scripts)

- **UCX lib path:** `ucx-ohpc/1.17.0` → `ucx-ohpc/1.18.0`. The `1.17.0` directory is **not installed** on the cluster (only `1.18.0` exists), so the old path pointed at nothing.
- **Module load:** `openmpi-arm/5.0.5` → `gnu14/14.2.0 && openmpi5/5.0.7` — correct module names for the current OpenHPC stack.
- **hivtrace_submit.sh:** also fixes a **pre-existing** bash syntax error (empty `if` body → `syntax error near unexpected token 'fi'`) that aborted the script. This bug is present on the committed branch, unrelated to the path fix, but fixed here since the file was already being touched.

## Scope note

`gard.sh` is intentionally **not** in this PR — it carries the separate MPI env-wrapper fix released in **v2.6.7** (#389). This PR is the complementary UCX/module fix for the other 15 scripts.

## Verification

- Full staged diff confirmed to contain **only** ucx/module/libucp changes (+ the one hivtrace `fi` fix) — no stray edits, no secrets.
- All 15 modified scripts pass `bash -n`.
- The identical UCX 1.18/openmpi5 configuration is already proven on `master` and was exercised end-to-end during the v2.6.7 GARD verification (openmpi5-gnu14/5.0.7 + ucx-ohpc/1.18.0).