### PR TITLE
fix: hivtrace Custom reference filepath used before assignment (2.6.x) (#408)

### DIFF
--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -61,6 +61,13 @@ var hivtrace = function(socket, stream, params) {
   self.prealigned = params.prealigned;
   self.strip_drams = params.strip_drams == "no" ? false : params.strip_drams;
 
+  // parameter-derived attributes.
+  // NOTE: self.filepath MUST be set before the Custom-reference block below,
+  // which derives custom_reference_fn from it. Previously filepath was assigned
+  // after that block, so a Custom reference was written to
+  // "undefined_custom_reference.fas" and never found. See #408.
+  self.filepath = path.join(self.output_dir, self.id);
+
   if (params.reference == "Custom") {
     self.custom_reference_fn = self.filepath + custom_reference_suffix;
     self.custom_reference = params.custom_reference;
@@ -71,8 +78,6 @@ var hivtrace = function(socket, stream, params) {
     ) {});
   }
 
-  // parameter-derived attributes
-  self.filepath = path.join(self.output_dir, self.id);
   self.status_fn = self.filepath + "_status";
   self.output_cluster_output = self.filepath + cluster_output_suffix;
   self.tn93_stdout = self.filepath + tn93_json_suffix;


### PR DESCRIPTION
Fixes #408 on release/2.6.x.

hivtrace's constructor derived `custom_reference_fn` from `self.filepath` **before** `self.filepath` was assigned, so a Custom-reference HIV-TRACE job wrote the reference to `undefined_custom_reference.fas` and could not find it. Moved the `self.filepath` assignment above the Custom-reference block.

Surfaced by the test-coverage sweep; the v3 companion (on the robustness-suite test branch) includes a regression test that fails with `'undefined_custom_reference.fas'` without the fix. difFUBAR/hivtrace param fixes for #403 are separate (#405).