### PR TITLE
fix: Release per-job Redis subscriber on socket disconnect (2.6.x) (#397)

### DIFF
--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -168,7 +168,8 @@ hivtrace.prototype.spawn = function() {
 
   // Setup Analysis
   var trace_runner = new HivTraceRunner(self.id, self.hivtrace_log);
-  new cs.ClientSocket(self.socket, self.id);
+  self.trace_runner = trace_runner;
+  self.client_socket = new cs.ClientSocket(self.socket, self.id);
 
   // On status updates, report to datamonkey-js
   trace_runner.on("status update", function(status_update) {
@@ -194,11 +195,13 @@ hivtrace.prototype.spawn = function() {
   // On errors, report to datamonkey-js
   trace_runner.on("script error", function(error) {
     self.onError(error);
+    trace_runner.close();
   });
 
   // When the analysis completes, return the results to datamonkey.
   trace_runner.on("completed", function() {
     self.onComplete();
+    trace_runner.close();
   });
 
   // Report the torque job id back to datamonkey
@@ -216,6 +219,12 @@ hivtrace.prototype.spawn = function() {
     self.warn("cancel called!");
     self.cancel_once = _.once(self.cancel);
     self.cancel_once();
+  });
+
+  // Release the python_<id> subscriber (and its status-watcher timer) if the
+  // client disconnects before the job reaches a terminal state. See issue #397.
+  self.socket.on("disconnect", function() {
+    if (self.trace_runner) self.trace_runner.close();
   });
 
   // Ensure output directory exists
@@ -414,6 +423,35 @@ var HivTraceRunner = function(id, hivtrace_log) {
 };
 
 util.inherits(HivTraceRunner, EventEmitter);
+
+/**
+ * Tears down the dedicated python_<id> Redis subscriber and the status-watcher
+ * timer. Idempotent — safe to call from terminal events and socket disconnect.
+ * See issue #397.
+ */
+HivTraceRunner.prototype.close = function() {
+  var self = this;
+  if (self._closed) return;
+  self._closed = true;
+
+  if (self.metronome_id) clearInterval(self.metronome_id);
+
+  logger.info(
+    "[REDIS] Closing subscriber for channel " + self.python_redis_channel
+  );
+  try {
+    self.subscriber.removeAllListeners("message");
+    self.subscriber.unsubscribe(self.python_redis_channel);
+    self.subscriber.quit();
+  } catch (err) {
+    logger.error("Error closing HivTrace Redis subscriber: " + err.message);
+    try {
+      self.subscriber.end(true);
+    } catch (e) {
+      logger.error("Error force-ending HivTrace Redis subscriber: " + e.message);
+    }
+  }
+};
 
 HivTraceRunner.prototype.log_publisher = function() {
   var self = this;

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -49,7 +49,7 @@ hyphyJob.prototype.warn = function(notification, complementary_info) {
 // Attach socket to redis channel
 hyphyJob.prototype.attachSocket = function() {
   var self = this;
-  new cs.ClientSocket(self.socket, self.id);
+  self.client_socket = new cs.ClientSocket(self.socket, self.id);
 };
 
 // Can either initialize a new job or check on previous one
@@ -159,6 +159,7 @@ hyphyJob.prototype.spawn = function() {
   // Should be called when the job completes
   self.socket.on("disconnect", function() {
     self.log("user disconnected");
+    if (self.client_socket) self.client_socket.close();
   });
 };
 

--- a/lib/clientsocket.js
+++ b/lib/clientsocket.js
@@ -39,6 +39,41 @@ ClientSocket.prototype.initializeServer = function() {
     logger.info("emitting " + message);
     self.socket.emit(redis_packet.type, redis_packet);
   });
+
+  // Bind the dedicated subscriber's lifetime to the browser socket so it is
+  // released when the client disconnects instead of leaking a pub/sub
+  // connection for every job. See issue #397.
+  if (self.socket && typeof self.socket.on === "function") {
+    self.socket.on("disconnect", function() {
+      self.close();
+    });
+  }
+};
+
+/**
+* Tears down the dedicated Redis subscriber. Idempotent — safe to call from
+* multiple triggers (socket disconnect, explicit call-site cleanup).
+*/
+
+ClientSocket.prototype.close = function() {
+  if (this._closed) return;
+  this._closed = true;
+
+  logger.info(`[REDIS] Closing subscriber for channel ${this.channel_id}`);
+  try {
+    // Drop the message listener before quitting so a late message cannot emit
+    // to an already-disconnected socket.
+    this.subscriber.removeAllListeners("message");
+    this.subscriber.unsubscribe(this.channel_id);
+    this.subscriber.quit();
+  } catch (err) {
+    logger.error("Error closing Redis subscriber: " + err.message);
+    try {
+      this.subscriber.end(true);
+    } catch (e) {
+      logger.error("Error force-ending Redis subscriber: " + e.message);
+    }
+  }
 };
 
 exports.ClientSocket = ClientSocket;


### PR DESCRIPTION
## Redis subscriber connection leak: `ClientSocket` never tears down its dedicated subscriber (v2 backport)

Backport of the fix for #397 to the `release/2.6.x` (v2) line. The v3/master PR is #398. (Referenced without an auto-close keyword so #397 stays open until both lines have merged.)

### The bug

Every job/socket creates a **dedicated Redis subscriber connection** (`ClientSocket` in `lib/clientsocket.js`, and `HivTraceRunner` in `app/hivtrace/hivtrace.js`), subscribes it to a per-job channel, and never tears it down — no `unsubscribe()`, no `quit()`, and no handler on the browser socket's `disconnect` event. The `ClientSocket` instances in `hyphyjob.js` and `hivtrace.js` were even constructed without keeping a reference.

When a client closes the tab, the subscriber is orphaned in pub/sub mode and accumulates indefinitely. A production Redis snapshot showed ~3/4 of all client connections leaked as idle pub/sub subscribers (`flags=P sub=1`), some idle over a day with `age ≈ idle`.

### The fix

- **`lib/clientsocket.js`**: idempotent `ClientSocket.prototype.close()` (remove `message` listener → `unsubscribe` → `quit`, with `end(true)` fallback), armed on `socket.on("disconnect")`. Fixes all `ClientSocket` call sites transparently.
- **`app/hyphyjob.js`**: retains the `ClientSocket` reference; existing `disconnect` handler now also calls `close()`.
- **`app/hivtrace/hivtrace.js`**: `HivTraceRunner`'s separate `python_<id>` subscriber gets a matching idempotent `close()` (also `clearInterval`s the status-watcher metronome timer), wired to the terminal `completed`/`script error` events and to socket `disconnect`.

### Verification (live Redis)

Loaded the actual patched v2 `ClientSocket` and asserted on `PUBSUB NUMSUB <channel>`:

```
subscribers_before_create=0
subscribers_while_open=1
subscribers_after_disconnect=0
close_flag_set=true
double_close_no_throw=true
subscribers_after_multi_close=0
RESULT=PASS
```

Count rises 0 → 1 on construction, returns to 0 after `disconnect`; double-`close()` doesn't throw and stays at 0. All three files pass `node -c`.
