### PR TITLE
Phase 0: enforce eslint in CI + add prettier (#410)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  push:
+    branches: [feature/v4-modernization]
+  pull_request:
+    branches: [feature/v4-modernization, master]
+
+jobs:
+  lint:
+    name: ESLint + Prettier (report-only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      # Report-only for now: the codebase has ~160 pre-existing
+      # eslint:recommended violations. A follow-up (Phase 0) will fix
+      # them and flip this to blocking. See #410.
+      - name: Run ESLint (report-only)
+        run: npm run lint
+        continue-on-error: true
+
+      # Prettier is not yet enforced; the codebase is not formatted.
+      # Report-only until an opt-in reformat lands.
+      - name: Check formatting with Prettier (report-only)
+        run: npm run format:check
+        continue-on-error: true

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": false,
+  "semi": true,
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:integration": "mocha -R spec --exit test/integration/slac-completes.js",
     "test:mcp": "mocha -R spec --exit test/mcp/mcp.test.js",
     "test-mcp": "npm run test:mcp",
+    "lint": "eslint app lib server.js",
+    "format:check": "prettier --check \"app/**/*.js\" \"lib/**/*.js\" server.js",
     "coverage": "nyc --reporter=text --reporter=html --include 'app/**/*.js' --include 'lib/**/*.js' npm run test"
   },
   "dependencies": {
@@ -38,6 +40,7 @@
     "chai": "^4.3.7",
     "eslint": "^7.32.0",
     "mocha": "^11.7.1",
+    "prettier": "^3.9.5",
     "socket.io-client": "^4.5.4",
     "socket.io-stream": "^0.9.1"
   }


### PR DESCRIPTION
## Phase 0 of #410 (guardrails) — non-breaking

Adds lint/format tooling and a CI workflow that surfaces (but does not yet enforce) code-style issues.

### Changes
- **`.github/workflows/lint.yml`** — new "Lint" workflow (checkout@v4, setup-node@v4 node 20, `npm install`) that runs:
  - `npm run lint` (`eslint app lib server.js`)
  - `npm run format:check` (`prettier --check`)
  - Triggers: push to `feature/v4-modernization`, and PRs into `feature/v4-modernization` and `master`.
- **`.prettierrc.json`** — consistent with the existing `.eslintrc.js` style: 2-space indent, double quotes, semicolons (`endOfLine: lf`, `trailingComma: es5`).
- **`package.json`** — adds `lint` and `format:check` scripts and `prettier` to `devDependencies`. No source files were reformatted.

### Report-only, by design
Running `npx eslint app lib server.js` locally against the current tree reports **160 problems (160 errors)** under `eslint:recommended`, and `prettier --check` flags **40 unformatted files**. To avoid making CI red on day one, both steps use `continue-on-error: true` so the job stays green while still printing the report in the logs.

A follow-up (still Phase 0) will fix the violations and flip these steps to blocking. This PR deliberately does **not** mass-reformat the codebase.

### Verification (run locally in the worktree)
- `node -c` / JSON parse: `package.json`, `.prettierrc.json` parse OK; `lint.yml` validated as YAML.
- `npm run lint` → exit 1, `160 problems (160 errors, 0 warnings)` (expected; surfaced report-only in CI).
- `npm run format:check` → exit 1, `Code style issues found in 40 files` (expected; report-only in CI).
- `npx prettier --version` → `3.9.5`.

Base: `feature/v4-modernization`. Do not merge to `master`.