### PR TITLE
fix: Release per-job Redis subscriber on socket disconnect (#397)

### DIFF
--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -168,7 +168,8 @@ hivtrace.prototype.spawn = function() {
 
   // Setup Analysis
   var trace_runner = new HivTraceRunner(self.id, self.hivtrace_log);
-  new cs.ClientSocket(self.socket, self.id);
+  self.trace_runner = trace_runner;
+  self.client_socket = new cs.ClientSocket(self.socket, self.id);
 
   // On status updates, report to datamonkey-js
   trace_runner.on("status update", function(status_update) {
@@ -194,11 +195,13 @@ hivtrace.prototype.spawn = function() {
   // On errors, report to datamonkey-js
   trace_runner.on("script error", function(error) {
     self.onError(error);
+    trace_runner.close();
   });
 
   // When the analysis completes, return the results to datamonkey.
   trace_runner.on("completed", function() {
     self.onComplete();
+    trace_runner.close();
   });
 
   // Report the torque job id back to datamonkey
@@ -216,6 +219,12 @@ hivtrace.prototype.spawn = function() {
     self.warn("cancel called!");
     self.cancel_once = _.once(self.cancel);
     self.cancel_once();
+  });
+
+  // Release the python_<id> subscriber (and its status-watcher timer) if the
+  // client disconnects before the job reaches a terminal state. See issue #397.
+  self.socket.on("disconnect", function() {
+    if (self.trace_runner) self.trace_runner.close();
   });
 
   // Ensure output directory exists
@@ -414,6 +423,35 @@ var HivTraceRunner = function(id, hivtrace_log) {
 };
 
 util.inherits(HivTraceRunner, EventEmitter);
+
+/**
+ * Tears down the dedicated python_<id> Redis subscriber and the status-watcher
+ * timer. Idempotent — safe to call from terminal events and socket disconnect.
+ * See issue #397.
+ */
+HivTraceRunner.prototype.close = function() {
+  var self = this;
+  if (self._closed) return;
+  self._closed = true;
+
+  if (self.metronome_id) clearInterval(self.metronome_id);
+
+  logger.info(
+    "[REDIS] Closing subscriber for channel " + self.python_redis_channel
+  );
+  try {
+    self.subscriber.removeAllListeners("message");
+    self.subscriber.unsubscribe(self.python_redis_channel);
+    self.subscriber.quit();
+  } catch (err) {
+    logger.error("Error closing HivTrace Redis subscriber: " + err.message);
+    try {
+      self.subscriber.end(true);
+    } catch (e) {
+      logger.error("Error force-ending HivTrace Redis subscriber: " + e.message);
+    }
+  }
+};
 
 HivTraceRunner.prototype.log_publisher = function() {
   var self = this;

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -61,7 +61,7 @@ hyphyJob.prototype.warn = function(notification, complementary_info) {
 hyphyJob.prototype.attachSocket = function() {
   var self = this;
   logger.info(`[DEBUG REDIS] Attaching socket to job ${self.id}`);
-  new cs.ClientSocket(self.socket, self.id);
+  self.client_socket = new cs.ClientSocket(self.socket, self.id);
 };
 
 // Can either initialize a new job or check on previous one
@@ -211,6 +211,7 @@ hyphyJob.prototype.spawn = function() {
   // Should be called when the job completes
   self.socket.on("disconnect", function() {
     self.log("user disconnected");
+    if (self.client_socket) self.client_socket.close();
   });
 };
 

--- a/lib/clientsocket.js
+++ b/lib/clientsocket.js
@@ -38,14 +38,49 @@ ClientSocket.prototype.initializeServer = function() {
   self.subscriber.on("message", function(channel, message) {
     logger.info(`[DEBUG REDIS] Received message on channel ${channel} for socket ${self.socket.id}`);
     logger.info(`[DEBUG REDIS] Message length: ${message.length} bytes`);
-    
+
     var redis_packet = JSON.parse(message);
     logger.info(`[DEBUG REDIS] Message type: ${redis_packet.type}`);
     logger.info("emitting " + message);
-    
+
     self.socket.emit(redis_packet.type, redis_packet);
     logger.info(`[DEBUG REDIS] Emitted ${redis_packet.type} event to client socket`);
   });
+
+  // Bind the dedicated subscriber's lifetime to the browser socket so it is
+  // released when the client disconnects instead of leaking a pub/sub
+  // connection for every job. See issue #397.
+  if (self.socket && typeof self.socket.on === "function") {
+    self.socket.on("disconnect", function() {
+      self.close();
+    });
+  }
+};
+
+/**
+* Tears down the dedicated Redis subscriber. Idempotent — safe to call from
+* multiple triggers (socket disconnect, explicit call-site cleanup).
+*/
+
+ClientSocket.prototype.close = function() {
+  if (this._closed) return;
+  this._closed = true;
+
+  logger.info(`[REDIS] Closing subscriber for channel ${this.channel_id}`);
+  try {
+    // Drop the message listener before quitting so a late message cannot emit
+    // to an already-disconnected socket.
+    this.subscriber.removeAllListeners("message");
+    this.subscriber.unsubscribe(this.channel_id);
+    this.subscriber.quit();
+  } catch (err) {
+    logger.error("Error closing Redis subscriber: " + err.message);
+    try {
+      this.subscriber.end(true);
+    } catch (e) {
+      logger.error("Error force-ending Redis subscriber: " + e.message);
+    }
+  }
 };
 
 exports.ClientSocket = ClientSocket;


### PR DESCRIPTION
## Redis subscriber connection leak: `ClientSocket` never tears down its dedicated subscriber

Fixes #397

### The bug

Every job/socket creates a **dedicated Redis subscriber connection** (`ClientSocket` in `lib/clientsocket.js`, and `HivTraceRunner` in `app/hivtrace/hivtrace.js`), subscribes it to a per-job channel, and then never tears it down. There was no `unsubscribe()`, no `quit()`, and no handler bound to the browser socket's `disconnect` event.

Worse, the `ClientSocket` instances in `app/hyphyjob.js` and `app/hivtrace/hivtrace.js` were constructed with `new cs.ClientSocket(...)` **without keeping a reference**, so nothing could ever clean them up.

When a client closes the tab or navigates away, the subscriber is orphaned in pub/sub mode and accumulates indefinitely. A production Redis snapshot showed roughly **three quarters of all client connections leaked as idle pub/sub subscribers** (`flags=P sub=1`, last command `subscribe`), some idle for well over a day with `age ≈ idle` — subscribed once, did nothing since. An application lifecycle bug on the SUBSCRIBE path, not a capacity issue.

### The fix

- **`lib/clientsocket.js`**: added idempotent `ClientSocket.prototype.close()` — removes the `message` listener (so no late emits to a dead socket), `unsubscribe()`s the channel, then `quit()`s the subscriber, with an `end(true)` fallback. `initializeServer()` arms it on `socket.on("disconnect")`. This transparently fixes all `ClientSocket` call sites (`job.js`, `hyphyjob.js`, `hivtrace.js`), including the resubscribe path.
- **`app/hyphyjob.js`**: retains the `ClientSocket` reference and the existing `disconnect` handler now calls `close()` (belt-and-suspenders; double-close is a no-op).
- **`app/hivtrace/hivtrace.js`**: `HivTraceRunner` owns a separate `python_<id>` subscriber that can't inherit the `ClientSocket` fix. Added a matching idempotent `HivTraceRunner.prototype.close()` (which also `clearInterval`s the status-watcher metronome timer, fixing a companion timer leak), wired to the terminal `completed`/`script error` events and to socket `disconnect`.

Net effect: the dedicated subscriber's lifetime is bound to the socket and the job, so connections are released on disconnect or completion instead of leaking.

### Verification (live Redis)

Loaded the actual patched `ClientSocket` from this branch, drove it with a stand-in socket, and asserted on `PUBSUB NUMSUB <channel>`:

```
subscribers_before_create=0
subscribers_while_open=1
subscribers_after_disconnect=0
close_flag_set=true
double_close_no_throw=true
subscribers_after_multi_close=0
RESULT=PASS
```

Count rises 0 → 1 on construction and returns to 0 after `disconnect`; double-`close()` does not throw and stays at 0. Runtime log confirms the path executes: `[REDIS] Closing subscriber for channel verify397-chan`. All three modified files pass `node -c`.

The longer-term direction of a single shared multiplexed subscriber (mentioned in the issue) is intentionally out of scope for this targeted fix.

---

The v2 port targeting `release/2.6.x` is a separate PR.
