### PR TITLE
fix: Stringify hivtrace hset params; read difFUBAR msa[0]._id (#403)

### DIFF
--- a/app/difFubar/difFubar.js
+++ b/app/difFubar/difFubar.js
@@ -20,7 +20,7 @@ var difFubar = function(socket, stream, params) {
   self.qsub_script = __dirname + "/" + self.qsub_script_name;
 
   // parameter attributes
-  self.msaid = self.params.msa._id;
+  self.msaid = self.params.msa && self.params.msa[0] && self.params.msa[0]._id;
   self.id = self.params.analysis._id;
   self.nj = self.params.msa[0].nj;
   

--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -164,7 +164,11 @@ hivtrace.prototype.spawn = function() {
   self.send_aligned_fasta_once = _.once(self.sendAlignedFasta);
   self.send_tn93_once = _.once(self.sendtn93);
 
-  client.hset(self.id, "params", self.params);
+  client.hset(
+    self.id,
+    "params",
+    typeof self.params === "string" ? self.params : JSON.stringify(self.params)
+  );
 
   // Setup Analysis
   var trace_runner = new HivTraceRunner(self.id, self.hivtrace_log);


### PR DESCRIPTION
Fixes #403.

Two latent bugs surfaced while repairing the socket test suite (they were hidden because the tests couldn't run under socket.io v4).

### 1. hivtrace `hset` throws on object params
`hivtrace.spawn()` called `client.hset(self.id, "params", self.params)` with an object. node-redis 3 rejects the non-string value and throws at `RedisClient.hset`, aborting `spawn()` before the job is submitted. Now stringifies when not already a string.

### 2. difFUBAR reads `msa._id` instead of `msa[0]._id`
The difFUBAR constructor read `self.params.msa._id`, but `msa` is an array (`msa[0].nj` is used correctly two lines later), so `self.msaid` was always `undefined`. Now guarded and reads `msa[0]._id`.

### Verification
Both fixes are validated by the repaired hivtrace and difFUBAR tests (companion test-harness PR): with fix #1 reverted, `test/hivtrace/hivtrace.js` fails with `RedisClient.hset` throwing at `hivtrace.js:167`; with it applied, the hivtrace submit-and-cancel test passes. All changed files pass `node -c`.

The v2 backport (hivtrace only — difFUBAR is v3-only) is a separate PR.