### PR TITLE
fix: Contrast-FEL — validate >=2 branch sets before submit

### DIFF
--- a/app/contrast-fel/cfel.js
+++ b/app/contrast-fel/cfel.js
@@ -40,7 +40,7 @@ var cfel = function(socket, stream, params) {
   if (isCheckOnly) {
     // Set defaults for required fields with complete parameter coverage
     self.genetic_code = params.genetic_code || "Universal";
-    const rawBranchSets = params['branch-set'] || params.branch_sets || "Foreground";
+    const rawBranchSets = params['branch-set'] || params.branch_sets || "";
     self.branch_sets = Array.isArray(rawBranchSets) ? rawBranchSets.join(":") : rawBranchSets;
     self.rate_variation = params.srv || (params.ds_variation == 1 ? "Yes" : "No") || "Yes";
     self.permutations = params.permutations || "Yes";
@@ -72,7 +72,7 @@ var cfel = function(socket, stream, params) {
     if (self.params.analysis) {
       self.id = self.params.analysis._id || (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
       self.nwk_tree = self.params.analysis.tagged_nwk_tree || self.params.nwk_tree || self.params.tree || "";
-      const rawBranchSets = self.params.analysis['branch-set'] || self.params.analysis.branch_sets || analysisParams['branch-set'] || analysisParams.branch_sets || "Foreground";
+      const rawBranchSets = self.params.analysis['branch-set'] || self.params.analysis.branch_sets || analysisParams['branch-set'] || analysisParams.branch_sets || "";
       self.branch_sets = Array.isArray(rawBranchSets) ? rawBranchSets.join(":") : rawBranchSets;
       self.rate_variation = analysisParams.srv || (self.params.analysis.ds_variation == 1 ? "Yes" : "No") || "Yes";
       self.permutations = analysisParams.permutations || "Yes";
@@ -81,7 +81,7 @@ var cfel = function(socket, stream, params) {
     } else {
       self.id = (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
       self.nwk_tree = self.params.nwk_tree || self.params.tree || "";
-      const rawBranchSets = self.params['branch-set'] || self.params.branch_sets || "Foreground";
+      const rawBranchSets = self.params['branch-set'] || self.params.branch_sets || "";
       self.branch_sets = Array.isArray(rawBranchSets) ? rawBranchSets.join(":") : rawBranchSets;
       self.rate_variation = self.params.srv || (self.params.ds_variation == 1 ? "Yes" : "No") || "Yes";
       self.permutations = self.params.permutations || "Yes";
@@ -235,6 +235,19 @@ var cfel = function(socket, stream, params) {
   }
   
   logger.info(`Contrast-FEL job ${self.id}: Initializing job`);
+  if (!isCheckOnly) {
+    var _cfelSetCount = String(self.branch_sets == null ? "" : self.branch_sets)
+      .split(":")
+      .filter(function (s) { return s.trim().length; })
+      .length;
+    if (_cfelSetCount < 2) {
+      var _cfelMsg = "Contrast-FEL requires at least two branch groups to compare, but " + _cfelSetCount + " were provided. Please tag a second group of branches in the tree and resubmit.";
+      logger.error("Contrast-FEL job " + self.id + ": " + _cfelMsg);
+      try { fs.writeFileSync(self.status_fn, "Error"); } catch (e) {}
+      if (self.socket) { self.socket.emit("script error", { error: _cfelMsg }); }
+      return; // do NOT call self.init(); nothing is submitted
+    }
+  }
   self.init();
   logger.info(`Contrast-FEL job ${self.id}: Job initialized`);
 

--- a/app/contrast-fel/cfel.sh
+++ b/app/contrast-fel/cfel.sh
@@ -98,6 +98,15 @@ PROCS=${procs:-1}
 sets=(`echo $branch_sets | sed 's/:/\n/g'`)
 BRANCH_SETS=$(for x in ${sets[@]}; do echo -n " --branch-set $x "; done;)
 
+# Contrast-FEL compares >= 2 branch groups. A single set makes HyPhy fit the
+# model and then core-dump on a 0x0 vs NxN matrix (issue #392). Fail fast,
+# reusing the same Error/exit convention as the ERR trap below.
+if [ "${#sets[@]}" -lt 2 ]; then
+  echo "Contrast-FEL requires at least two branch groups to compare, but only ${#sets[@]} was supplied ('$branch_sets'). Please tag a second branch group on the tree and resubmit." > "$PROGRESS_FILE"
+  echo "Error" > "$STATUS_FILE"
+  exit 1
+fi
+
 # Set HYPHY executable - prefer regular hyphy for local execution
 HYPHY_REGULAR=$CWD/../../.hyphy/hyphy
 HYPHY_NON_MPI=$CWD/../../.hyphy/HYPHYMP


### PR DESCRIPTION
## Contrast-FEL: validate >=2 branch sets before submit

Fixes #392

### The bug

Contrast-FEL compares selective pressure across **two or more** tagged branch groups. A job submitted with only a **single** tagged set (or none) still launched HyPhy, which fit the model and then crashed at the contrast step — the missing second set surfaces as an empty (0x0) matrix:

```
Incompatible dimensions when trying to add or subtract matrices:
first argument was a 0x0 matrix and the second was a 61x61 matrix.
... dumped core
```

It can also surface downstream as `User-defined function 'selection.io.sitelist_matches_pattern' needs 4 parameters, but 3 were supplied`. The wrapper forwarded whatever sets were tagged without validating the count, so a doomed HyPhy run consumed a scheduler slot before core-dumping. Affects both DM2 and DM3 stacks and both bundled HyPhy builds.

### The fix

Two layers, scoped entirely to Contrast-FEL:

- **`cfel.sh` (authoritative)** — immediately after the sets are parsed and before `BRANCH_SETS` or any HyPhy/`srun` launch: if `${#sets[@]} < 2`, write a user-facing message to the progress file, set status `Error`, and `exit 1` — before any scheduler allocation.
- **`cfel.js` (pre-submit UX)** — count distinct non-empty branch sets; if `< 2`, write `Error` status, `socket.emit("script error", …)`, and **return without calling `self.init()`** (the constructor is invoked with no try/catch, so it emits-and-returns rather than throwing). Also removes the unsafe single-set `|| "Foreground"` default so a zero-tag submission is rejected cleanly rather than silently defaulting to one set.

### Verification (end-to-end, real cluster)

Exercised the real wrapper on the cluster:

| Case | branch sets | Exit | HyPhy invoked? | Status |
|------|-------------|------|----------------|--------|
| Single set | 1 | `1` | No | `Error` |
| Zero sets | 0 | `1` | No | `Error` |
| Two sets | 2 | passes guard | Yes | proceeds |

Single/zero sets fail fast with the guard message and never allocate a node or launch HyPhy; two sets pass through and assemble `BRANCH_SETS` exactly as before, confirming valid submissions are unaffected.

### Note

HyPhy arguably should also validate `>= 2` sets and error cleanly rather than core-dump; that is a separate upstream concern. This PR is the backend guard.
