### PR TITLE
fix: GARD codon jobs — pass genetic --code to HyPhy

### DIFF
--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -5,6 +5,7 @@ const config = require("../../config.json"),
   logger = require("../../lib/logger").logger,
   fs = require("fs"),
   datatypes = require("../type").type,
+  code = require("../code").code,
   path = require("path"),
   utilities = require("../../lib/utilities");
 
@@ -64,7 +65,7 @@ var gard = function(socket, stream, params) {
     // parameter attributes with fallbacks
     if (self.params.msa) {
       self.msaid = self.params.msa._id;
-      self.genetic_code = self.params.msa[0] ? (self.params.msa[0].gencodeid + 1) : "Universal";
+      self.genetic_code = self.params.msa[0] ? (code[self.params.msa[0].gencodeid + 1] || "Universal") : "Universal";
       self.nwk_tree = self.params.msa[0] ? (self.params.msa[0].usertree || self.params.msa[0].nj) : "";
       // Use analysis.tagged_nwk_tree if available (for unified format)
       if (self.params.analysis && self.params.analysis.tagged_nwk_tree) {

--- a/app/gard/gard.sh
+++ b/app/gard/gard.sh
@@ -171,12 +171,12 @@ if [ -n "$SLURM_JOB_ID" ]; then
 
   if [ -f "$HYPHY_MPI" ]; then
     echo "Using MPI HYPHY under srun: $HYPHY_MPI"
-    echo "srun --mpi=$MPI_TYPE -n $PROCS env LD_LIBRARY_PATH=$MPI_LIB_PATH:\$LD_LIBRARY_PATH $HYPHY_MPI ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
-    srun --mpi=$MPI_TYPE -n $PROCS /usr/bin/env LD_LIBRARY_PATH="$MPI_LIB_PATH:$LD_LIBRARY_PATH" $HYPHY_MPI ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
+    echo "srun --mpi=$MPI_TYPE -n $PROCS env LD_LIBRARY_PATH=$MPI_LIB_PATH:\$LD_LIBRARY_PATH $HYPHY_MPI ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
+    srun --mpi=$MPI_TYPE -n $PROCS /usr/bin/env LD_LIBRARY_PATH="$MPI_LIB_PATH:$LD_LIBRARY_PATH" $HYPHY_MPI ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
   else
     echo "MPI HYPHY not found at $HYPHY_MPI, falling back to non-MPI HYPHY: $HYPHY_NON_MPI"
-    echo "$HYPHY_NON_MPI ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
-    $HYPHY_NON_MPI ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
+    echo "$HYPHY_NON_MPI ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
+    $HYPHY_NON_MPI ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
   fi
 else
   # For local execution, use the HYPHY executable determined above
@@ -185,11 +185,11 @@ else
   
   # Check if we can use MPI for local execution (if using MPI version)
   if [[ "$HYPHY" == *"HYPHYMPI"* ]] && command -v mpirun &> /dev/null; then
-    echo "mpirun -np $PROCS $HYPHY ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
-    mpirun -np $PROCS $HYPHY ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
+    echo "mpirun -np $PROCS $HYPHY ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
+    mpirun -np $PROCS $HYPHY ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
   else
-    echo "$HYPHY ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
-    $HYPHY ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
+    echo "$HYPHY ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
+    $HYPHY ENV="TOLERATE_NUMERICAL_ERRORS=1;" LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --max-breakpoints $MAX_BREAKPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
   fi
 fi
 


### PR DESCRIPTION
## Fix GARD codon jobs: pass genetic `--code` to HyPhy

Fixes #391

### The bug

GARD analyses on **codon** alignments fail deterministically at HyPhy load time. `app/gard/gard.sh` never passed `--code` to the GARD invocation, so HyPhy's codon model setup (`models.codon.MG_REV.ModelDescription`) was called with one argument instead of two and aborted immediately:

```
Error: User-defined function 'models.codon.MG_REV.ModelDescription' needs 2 parameters, but 1 were supplied.
```

The failure is fully deterministic and node-independent. Nucleotide/protein GARD jobs are unaffected (that path needs no genetic code). Other codon-capable methods here (e.g. Contrast-FEL, FUBAR) already pass `--code $GENETIC_CODE`; GARD did not.

### The fix

Two load-bearing halves, both required:

- **`gard.sh`** — add `--code $GENETIC_CODE` to **every** GARD invocation (MPI-via-srun, direct mpirun, and non-MPI fallback), matching the pattern in the working codon methods. `GENETIC_CODE` already defaults to `Universal`.
- **`gard.js`** — forward the genetic-code **NAME**, not the raw index. `gencodeid` is routed through the shared `../code` table (`code[gencodeid + 1] || "Universal"`). Without this, the shell would forward a bare index like `--code 1`, which HyPhy's ChoiceList cannot resolve — reintroducing the bug for any non-Universal code.

Behavior for nucleotide/protein datatypes is unchanged (HyPhy ignores the code for non-codon models).

### Verification (end-to-end, real SLURM/MPI cluster)

- **Before:** an in-frame codon alignment submitted to GARD (`--type codon`) fails within seconds with the `models.codon.MG_REV.ModelDescription needs 2 parameters` arity error; the same alignment as `--type nucleotide` succeeds, isolating the missing genetic code.
- **After:** the identical codon submission runs to completion; the emitted HyPhy command line includes `--code Universal`, GARD proceeds past model setup and writes valid results JSON. Direct HyPhy GARD runs confirmed a numeric code is rejected while named codes are accepted and produce distinct, valid JSON.
- **Regression:** a nucleotide GARD job still completes; verified across both the MPI (srun) and non-MPI paths, deterministic across repeated submissions.

### Scope

- **Fixed & verified:** GARD codon path.
- PRIME audit item from the issue: already passes `--code`, no change needed.
- Companion v2 backport on `release/2.6.x` tracked separately.
