### PR TITLE
fix: Stringify hivtrace hset params (2.6.x) (#403)

### DIFF
--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -164,7 +164,11 @@ hivtrace.prototype.spawn = function() {
   self.send_aligned_fasta_once = _.once(self.sendAlignedFasta);
   self.send_tn93_once = _.once(self.sendtn93);
 
-  client.hset(self.id, "params", self.params);
+  client.hset(
+    self.id,
+    "params",
+    typeof self.params === "string" ? self.params : JSON.stringify(self.params)
+  );
 
   // Setup Analysis
   var trace_runner = new HivTraceRunner(self.id, self.hivtrace_log);


### PR DESCRIPTION
Backport of the hivtrace fix from #403 / #404 to release/2.6.x.

`hivtrace.spawn()` called `client.hset(self.id, "params", self.params)` with an object; node-redis 3 rejects the non-string value and throws at `RedisClient.hset`, aborting spawn before submission. Now stringifies when not already a string.

(The difFUBAR `msa[0]._id` fix from #404 doesn't apply — difFUBAR is v3-only.) Validated by the repaired hivtrace test; passes `node -c`.