### PR TITLE
Phase 0: run test:ci lane in CI (#410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [feature/v4-modernization]
+  pull_request:
+    branches: [feature/v4-modernization, master]
+
+jobs:
+  test:
+    name: Unit Tests (no cluster)
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Create config.json
+        run: |
+          echo '{"port":7015,"redis_host":"localhost","redis_port":6379,"loglevel":"info","submit_type":"local","mcp_port":7016}' > config.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run cluster-free test lane
+        run: npm run test:ci


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` — a "CI" workflow with a single job "Unit Tests (no cluster)" that runs the cluster-free `test:ci` mocha lane.

## What changed
- New file only: `.github/workflows/ci.yml`
- Triggers:
  - `push` to `feature/v4-modernization`
  - `pull_request` targeting `feature/v4-modernization` and `master`
- Structure mirrors the existing `.github/workflows/mcp-tests.yml`:
  - `redis:7` service on 6379 with the same healthcheck (ping, 10s/5s/5 retries)
  - node matrix `[18, 20, 22]`
  - `actions/checkout@v4`, `actions/setup-node@v4`
  - writes a local `config.json` with `submit_type: local`
  - `npm install`, then `npm run test:ci`
- Does NOT run `test:slurm` — that lane needs the SLURM/MPI cluster, which is unavailable on GitHub runners.

## Why
This is Phase 0 (GUARDRAILS) of the v4 modernization epic (#410). Non-breaking: adds CI coverage for the cluster-free regression/error-path/validation/mock/sanitize/difFubar/fubar-redirection tests so the long-lived `feature/v4-modernization` integration branch stays green as later phases land.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses; name/job/triggers/matrix/final-step confirmed.

Part of #410.