### PR TITLE
Phase 0: global unhandledRejection/uncaughtException handlers (#410)

### DIFF
--- a/server.js
+++ b/server.js
@@ -651,3 +651,37 @@ var mcp = require("./lib/mcp");
 mcp.startMcpServer(config, client);
 
 process.setMaxListeners(20); // bounded; GH #400 removed per-job cancelJob listeners
+
+// -----------------------------------------------------------------------------
+// Global process-level error handlers (Phase 0 guardrails, #410)
+//
+// These are a safety net for errors that escape the normal request/socket
+// handling and would otherwise be handled by Node's default behavior.
+// They log loudly through the existing winston logger so failures are visible
+// in production, rather than being lost to stderr in a PM2 cluster worker.
+// -----------------------------------------------------------------------------
+
+// Unhandled promise rejections: log with full error + stack, but do NOT exit.
+// A rejected promise leaves the process in a known-enough state to keep serving
+// other requests; killing the worker here would be more disruptive than useful.
+process.on("unhandledRejection", (reason, promise) => {
+  logger.error("Unhandled promise rejection (#410 guardrail)", {
+    reason: reason instanceof Error ? reason.message : reason,
+    stack: reason instanceof Error ? reason.stack : null,
+    promise: String(promise),
+  });
+});
+
+// Uncaught exceptions: an exception reached the top of the stack, so this worker
+// is in an unknown/undefined state. Log it, then exit non-zero after a short
+// flush delay so the winston transport can write the record. PM2 will restart
+// the worker. We deliberately do NOT swallow this — a corrupted process should
+// be replaced, not kept alive serving requests from an unknown state.
+process.on("uncaughtException", (err) => {
+  logger.error("Uncaught exception — restarting worker (#410 guardrail)", {
+    message: err && err.message,
+    stack: err && err.stack,
+  });
+  // Give the logger a moment to flush before exiting; PM2 handles the restart.
+  setTimeout(() => process.exit(1), 500);
+});


### PR DESCRIPTION
## Phase 0 guardrail (#410)

Adds global process-level error handlers to `server.js` as part of Phase 0 (GUARDRAILS) of the v4 modernization epic (#410). **Non-breaking**; `server.js` is the only file changed.

### What changed
Two handlers are registered near the end of `server.js` (right after `mcp.startMcpServer` / `process.setMaxListeners(20)`), both logging through the existing winston `logger`:

- **`unhandledRejection`** — logs loudly with the rejection reason + stack, but does **not** exit. A rejected promise leaves the worker in a known-enough state to keep serving other requests, so killing it would be more disruptive than useful.
- **`uncaughtException`** — logs the error + stack, then exits with a non-zero code after a short (500ms) flush delay so the winston transport can write the record. PM2 then restarts the worker. The exception is deliberately **not** swallowed: an unknown-state process should be replaced, not kept alive.

### Why
In the PM2 cluster setup, uncaught errors that escape the normal request/socket handling would otherwise go to raw stderr (easily lost) or leave a worker in an undefined state. These handlers make such failures visible and restart cleanly.

### Verification
- `node -c server.js` → OK (no syntax errors)
- `npx eslint server.js` → 8 errors, all pre-existing on the base branch (lines 76/86/92/97/101/106/390); this change introduces **zero** new lint errors.

Phase 0 of #410. Do not merge to master — targets `feature/v4-modernization`.