### PR TITLE
fix: Eliminate per-job resource leaks (cancelJob listeners, difFUBAR redis, hivtrace Tail) (#400)

### DIFF
--- a/app/difFubar/difFubar.js
+++ b/app/difFubar/difFubar.js
@@ -6,7 +6,13 @@ var config = require("../../config.json"),
   fs = require("fs"),
   path = require("path");
 
-// Redis client is handled by the base hyphyJob class
+// Module-level redis client, mirroring app/hyphyjob.js. Reused across
+// onComplete calls instead of creating (and leaking) a client per job
+// (GH #400).
+var client = redis.createClient({
+  host: config.redis_host,
+  port: config.redis_port
+});
 
 var difFubar = function(socket, stream, params) {
   var self = this;
@@ -271,14 +277,7 @@ difFubar.prototype.onComplete = function() {
           
           self.log("complete", "success (direct file transmission)");
           
-          // Use shared Redis client pattern like base class
-          const redis = require("redis");
-          const config = require("../../config.json");
-          const client = redis.createClient({
-            host: config.redis_host,
-            port: config.redis_port
-          });
-          
+          // Reuse the module-level redis client (GH #400).
           client.hset(self.id, "results", str_redis_packet, "status", "completed");
           client.publish(self.id, str_redis_packet);
           client.lrem("active_jobs", 1, self.id);

--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -12,7 +12,8 @@ var spawn = require("child_process").spawn,
   JobStatus = require("../../lib/jobstatus.js").JobStatus,
   logger = require("../../lib/logger").logger,
   redis = require("redis"),
-  utilities = require("../../lib/utilities");
+  utilities = require("../../lib/utilities"),
+  jobRegistry = require("../../lib/jobregistry.js");
 
 // Use redis as our key-value store
 var client = redis.createClient({ host: config.redis_host, port: config.redis_port });
@@ -214,17 +215,16 @@ hivtrace.prototype.spawn = function() {
     self.socket.emit("tn93 summary", tn93);
   });
 
-  // Global event that triggers all jobs to cancel
-  process.on("cancelJob", function(msg) {
-    self.warn("cancel called!");
-    self.cancel_once = _.once(self.cancel);
-    self.cancel_once();
-  });
+  // See GH #400: register in the central registry instead of adding a
+  // per-job process listener. cancel/onError are inherited from hyphyJob.
+  jobRegistry.register(self);
 
-  // Release the python_<id> subscriber (and its status-watcher timer) if the
-  // client disconnects before the job reaches a terminal state. See issue #397.
+  // Release the python_<id> subscriber, the Tail watcher and the status
+  // timer (via trace_runner.close), and the registry slot, if the client
+  // disconnects before the job reaches a terminal state. See #397, #400.
   self.socket.on("disconnect", function() {
     if (self.trace_runner) self.trace_runner.close();
+    jobRegistry.unregister(self.id);
   });
 
   // Ensure output directory exists
@@ -346,6 +346,7 @@ hivtrace.prototype.onComplete = function() {
 
       // Remove id from active_job queue
       client.lrem("active_jobs", 1, self.id);
+      jobRegistry.unregister(self.id);
     } else {
       self.onError(
         "job seems to have completed, but no results found: " +
@@ -436,6 +437,16 @@ HivTraceRunner.prototype.close = function() {
 
   if (self.metronome_id) clearInterval(self.metronome_id);
 
+  // Stop watching the hivtrace log file (node-tail exposes unwatch()). See #400.
+  if (self.tail) {
+    try {
+      self.tail.unwatch();
+    } catch (e) {
+      logger.warn("error unwatching hivtrace log tail: " + e);
+    }
+    self.tail = null;
+  }
+
   logger.info(
     "[REDIS] Closing subscriber for channel " + self.python_redis_channel
   );
@@ -456,10 +467,10 @@ HivTraceRunner.prototype.close = function() {
 HivTraceRunner.prototype.log_publisher = function() {
   var self = this;
 
-  // read log file
-  var tail = new Tail(self.hivtrace_log);
+  // read log file (stored on self so close() can stop watching it; GH #400)
+  self.tail = new Tail(self.hivtrace_log);
 
-  tail.on("line", function(data) {
+  self.tail.on("line", function(data) {
     logger.debug(data);
 
     if (data.indexOf("INFO:") != -1) {

--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -168,7 +168,8 @@ hivtrace.prototype.spawn = function() {
 
   // Setup Analysis
   var trace_runner = new HivTraceRunner(self.id, self.hivtrace_log);
-  new cs.ClientSocket(self.socket, self.id);
+  self.trace_runner = trace_runner;
+  self.client_socket = new cs.ClientSocket(self.socket, self.id);
 
   // On status updates, report to datamonkey-js
   trace_runner.on("status update", function(status_update) {
@@ -194,11 +195,13 @@ hivtrace.prototype.spawn = function() {
   // On errors, report to datamonkey-js
   trace_runner.on("script error", function(error) {
     self.onError(error);
+    trace_runner.close();
   });
 
   // When the analysis completes, return the results to datamonkey.
   trace_runner.on("completed", function() {
     self.onComplete();
+    trace_runner.close();
   });
 
   // Report the torque job id back to datamonkey
@@ -216,6 +219,12 @@ hivtrace.prototype.spawn = function() {
     self.warn("cancel called!");
     self.cancel_once = _.once(self.cancel);
     self.cancel_once();
+  });
+
+  // Release the python_<id> subscriber (and its status-watcher timer) if the
+  // client disconnects before the job reaches a terminal state. See issue #397.
+  self.socket.on("disconnect", function() {
+    if (self.trace_runner) self.trace_runner.close();
   });
 
   // Ensure output directory exists
@@ -414,6 +423,35 @@ var HivTraceRunner = function(id, hivtrace_log) {
 };
 
 util.inherits(HivTraceRunner, EventEmitter);
+
+/**
+ * Tears down the dedicated python_<id> Redis subscriber and the status-watcher
+ * timer. Idempotent — safe to call from terminal events and socket disconnect.
+ * See issue #397.
+ */
+HivTraceRunner.prototype.close = function() {
+  var self = this;
+  if (self._closed) return;
+  self._closed = true;
+
+  if (self.metronome_id) clearInterval(self.metronome_id);
+
+  logger.info(
+    "[REDIS] Closing subscriber for channel " + self.python_redis_channel
+  );
+  try {
+    self.subscriber.removeAllListeners("message");
+    self.subscriber.unsubscribe(self.python_redis_channel);
+    self.subscriber.quit();
+  } catch (err) {
+    logger.error("Error closing HivTrace Redis subscriber: " + err.message);
+    try {
+      self.subscriber.end(true);
+    } catch (e) {
+      logger.error("Error force-ending HivTrace Redis subscriber: " + e.message);
+    }
+  }
+};
 
 HivTraceRunner.prototype.log_publisher = function() {
   var self = this;

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -10,6 +10,8 @@ const cs = require("../lib/clientsocket.js"),
   JobStatus = require(__dirname + "/../lib/jobstatus.js").JobStatus,
   config = require("../config.json");
 
+var jobRegistry = require("../lib/jobregistry.js");
+
 // Use redis as our key-value store
 var client = redis.createClient({
   host: config.redis_host,
@@ -201,17 +203,17 @@ hyphyJob.prototype.spawn = function() {
     logger.info(`Job ${self.id}: Job submitted to runner`);
   });
 
-  // Global event that triggers all jobs to cancel
-  process.on("cancelJob", function() {
-    self.warn("cancel called!");
-    self.cancel_once = _.once(self.cancel);
-    self.cancel_once();
-  });
+  // Register in the central job registry; a single process-level
+  // "cancelJob" listener (lib/jobregistry.js) broadcast-cancels all
+  // live jobs without leaking one listener per job (GH #400).
+  jobRegistry.register(self);
 
-  // Should be called when the job completes
+  // Release the registry slot (and the redis subscriber) if the user
+  // disconnects before the job reaches a terminal state.
   self.socket.on("disconnect", function() {
     self.log("user disconnected");
     if (self.client_socket) self.client_socket.close();
+    jobRegistry.unregister(self.id);
   });
 };
 
@@ -320,6 +322,7 @@ hyphyJob.prototype.onComplete = function() {
 
         // Remove id from active_job queue
         client.lrem("active_jobs", 1, self.id);
+        jobRegistry.unregister(self.id);
         delete this;
       } else {
         // Empty results file
@@ -470,6 +473,7 @@ hyphyJob.prototype.onError = function(error) {
     client.hset(self.id, "error", str_redis_packet, "status", "error");
     client.publish(self.id, str_redis_packet);
     client.lrem("active_jobs", 1, self.id);
+    jobRegistry.unregister(self.id);
     client.llen("active_jobs", function(err, n) {
       process.emit("jobCancelled", n);
     });

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -61,7 +61,7 @@ hyphyJob.prototype.warn = function(notification, complementary_info) {
 hyphyJob.prototype.attachSocket = function() {
   var self = this;
   logger.info(`[DEBUG REDIS] Attaching socket to job ${self.id}`);
-  new cs.ClientSocket(self.socket, self.id);
+  self.client_socket = new cs.ClientSocket(self.socket, self.id);
 };
 
 // Can either initialize a new job or check on previous one
@@ -211,6 +211,7 @@ hyphyJob.prototype.spawn = function() {
   // Should be called when the job completes
   self.socket.on("disconnect", function() {
     self.log("user disconnected");
+    if (self.client_socket) self.client_socket.close();
   });
 };
 

--- a/lib/clientsocket.js
+++ b/lib/clientsocket.js
@@ -38,14 +38,49 @@ ClientSocket.prototype.initializeServer = function() {
   self.subscriber.on("message", function(channel, message) {
     logger.info(`[DEBUG REDIS] Received message on channel ${channel} for socket ${self.socket.id}`);
     logger.info(`[DEBUG REDIS] Message length: ${message.length} bytes`);
-    
+
     var redis_packet = JSON.parse(message);
     logger.info(`[DEBUG REDIS] Message type: ${redis_packet.type}`);
     logger.info("emitting " + message);
-    
+
     self.socket.emit(redis_packet.type, redis_packet);
     logger.info(`[DEBUG REDIS] Emitted ${redis_packet.type} event to client socket`);
   });
+
+  // Bind the dedicated subscriber's lifetime to the browser socket so it is
+  // released when the client disconnects instead of leaking a pub/sub
+  // connection for every job. See issue #397.
+  if (self.socket && typeof self.socket.on === "function") {
+    self.socket.on("disconnect", function() {
+      self.close();
+    });
+  }
+};
+
+/**
+* Tears down the dedicated Redis subscriber. Idempotent — safe to call from
+* multiple triggers (socket disconnect, explicit call-site cleanup).
+*/
+
+ClientSocket.prototype.close = function() {
+  if (this._closed) return;
+  this._closed = true;
+
+  logger.info(`[REDIS] Closing subscriber for channel ${this.channel_id}`);
+  try {
+    // Drop the message listener before quitting so a late message cannot emit
+    // to an already-disconnected socket.
+    this.subscriber.removeAllListeners("message");
+    this.subscriber.unsubscribe(this.channel_id);
+    this.subscriber.quit();
+  } catch (err) {
+    logger.error("Error closing Redis subscriber: " + err.message);
+    try {
+      this.subscriber.end(true);
+    } catch (e) {
+      logger.error("Error force-ending Redis subscriber: " + e.message);
+    }
+  }
 };
 
 exports.ClientSocket = ClientSocket;

--- a/lib/jobregistry.js
+++ b/lib/jobregistry.js
@@ -1,0 +1,28 @@
+// Central registry of live jobs so a single process-level "cancelJob"
+// listener can broadcast-cancel all active jobs without leaking one
+// listener per job (see GH #400).
+var _ = require("underscore");
+
+var activeJobs = new Map(); // id -> job instance
+
+function register(job) {
+  if (job && job.id) activeJobs.set(job.id, job);
+}
+
+function unregister(id) {
+  if (id) activeJobs.delete(id);
+}
+
+function cancelAll() {
+  activeJobs.forEach(function(job) {
+    // Bind once per job so repeated cancelJob events cancel at most once.
+    job.cancel_broadcast_once =
+      job.cancel_broadcast_once || _.once(job.cancel.bind(job));
+    job.cancel_broadcast_once();
+  });
+}
+
+// Install the SINGLE permanent listener exactly once (module is cached by Node).
+process.on("cancelJob", cancelAll);
+
+module.exports = { register: register, unregister: unregister, cancelAll: cancelAll };

--- a/server.js
+++ b/server.js
@@ -650,4 +650,4 @@ io.sockets.on("connection", function(socket) {
 var mcp = require("./lib/mcp");
 mcp.startMcpServer(config, client);
 
-process.setMaxListeners(0);
+process.setMaxListeners(20); // bounded; GH #400 removed per-job cancelJob listeners


### PR DESCRIPTION
## Eliminate per-job resource leaks: cancelJob listeners, difFUBAR Redis client, hivtrace Tail (#400)

Fixes #400. Follow-up to the Redis subscriber leak (#397 / #398).

> **Stacking note:** this branch is based on `fix/redis-subscriber-leak-397` (PR #398), so please **merge #398 first**. Its diff against `master` will then reduce to only the changes below.

### The leaks

1. **`cancelJob` listener leak (HIGH).** `hyphyJob.spawn()` and `hivtrace.spawn()` each registered a `process.on("cancelJob", …)` listener **per job**, never removed. The closure captured `self` (the whole job object), pinning every job that ever ran onto the global `process` EventEmitter — so jobs (and everything they reference) could never be garbage-collected. `server.js` masked the resulting "possible EventEmitter memory leak" warning with `process.setMaxListeners(0)`. Since every analysis inherits `hyphyJob`, this fired on essentially every job.

2. **difFUBAR per-job Redis client (HIGH).** `difFubar.onComplete` created a fresh `redis.createClient()` on every completion, ran `hset`/`publish`/`lrem`, and abandoned it — one leaked connection per difFUBAR job.

3. **hivtrace `Tail` watcher (MEDIUM).** `HivTraceRunner.log_publisher` created a `new Tail(...)` on the log file that was never closed — a file-descriptor/watcher leak per hivtrace job.

### The fix

- **New `lib/jobregistry.js`** — holds a `Map` of live jobs and installs **exactly one** permanent `process.on("cancelJob")` listener that broadcast-cancels every registered job (idempotent per job via `_.once(job.cancel.bind(job))`). Listener count on `process` is now a constant 1 regardless of job volume.
- **`app/hyphyjob.js` / `app/hivtrace/hivtrace.js`** — replaced the per-job `process.on("cancelJob")` with `jobRegistry.register(self)` in `spawn()`, and `jobRegistry.unregister(self.id)` on completion (`onComplete`), error/cancel (`onError`), and socket `disconnect`. Cancellation semantics are unchanged: emitting `cancelJob` still cancels all in-flight jobs (this is how the test suite broadcasts cancel).
- **`server.js`** — `setMaxListeners(0)` → `setMaxListeners(20)`, so a reintroduced per-job-listener leak would surface as a warning again instead of being silently masked.
- **`app/difFubar/difFubar.js`** — reuse a module-level Redis client (like the other analyses) instead of creating one per completion.
- **`app/hivtrace/hivtrace.js`** — store the `Tail` on `self.tail` and `unwatch()` it inside the existing `HivTraceRunner.close()` teardown (added in #397).

### Verification

A focused harness loaded `lib/jobregistry.js` and drove the cancel path:

```
cancelled_order=["A","B","C"]      # register A,B → cancelJob cancels both; re-emit is a no-op; C registered later cancels, unregistered B does not
cancelJob_listener_count=1         # exactly one process listener regardless of job count
RESULT=PASS
```

This confirms: broadcast-cancel still works, is idempotent (no double-cancel), respects unregister, and the listener leak is gone. All changed files pass `node -c`.
