### PR TITLE
fix: GARD codon jobs — pass genetic --code to HyPhy (2.6.x)

### DIFF
--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -1,5 +1,6 @@
 const config = require("../../config.json"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
+  code = require("../code").code,
   redis = require("redis"),
   util = require("util"),
   logger = require("../../lib/logger").logger,
@@ -32,7 +33,7 @@ var gard = function(socket, stream, params) {
   self.rate_variation =
     variation_map[self.params.analysis.site_to_site_variation];
   self.rate_classes = self.params.analysis.rate_classes || 2;
-  self.genetic_code = self.params.msa[0].gencodeid + 1;
+  self.genetic_code = code[self.params.msa[0].gencodeid + 1] || "Universal";
   self.run_mode = self.params.analysis.run_mode == "1" ? "Faster": "Normal";
   self.datatype = self.params.analysis.datatype || "0";
   self.datatype = datatypes[self.datatype];

--- a/app/gard/gard.sh
+++ b/app/gard/gard.sh
@@ -33,7 +33,7 @@ STATUS_FILE=$sfn
 PROGRESS_FILE=$pfn
 RESULTS_FN=$rfn
 
-GENETIC_CODE=$genetic_code
+GENETIC_CODE="${genetic_code:-Universal}"
 RATE_VARIATION=$rate_var
 RATE_CLASSES=$rate_classes
 DATATYPE=$datatype
@@ -88,18 +88,18 @@ if [ -n "$SLURM_JOB_ID" ]; then
 
   if [ -f "$HYPHY" ]; then
     echo "Using MPI HYPHY under srun: $HYPHY"
-    echo "srun --mpi=$MPI_TYPE -n $PROCS env LD_LIBRARY_PATH=$MPI_LIB_PATH:\$LD_LIBRARY_PATH $HYPHY LIBPATH=$HYPHY_PATH ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
-    srun --mpi=$MPI_TYPE -n $PROCS /usr/bin/env LD_LIBRARY_PATH="$MPI_LIB_PATH:$LD_LIBRARY_PATH" $HYPHY LIBPATH=$HYPHY_PATH ENV="TOLERATE_NUMERICAL_ERRORS=1;" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
+    echo "srun --mpi=$MPI_TYPE -n $PROCS env LD_LIBRARY_PATH=$MPI_LIB_PATH:\$LD_LIBRARY_PATH $HYPHY LIBPATH=$HYPHY_PATH ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
+    srun --mpi=$MPI_TYPE -n $PROCS /usr/bin/env LD_LIBRARY_PATH="$MPI_LIB_PATH:$LD_LIBRARY_PATH" $HYPHY LIBPATH=$HYPHY_PATH ENV="TOLERATE_NUMERICAL_ERRORS=1;" $GARD --type $DATATYPE --alignment $FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
   else
     echo "MPI HYPHY not found at $HYPHY, falling back to non-MPI HYPHY: $HYPHY_NON_MPI"
-    echo "$HYPHY_NON_MPI LIBPATH=$HYPHY_PATH ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
-    $HYPHY_NON_MPI LIBPATH=$HYPHY_PATH ENV="TOLERATE_NUMERICAL_ERRORS=1;" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
+    echo "$HYPHY_NON_MPI LIBPATH=$HYPHY_PATH ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
+    $HYPHY_NON_MPI LIBPATH=$HYPHY_PATH ENV="TOLERATE_NUMERICAL_ERRORS=1;" $GARD --type $DATATYPE --alignment $FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
   fi
 else
   # Using mpirun for non-SLURM environments
-  echo "mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
+  echo "mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH -z ENV=\"TOLERATE_NUMERICAL_ERRORS=1;\" $GARD --type $DATATYPE --alignment $FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE"
   export TOLERATE_NUMERICAL_ERRORS=1
-  mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
+  mpirun -np $PROCS $HYPHY LIBPATH=$HYPHY_PATH $GARD --type $DATATYPE --alignment $FN --code $GENETIC_CODE --model $MODEL --mode $RUN_MODE --rv $RATE_VARIATION --rate-classes $RATE_CLASSES --output $RESULTS_FN > $PROGRESS_FILE
 fi
 
 echo "Completed" > $STATUS_FILE


### PR DESCRIPTION
## Fix GARD codon jobs: pass genetic `--code` to HyPhy (2.6.x)

Backport of the GARD codon `--code` fix to the 2.6.x (DM2) line. Port of the same fix landing on the v3/master line.

Refs #391 (v2 port — auto-close handled by the v3/master PR)

### The bug

GARD codon jobs fail deterministically at HyPhy load time because `app/gard/gard.sh` never passed `--code`, so `models.codon.MG_REV.ModelDescription` was called with one argument instead of two:

```
Error: User-defined function 'models.codon.MG_REV.ModelDescription' needs 2 parameters, but 1 were supplied.
```

On `release/2.6.x`, `gard.sh` additionally set `GENETIC_CODE=$genetic_code` with **no default**, so an unspecified code left the value empty.

### The fix

- **`gard.sh`** — add `--code $GENETIC_CODE` to all four GARD invocation lines, and harden the default to `GENETIC_CODE="${genetic_code:-Universal}"`.
- **`gard.js`** — map `gencodeid` through the shared `../code` table (`code[gencodeid + 1] || "Universal"`) so HyPhy receives a resolvable code NAME rather than a bare index. Both halves must land together.

### Verification

Bug confirmed by inspection against the working codon reference scripts (`cfel.sh`, `fubar.sh`, which pass `--code $GENETIC_CODE`); fix verified via direct HyPhy GARD runs (numeric code rejected, named codes accepted → valid JSON) on the same shared SLURM/MPI cluster as the v3 change.
