### PR TITLE
fix: Contrast-FEL — validate >=2 branch sets before submit (2.6.x)

### DIFF
--- a/app/contrast-fel/cfel.js
+++ b/app/contrast-fel/cfel.js
@@ -28,7 +28,11 @@ var cfel = function(socket, stream, params) {
   self.id = self.params.analysis._id;
   self.genetic_code = code[self.params.msa[0].gencodeid + 1];
   self.nwk_tree = self.params.analysis.tagged_nwk_tree;
-  self.branch_sets = self.params.analysis.branch_sets.join(":");
+  var _cfelRaw = (self.params.analysis && self.params.analysis.branch_sets) || [];
+  self.branch_set_list = (Array.isArray(_cfelRaw) ? _cfelRaw : String(_cfelRaw).split(":"))
+    .map(function (s) { return (s == null ? "" : String(s)).trim(); })
+    .filter(function (s, i, a) { return s.length && a.indexOf(s) === i; });
+  self.branch_sets = self.branch_set_list.join(":");
   self.rate_variation = self.params.analysis.ds_variation == 1 ? "Yes" : "No";
 
   // parameter-derived attributes
@@ -147,6 +151,13 @@ var cfel = function(socket, stream, params) {
 
   // Ensure the progress file exists
   fs.openSync(self.progress_fn, "w");
+
+  if (self.branch_set_list.length < 2) {
+    var _cfelMsg = "Contrast-FEL requires at least two branch groups to compare, but " + self.branch_set_list.length + " were provided. Please tag a second group of branches in the tree and resubmit.";
+    try { fs.writeFileSync(self.status_fn, "Error"); } catch (e) {}
+    if (self.socket) { self.socket.emit("script error", { error: _cfelMsg }); }
+    return; // do not submit
+  }
   self.init();
 };
 

--- a/app/contrast-fel/cfel.sh
+++ b/app/contrast-fel/cfel.sh
@@ -40,6 +40,14 @@ sets=(`echo $branch_sets | sed 's/:/\n/g'`)
 
 BRANCH_SETS=$(for x in ${sets[@]}; do echo -n " --branch-set $x "; done;)
 
+# Contrast-FEL compares >= 2 branch groups. A single set makes HyPhy fit the
+# model and then core-dump on a 0x0 vs NxN matrix (issue #392). Fail fast.
+if [ "${#sets[@]}" -lt 2 ]; then
+  echo "Contrast-FEL requires at least two branch groups to compare, but only ${#sets[@]} was supplied ('$branch_sets'). Please tag a second branch group on the tree and resubmit." >> $PROGRESS_FILE
+  echo "Error" > $STATUS_FILE
+  exit 1
+fi
+
 HYPHY=$CWD/../../.hyphy/HYPHYMPI
 HYPHY_PATH=$CWD/../../.hyphy/res/
 RESULTS_FILE=$fn.FEL.json


### PR DESCRIPTION
## Contrast-FEL: validate >=2 branch sets before submit (2.6.x)

Backend guard for Contrast-FEL on the 2.6.x (DM2) line. Port of the same fix landing on the v3/master line.

Refs #392 (v2 port — auto-close handled by the v3/master PR)

### The bug

A single tagged branch set (or none) let HyPhy fit the model and then core-dump at the contrast step, because the missing second set surfaces as an empty (0x0) matrix:

```
Incompatible dimensions when trying to add or subtract matrices:
first argument was a 0x0 matrix and the second was a 61x61 matrix.
... dumped core
```

The wrapper forwarded whatever sets were tagged without validating the count, wasting a scheduler slot on a doomed run.

### The fix

- **`cfel.sh`** — guard right after the sets are parsed: if fewer than two, write a user-facing message to the progress file, set status `Error`, and `exit 1` before any HyPhy launch.
- **`cfel.js`** — count non-empty sets and, if `< 2`, emit `script error` and return without submitting.

### Verification

Exercised the real `cfel.sh` on the cluster: single set → `exit 1` + `Error`, no HyPhy launch, no results file; zero sets → same; two sets → guard passes and the wrapper proceeds into HyPhy with `--branch-set test1 --branch-set test2`, confirming valid multi-group submissions are unaffected.
