### PR TITLE
fix: Eliminate per-job resource leaks (cancelJob listeners, hivtrace Tail) (2.6.x) (#400)

### DIFF
--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -12,7 +12,8 @@ var spawn = require("child_process").spawn,
   JobStatus = require("../../lib/jobstatus.js").JobStatus,
   logger = require("../../lib/logger").logger,
   redis = require("redis"),
-  utilities = require("../../lib/utilities");
+  utilities = require("../../lib/utilities"),
+  jobRegistry = require("../../lib/jobregistry.js");
 
 // Use redis as our key-value store
 var client = redis.createClient({ host: config.redis_host, port: config.redis_port });
@@ -214,17 +215,16 @@ hivtrace.prototype.spawn = function() {
     self.socket.emit("tn93 summary", tn93);
   });
 
-  // Global event that triggers all jobs to cancel
-  process.on("cancelJob", function(msg) {
-    self.warn("cancel called!");
-    self.cancel_once = _.once(self.cancel);
-    self.cancel_once();
-  });
+  // See GH #400: register in the central registry instead of adding a
+  // per-job process listener. cancel/onError are inherited from hyphyJob.
+  jobRegistry.register(self);
 
-  // Release the python_<id> subscriber (and its status-watcher timer) if the
-  // client disconnects before the job reaches a terminal state. See issue #397.
+  // Release the python_<id> subscriber, the Tail watcher and the status
+  // timer (via trace_runner.close), and the registry slot, if the client
+  // disconnects before the job reaches a terminal state. See #397, #400.
   self.socket.on("disconnect", function() {
     if (self.trace_runner) self.trace_runner.close();
+    jobRegistry.unregister(self.id);
   });
 
   // Ensure output directory exists
@@ -346,6 +346,7 @@ hivtrace.prototype.onComplete = function() {
 
       // Remove id from active_job queue
       client.lrem("active_jobs", 1, self.id);
+      jobRegistry.unregister(self.id);
     } else {
       self.onError(
         "job seems to have completed, but no results found: " +
@@ -436,6 +437,16 @@ HivTraceRunner.prototype.close = function() {
 
   if (self.metronome_id) clearInterval(self.metronome_id);
 
+  // Stop watching the hivtrace log file (node-tail exposes unwatch()). See #400.
+  if (self.tail) {
+    try {
+      self.tail.unwatch();
+    } catch (e) {
+      logger.warn("error unwatching hivtrace log tail: " + e);
+    }
+    self.tail = null;
+  }
+
   logger.info(
     "[REDIS] Closing subscriber for channel " + self.python_redis_channel
   );
@@ -456,10 +467,10 @@ HivTraceRunner.prototype.close = function() {
 HivTraceRunner.prototype.log_publisher = function() {
   var self = this;
 
-  // read log file
-  var tail = new Tail(self.hivtrace_log);
+  // read log file (stored on self so close() can stop watching it; GH #400)
+  self.tail = new Tail(self.hivtrace_log);
 
-  tail.on("line", function(data) {
+  self.tail.on("line", function(data) {
     logger.debug(data);
 
     if (data.indexOf("INFO:") != -1) {

--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -168,7 +168,8 @@ hivtrace.prototype.spawn = function() {
 
   // Setup Analysis
   var trace_runner = new HivTraceRunner(self.id, self.hivtrace_log);
-  new cs.ClientSocket(self.socket, self.id);
+  self.trace_runner = trace_runner;
+  self.client_socket = new cs.ClientSocket(self.socket, self.id);
 
   // On status updates, report to datamonkey-js
   trace_runner.on("status update", function(status_update) {
@@ -194,11 +195,13 @@ hivtrace.prototype.spawn = function() {
   // On errors, report to datamonkey-js
   trace_runner.on("script error", function(error) {
     self.onError(error);
+    trace_runner.close();
   });
 
   // When the analysis completes, return the results to datamonkey.
   trace_runner.on("completed", function() {
     self.onComplete();
+    trace_runner.close();
   });
 
   // Report the torque job id back to datamonkey
@@ -216,6 +219,12 @@ hivtrace.prototype.spawn = function() {
     self.warn("cancel called!");
     self.cancel_once = _.once(self.cancel);
     self.cancel_once();
+  });
+
+  // Release the python_<id> subscriber (and its status-watcher timer) if the
+  // client disconnects before the job reaches a terminal state. See issue #397.
+  self.socket.on("disconnect", function() {
+    if (self.trace_runner) self.trace_runner.close();
   });
 
   // Ensure output directory exists
@@ -414,6 +423,35 @@ var HivTraceRunner = function(id, hivtrace_log) {
 };
 
 util.inherits(HivTraceRunner, EventEmitter);
+
+/**
+ * Tears down the dedicated python_<id> Redis subscriber and the status-watcher
+ * timer. Idempotent — safe to call from terminal events and socket disconnect.
+ * See issue #397.
+ */
+HivTraceRunner.prototype.close = function() {
+  var self = this;
+  if (self._closed) return;
+  self._closed = true;
+
+  if (self.metronome_id) clearInterval(self.metronome_id);
+
+  logger.info(
+    "[REDIS] Closing subscriber for channel " + self.python_redis_channel
+  );
+  try {
+    self.subscriber.removeAllListeners("message");
+    self.subscriber.unsubscribe(self.python_redis_channel);
+    self.subscriber.quit();
+  } catch (err) {
+    logger.error("Error closing HivTrace Redis subscriber: " + err.message);
+    try {
+      self.subscriber.end(true);
+    } catch (e) {
+      logger.error("Error force-ending HivTrace Redis subscriber: " + e.message);
+    }
+  }
+};
 
 HivTraceRunner.prototype.log_publisher = function() {
   var self = this;

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -10,6 +10,8 @@ const cs = require("../lib/clientsocket.js"),
   JobStatus = require(__dirname + "/../lib/jobstatus.js").JobStatus,
   config = require("../config.json");
 
+var jobRegistry = require("../lib/jobregistry.js");
+
 // Use redis as our key-value store
 var client = redis.createClient({
   host: config.redis_host,
@@ -149,17 +151,17 @@ hyphyJob.prototype.spawn = function() {
     logger.info(`Job ${self.id}: Job submitted to runner`);
   });
 
-  // Global event that triggers all jobs to cancel
-  process.on("cancelJob", function() {
-    self.warn("cancel called!");
-    self.cancel_once = _.once(self.cancel);
-    self.cancel_once();
-  });
+  // Register in the central job registry; a single process-level
+  // "cancelJob" listener (lib/jobregistry.js) broadcast-cancels all
+  // live jobs without leaking one listener per job (GH #400).
+  jobRegistry.register(self);
 
-  // Should be called when the job completes
+  // Release the registry slot (and the redis subscriber) if the user
+  // disconnects before the job reaches a terminal state.
   self.socket.on("disconnect", function() {
     self.log("user disconnected");
     if (self.client_socket) self.client_socket.close();
+    jobRegistry.unregister(self.id);
   });
 };
 
@@ -254,6 +256,7 @@ hyphyJob.prototype.onComplete = function() {
 
         // Remove id from active_job queue
         client.lrem("active_jobs", 1, self.id);
+        jobRegistry.unregister(self.id);
         delete this;
       } else {
         // Empty results file
@@ -392,6 +395,7 @@ hyphyJob.prototype.onError = function(error) {
     client.hset(self.id, "error", str_redis_packet, "status", "error");
     client.publish(self.id, str_redis_packet);
     client.lrem("active_jobs", 1, self.id);
+    jobRegistry.unregister(self.id);
     client.llen("active_jobs", function(err, n) {
       process.emit("jobCancelled", n);
     });

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -49,7 +49,7 @@ hyphyJob.prototype.warn = function(notification, complementary_info) {
 // Attach socket to redis channel
 hyphyJob.prototype.attachSocket = function() {
   var self = this;
-  new cs.ClientSocket(self.socket, self.id);
+  self.client_socket = new cs.ClientSocket(self.socket, self.id);
 };
 
 // Can either initialize a new job or check on previous one
@@ -159,6 +159,7 @@ hyphyJob.prototype.spawn = function() {
   // Should be called when the job completes
   self.socket.on("disconnect", function() {
     self.log("user disconnected");
+    if (self.client_socket) self.client_socket.close();
   });
 };
 

--- a/lib/clientsocket.js
+++ b/lib/clientsocket.js
@@ -39,6 +39,41 @@ ClientSocket.prototype.initializeServer = function() {
     logger.info("emitting " + message);
     self.socket.emit(redis_packet.type, redis_packet);
   });
+
+  // Bind the dedicated subscriber's lifetime to the browser socket so it is
+  // released when the client disconnects instead of leaking a pub/sub
+  // connection for every job. See issue #397.
+  if (self.socket && typeof self.socket.on === "function") {
+    self.socket.on("disconnect", function() {
+      self.close();
+    });
+  }
+};
+
+/**
+* Tears down the dedicated Redis subscriber. Idempotent — safe to call from
+* multiple triggers (socket disconnect, explicit call-site cleanup).
+*/
+
+ClientSocket.prototype.close = function() {
+  if (this._closed) return;
+  this._closed = true;
+
+  logger.info(`[REDIS] Closing subscriber for channel ${this.channel_id}`);
+  try {
+    // Drop the message listener before quitting so a late message cannot emit
+    // to an already-disconnected socket.
+    this.subscriber.removeAllListeners("message");
+    this.subscriber.unsubscribe(this.channel_id);
+    this.subscriber.quit();
+  } catch (err) {
+    logger.error("Error closing Redis subscriber: " + err.message);
+    try {
+      this.subscriber.end(true);
+    } catch (e) {
+      logger.error("Error force-ending Redis subscriber: " + e.message);
+    }
+  }
 };
 
 exports.ClientSocket = ClientSocket;

--- a/lib/jobregistry.js
+++ b/lib/jobregistry.js
@@ -1,0 +1,28 @@
+// Central registry of live jobs so a single process-level "cancelJob"
+// listener can broadcast-cancel all active jobs without leaking one
+// listener per job (see GH #400).
+var _ = require("underscore");
+
+var activeJobs = new Map(); // id -> job instance
+
+function register(job) {
+  if (job && job.id) activeJobs.set(job.id, job);
+}
+
+function unregister(id) {
+  if (id) activeJobs.delete(id);
+}
+
+function cancelAll() {
+  activeJobs.forEach(function(job) {
+    // Bind once per job so repeated cancelJob events cancel at most once.
+    job.cancel_broadcast_once =
+      job.cancel_broadcast_once || _.once(job.cancel.bind(job));
+    job.cancel_broadcast_once();
+  });
+}
+
+// Install the SINGLE permanent listener exactly once (module is cached by Node).
+process.on("cancelJob", cancelAll);
+
+module.exports = { register: register, unregister: unregister, cancelAll: cancelAll };

--- a/server.js
+++ b/server.js
@@ -335,4 +335,4 @@ io.sockets.on("connection", function(socket) {
 
 
 
-process.setMaxListeners(0);
+process.setMaxListeners(20); // bounded; GH #400 removed per-job cancelJob listeners


### PR DESCRIPTION
## Eliminate per-job resource leaks: cancelJob listeners + hivtrace Tail (2.6.x) (#400)

Backport of #400 to the `release/2.6.x` (v2) line. The v3/master PR is the companion. Follow-up to #397 / #399.

> **Stacking note:** based on `fix/redis-subscriber-leak-397-2.6.x` (PR #399), so please **merge #399 first**; the diff against `release/2.6.x` then reduces to only the changes below.

### The leaks (same as v3, minus difFUBAR which is v3-only)

1. **`cancelJob` listener leak (HIGH)** — per-job `process.on("cancelJob")` in `hyphyJob.spawn()`/`hivtrace.spawn()`, never removed, closure captures the whole job object so jobs never GC. `server.js` masked the warning with `setMaxListeners(0)`.
2. **hivtrace `Tail` watcher (MEDIUM)** — `new Tail(...)` never closed.

### The fix

- **New `lib/jobregistry.js`** — one permanent `cancelJob` listener broadcast-cancelling a `Map` of live jobs (idempotent per job). Jobs register in `spawn()`, unregister on completion/error/disconnect.
- **`server.js`** — `setMaxListeners(0)` → `setMaxListeners(20)`.
- **`app/hivtrace/hivtrace.js`** — `Tail` stored on `self.tail` and `unwatch()`'d in the existing `HivTraceRunner.close()`.

(difFUBAR is not present on 2.6.x, so that part of #400 doesn't apply here.)

### Verification

```
cancelled=["A","B","C"] listeners=1 RESULT=PASS
```

Broadcast-cancel works, is idempotent, respects unregister, and keeps exactly one process listener. All changed files pass `node -c`.
