### PR TITLE
Phase 1: redis v5 client factory + deps (#410)

### DIFF
--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -1,0 +1,136 @@
+/**
+ * Shared redis v5 (node-redis) client factory.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Historically every module did its own `var client = redis.createClient(...)`
+ * at module scope (server.js, app/job.js, lib/jobqueue.js, app/hivtrace/*, ...).
+ * redis@5 is promise-native and requires an explicit `await client.connect()`
+ * after `createClient`, so the old pattern no longer works verbatim. This module
+ * centralizes connection setup so every caller shares one consistent, connected
+ * client and one consistent config shape.
+ *
+ * HOW TO USE IT (the pattern every sibling PR must follow)
+ * --------------------------------------------------------
+ *   const { client } = require("../lib/redis-client");
+ *   // ...later, inside an async function or a .then():
+ *   const obj = await client.hGetAll(job_id);   // commands are camelCased
+ *   await client.hSet(job_id, "status", "done");
+ *   await client.rPush("active_jobs", job_id);
+ *
+ * The exported `client` begins connecting the moment this module is first
+ * required (mirroring the old module-scope `createClient` behaviour). Because
+ * redis@5 buffers commands issued before the socket is ready, callers may issue
+ * commands immediately; they resolve once the connection is established. If you
+ * need to be certain the socket is up, `await client.connect()` is idempotent-ish
+ * only when NOT already connecting — prefer `await ready` (also exported) which
+ * resolves when the initial connect() settles.
+ *
+ * v5 API NOTES (vs the old v3 API this replaces)
+ * ----------------------------------------------
+ *   - createClient({ url } | { socket: { host, port }, password }) — no callbacks.
+ *   - Commands are camelCased: hgetall->hGetAll, hset->hSet, hget->hGet,
+ *     lrem->lRem, rpush->rPush, llen->lLen, del->del.
+ *   - Commands return promises; there is no (err, reply) callback form.
+ *
+ * PUB/SUB — SUBSCRIBER DUPLICATE PATTERN (read carefully)
+ * -------------------------------------------------------
+ * In redis@5 a connection that is in subscriber mode CANNOT issue normal
+ * commands, so a subscriber MUST be a SEPARATE connection. Use the exported
+ * `createSubscriber()` helper, which does `client.duplicate()` + `connect()`.
+ *
+ * There is NO more `.on("message", ...)`. The listener is passed directly to
+ * `.subscribe()`, and the message is the FIRST argument:
+ *
+ *   const sub = await createSubscriber();
+ *   await sub.subscribe(channel, (message, channel) => {
+ *     const packet = JSON.parse(message);
+ *     // ...
+ *   });
+ *
+ * Teardown (preserve this exactly — see leak fixes #397/#400):
+ *
+ *   await sub.unsubscribe(channel);
+ *   await sub.quit();              // graceful; falls back to sub.destroy() on error
+ *
+ * `createSubscriber()` returns a promise resolving to a CONNECTED duplicate
+ * client. It attaches an "error" handler so a broken subscriber socket logs
+ * instead of crashing the process.
+ */
+
+const redis = require("redis"),
+  logger = require("./logger").logger,
+  config = require("../config.json");
+
+/**
+ * Build the redis@5 client options from config.json.
+ * config.redis_host, config.redis_port, and optional config.redis_password.
+ */
+function buildClientOptions() {
+  const options = {
+    socket: {
+      host: config.redis_host,
+      port: config.redis_port,
+    },
+  };
+  if (config.redis_password) {
+    options.password = config.redis_password;
+  }
+  return options;
+}
+
+// Create the shared client at module scope, mirroring the historical
+// `var client = redis.createClient(...)` behaviour. In redis@5 this does NOT
+// open the socket by itself — connect() below does that.
+const client = redis.createClient(buildClientOptions());
+
+// Always attach an error handler so a transient redis error logs instead of
+// throwing an unhandled 'error' event and crashing the process.
+client.on("error", function (err) {
+  logger.error("Redis client error: " + err.message);
+});
+
+// Kick off the connection immediately on load. redis@5 queues commands issued
+// before the socket is ready and flushes them once connected, so callers can
+// require this module and issue commands without awaiting `ready` first.
+// We expose `ready` for callers that want to be sure the socket is up.
+const ready = client
+  .connect()
+  .then(function () {
+    logger.info("Redis shared client connected");
+  })
+  .catch(function (err) {
+    logger.error("Redis shared client failed to connect: " + err.message);
+  });
+
+/**
+ * Create and connect a dedicated subscriber connection.
+ *
+ * redis@5 requires pub/sub to run on its own connection (a subscribed client
+ * cannot run normal commands), so we duplicate the shared client's config and
+ * connect the copy. Returns a promise resolving to a CONNECTED client.
+ *
+ * Callers own the returned client's lifetime and MUST tear it down when done:
+ *   await sub.unsubscribe(channel);
+ *   await sub.quit();
+ * (see lib/clientsocket.js and app/hivtrace/hivtrace.js for the leak-safe
+ * teardown enforced by #397/#400 and the live-PUBSUB regression tests.)
+ *
+ * @returns {Promise<import('redis').RedisClientType>} connected subscriber
+ */
+function createSubscriber() {
+  const subscriber = client.duplicate();
+  subscriber.on("error", function (err) {
+    logger.error("Redis subscriber error: " + err.message);
+  });
+  return subscriber.connect().then(function () {
+    return subscriber;
+  });
+}
+
+module.exports = {
+  client,
+  ready,
+  createSubscriber,
+  buildClientOptions,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
   "name": "datamonkey-js-server",
-  "version": "3.3.4",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datamonkey-js-server",
-      "version": "3.3.4",
+      "version": "3.4.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "commander": "^6.0.0",
+        "date-fns": "^4.4.0",
         "express": "^5.2.1",
         "moment": "2.x.x",
         "moment-timezone": "0.5.37",
         "q": "^1.2.1",
-        "redis": "^3.1.2",
+        "redis": "^5.12.1",
         "should": "^13.2.3",
         "socket.io": "4.6.2",
         "tail": "0.4.x",
@@ -28,11 +29,12 @@
         "chai": "^4.3.7",
         "eslint": "^7.32.0",
         "mocha": "^11.7.1",
+        "prettier": "^3.9.5",
         "socket.io-client": "^4.5.4",
         "socket.io-stream": "^0.9.1"
       },
       "engines": {
-        "node": ">=13"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -309,6 +311,78 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -885,6 +959,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "license": "MIT",
@@ -1092,6 +1175,16 @@
         "whatwg-url": "^6.4.0"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.2",
       "license": "MIT",
@@ -1147,13 +1240,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "1.5.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -3505,13 +3591,19 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.11.1",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-data": {
@@ -3644,49 +3736,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
       "dependencies": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-redis"
-      }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-      "license": "MIT"
-    },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/regexpp": {
@@ -4660,6 +4722,18 @@
       },
       "bin": {
         "translate-gard": "cli.js"
+      }
+    },
+    "node_modules/translate-gard/node_modules/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/translate-gard/node_modules/should": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^6.0.0",
+    "date-fns": "^4.4.0",
     "express": "^5.2.1",
     "moment": "2.x.x",
     "moment-timezone": "0.5.37",
     "q": "^1.2.1",
-    "redis": "^3.1.2",
+    "redis": "^5.12.1",
     "should": "^13.2.3",
     "socket.io": "4.6.2",
     "tail": "0.4.x",


### PR DESCRIPTION
Foundation step of the v4 modernization epic (#410). Establishes the shared redis@5 client factory that every sibling migration PR will require, plus the locked dependency targets.

## Dependency changes
- `redis` 3.1.2 -> **5.12.1** (node-redis v5, promise-native)
- add `date-fns` **4.4.0** (moment replacement; moment migrates in a sibling PR)
- `moment`, `q`, `underscore` intentionally kept in `dependencies` for now — their files migrate in sibling PRs.

## New: `lib/redis-client.js`
A small module that centralizes redis v5 connection setup so every caller shares one consistent, connected client.

- Builds options from `config.json` (`redis_host` / `redis_port` / optional `redis_password`) using the v5 `{ socket: { host, port }, password }` shape.
- Creates the client at module scope and calls `connect()` on load (mirroring the historical module-scope `createClient`), exporting a `ready` promise for callers that must be sure the socket is up.
- Attaches an `"error"` handler so transient redis errors log via `lib/logger` instead of crashing the process.
- `createSubscriber()` duplicates the shared client and connects it, encapsulating the v5 rule that a subscriber **must** be a separate connection. Comments document the listener-passed-to-`subscribe()` pattern and the leak-safe `unsubscribe()` + `quit()` teardown enforced by #397/#400.

## Pattern sibling PRs must follow
```js
const { client } = require("../lib/redis-client");
const obj = await client.hGetAll(job_id);   // commands are camelCased

// pub/sub — subscriber MUST be a separate connection:
const { createSubscriber } = require("../lib/redis-client");
const sub = await createSubscriber();
await sub.subscribe(channel, (message, channel) => { /* message is 1st arg; no .on('message') */ });
// teardown (preserve for #397/#400):
await sub.unsubscribe(channel);
await sub.quit();
```
Command renames: `hset`->`hSet`, `hgetall`->`hGetAll`, `hget`->`hGet`, `lrem`->`lRem`, `rpush`->`rPush`, `llen`->`lLen`, `del`->`del`.

## Verification
- `node -c lib/redis-client.js` clean.
- Live functional probe against redis: `connect()`, camelCased commands (`hSet`/`hGetAll`/`rPush`/`lLen`/`lRem`/`del`), and the `createSubscriber()` duplicate + pub/sub round-trip (message delivered as first arg, channel second) all pass.

## Scope note
This PR only lands the deps bump + the factory module. No app/lib callers are migrated here — `lib/clientsocket.js`, `app/job.js`, `app/hivtrace/hivtrace.js`, `lib/jobqueue.js`, `server.js`, etc. still use the v3 API and are migrated (with their tests brought green) in the sibling Phase 1 PRs that build on this foundation.

Part of #410.