### PR TITLE
test(v4): migrate test suites to redis v5 API [#410]

### DIFF
--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -1,0 +1,136 @@
+/**
+ * Shared redis v5 (node-redis) client factory.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Historically every module did its own `var client = redis.createClient(...)`
+ * at module scope (server.js, app/job.js, lib/jobqueue.js, app/hivtrace/*, ...).
+ * redis@5 is promise-native and requires an explicit `await client.connect()`
+ * after `createClient`, so the old pattern no longer works verbatim. This module
+ * centralizes connection setup so every caller shares one consistent, connected
+ * client and one consistent config shape.
+ *
+ * HOW TO USE IT (the pattern every sibling PR must follow)
+ * --------------------------------------------------------
+ *   const { client } = require("../lib/redis-client");
+ *   // ...later, inside an async function or a .then():
+ *   const obj = await client.hGetAll(job_id);   // commands are camelCased
+ *   await client.hSet(job_id, "status", "done");
+ *   await client.rPush("active_jobs", job_id);
+ *
+ * The exported `client` begins connecting the moment this module is first
+ * required (mirroring the old module-scope `createClient` behaviour). Because
+ * redis@5 buffers commands issued before the socket is ready, callers may issue
+ * commands immediately; they resolve once the connection is established. If you
+ * need to be certain the socket is up, `await client.connect()` is idempotent-ish
+ * only when NOT already connecting — prefer `await ready` (also exported) which
+ * resolves when the initial connect() settles.
+ *
+ * v5 API NOTES (vs the old v3 API this replaces)
+ * ----------------------------------------------
+ *   - createClient({ url } | { socket: { host, port }, password }) — no callbacks.
+ *   - Commands are camelCased: hgetall->hGetAll, hset->hSet, hget->hGet,
+ *     lrem->lRem, rpush->rPush, llen->lLen, del->del.
+ *   - Commands return promises; there is no (err, reply) callback form.
+ *
+ * PUB/SUB — SUBSCRIBER DUPLICATE PATTERN (read carefully)
+ * -------------------------------------------------------
+ * In redis@5 a connection that is in subscriber mode CANNOT issue normal
+ * commands, so a subscriber MUST be a SEPARATE connection. Use the exported
+ * `createSubscriber()` helper, which does `client.duplicate()` + `connect()`.
+ *
+ * There is NO more `.on("message", ...)`. The listener is passed directly to
+ * `.subscribe()`, and the message is the FIRST argument:
+ *
+ *   const sub = await createSubscriber();
+ *   await sub.subscribe(channel, (message, channel) => {
+ *     const packet = JSON.parse(message);
+ *     // ...
+ *   });
+ *
+ * Teardown (preserve this exactly — see leak fixes #397/#400):
+ *
+ *   await sub.unsubscribe(channel);
+ *   await sub.quit();              // graceful; falls back to sub.destroy() on error
+ *
+ * `createSubscriber()` returns a promise resolving to a CONNECTED duplicate
+ * client. It attaches an "error" handler so a broken subscriber socket logs
+ * instead of crashing the process.
+ */
+
+const redis = require("redis"),
+  logger = require("./logger").logger,
+  config = require("../config.json");
+
+/**
+ * Build the redis@5 client options from config.json.
+ * config.redis_host, config.redis_port, and optional config.redis_password.
+ */
+function buildClientOptions() {
+  const options = {
+    socket: {
+      host: config.redis_host,
+      port: config.redis_port,
+    },
+  };
+  if (config.redis_password) {
+    options.password = config.redis_password;
+  }
+  return options;
+}
+
+// Create the shared client at module scope, mirroring the historical
+// `var client = redis.createClient(...)` behaviour. In redis@5 this does NOT
+// open the socket by itself — connect() below does that.
+const client = redis.createClient(buildClientOptions());
+
+// Always attach an error handler so a transient redis error logs instead of
+// throwing an unhandled 'error' event and crashing the process.
+client.on("error", function (err) {
+  logger.error("Redis client error: " + err.message);
+});
+
+// Kick off the connection immediately on load. redis@5 queues commands issued
+// before the socket is ready and flushes them once connected, so callers can
+// require this module and issue commands without awaiting `ready` first.
+// We expose `ready` for callers that want to be sure the socket is up.
+const ready = client
+  .connect()
+  .then(function () {
+    logger.info("Redis shared client connected");
+  })
+  .catch(function (err) {
+    logger.error("Redis shared client failed to connect: " + err.message);
+  });
+
+/**
+ * Create and connect a dedicated subscriber connection.
+ *
+ * redis@5 requires pub/sub to run on its own connection (a subscribed client
+ * cannot run normal commands), so we duplicate the shared client's config and
+ * connect the copy. Returns a promise resolving to a CONNECTED client.
+ *
+ * Callers own the returned client's lifetime and MUST tear it down when done:
+ *   await sub.unsubscribe(channel);
+ *   await sub.quit();
+ * (see lib/clientsocket.js and app/hivtrace/hivtrace.js for the leak-safe
+ * teardown enforced by #397/#400 and the live-PUBSUB regression tests.)
+ *
+ * @returns {Promise<import('redis').RedisClientType>} connected subscriber
+ */
+function createSubscriber() {
+  const subscriber = client.duplicate();
+  subscriber.on("error", function (err) {
+    logger.error("Redis subscriber error: " + err.message);
+  });
+  return subscriber.connect().then(function () {
+    return subscriber;
+  });
+}
+
+module.exports = {
+  client,
+  ready,
+  createSubscriber,
+  buildClientOptions,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
   "name": "datamonkey-js-server",
-  "version": "3.3.4",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datamonkey-js-server",
-      "version": "3.3.4",
+      "version": "3.4.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "commander": "^6.0.0",
+        "date-fns": "^4.4.0",
         "express": "^5.2.1",
         "moment": "2.x.x",
         "moment-timezone": "0.5.37",
         "q": "^1.2.1",
-        "redis": "^3.1.2",
+        "redis": "^5.12.1",
         "should": "^13.2.3",
         "socket.io": "4.6.2",
         "tail": "0.4.x",
@@ -28,11 +29,12 @@
         "chai": "^4.3.7",
         "eslint": "^7.32.0",
         "mocha": "^11.7.1",
+        "prettier": "^3.9.5",
         "socket.io-client": "^4.5.4",
         "socket.io-stream": "^0.9.1"
       },
       "engines": {
-        "node": ">=13"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -309,6 +311,78 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -885,6 +959,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "license": "MIT",
@@ -1092,6 +1175,16 @@
         "whatwg-url": "^6.4.0"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.2",
       "license": "MIT",
@@ -1147,13 +1240,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "1.5.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -3505,13 +3591,19 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.11.1",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-data": {
@@ -3644,49 +3736,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
       "dependencies": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-redis"
-      }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-      "license": "MIT"
-    },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/regexpp": {
@@ -4660,6 +4722,18 @@
       },
       "bin": {
         "translate-gard": "cli.js"
+      }
+    },
+    "node_modules/translate-gard/node_modules/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/translate-gard/node_modules/should": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^6.0.0",
+    "date-fns": "^4.4.0",
     "express": "^5.2.1",
     "moment": "2.x.x",
     "moment-timezone": "0.5.37",
     "q": "^1.2.1",
-    "redis": "^3.1.2",
+    "redis": "^5.12.1",
     "should": "^13.2.3",
     "socket.io": "4.6.2",
     "tail": "0.4.x",

--- a/test/busted/busted.js
+++ b/test/busted/busted.js
@@ -4,7 +4,7 @@ var fs        = require('fs'),
     path      = require('path'),
     clientio  = require('socket.io-client'),
     io        = require('socket.io')(5101),
-    redis     = require('redis'),
+    redisClient = require(__dirname + '/../../lib/redis-client.js'),
     busted    = require(__dirname + '/../../app/busted/busted.js'),
     job       = require(__dirname + '/../../app/job.js'),
     ss        = require('socket.io-stream'),
@@ -22,9 +22,10 @@ var options = {
   transports: ['websocket']
 };
 
-var client = redis.createClient({
-  host: config.redis_host, port: config.redis_port
-});
+// redis@5 migration: reuse the shared connected client from lib/redis-client.js
+// instead of `redis.createClient({host,port})`. Commands are camelCased and
+// promise-returning (del stays `del`).
+var client = redisClient.client;
 
 // Track SLURM job ids that get created so we can scancel them in teardown and
 // never leave a busted job occupying the datamonkey partition for 72h.
@@ -36,7 +37,10 @@ describe('busted jobrunner', function() {
   var fn = path.join(__dirname, '/res/', id);
   var params_file = path.join(__dirname, '/res/params.json');
 
-  client.del(id);
+  // redis@5: del() is promise-returning; swallow errors for this best-effort
+  // pre-test cleanup (issued before the shared client's socket is guaranteed up,
+  // but v5 buffers commands until connected).
+  redisClient.ready.then(function () { return client.del(id); }).catch(function () {});
 
   io.sockets.on('connection', function (socket) {
     // The production request path routes spawn(stream, params) to the analysis

--- a/test/coverage-gaps/job-lifecycle.js
+++ b/test/coverage-gaps/job-lifecycle.js
@@ -21,17 +21,32 @@
  */
 
 var should  = require('should'),
-    redis   = require('redis'),
     child   = require('child_process'),
     fs      = require('fs'),
     path    = require('path'),
     EventEmitter = require('events').EventEmitter,
-    config  = require(__dirname + '/../../config.json'),
+    redisClient = require(__dirname + '/../../lib/redis-client.js'),
     job     = require(__dirname + '/../../app/job.js'),
     jobdel  = require(__dirname + '/../../lib/jobdel.js'),
     utilities = require(__dirname + '/../../lib/utilities.js');
 
-var client = redis.createClient({ host: config.redis_host, port: config.redis_port });
+// redis@5 migration: the shared connected client from lib/redis-client.js
+// replaces the module-scope `redis.createClient({host,port})`. Commands are
+// camelCased and promise-returning (hset->hSet, del->del). The seed helpers
+// below preserve their callback signatures so the specs are unchanged.
+var client = redisClient.client;
+
+// Seed a single hash field, invoking cb once the write resolves. Wraps the
+// promise-based v5 hSet so the existing nested-callback test bodies keep working
+// without weakening any assertion. `client.hSet(key, field, value)`.
+function seedHash(key, field, value, cb) {
+  redisClient.ready
+    .then(function () {
+      return client.hSet(key, field, value);
+    })
+    .then(function () { cb(); })
+    .catch(function (err) { cb(err); });
+}
 
 // A stand-in socket that records emits and disconnects.
 function recSocket(id) {
@@ -55,14 +70,14 @@ describe('coverage-gaps: job lifecycle & utilities', function () {
   describe('job.resubscribe() (app/job.js)', function () {
     this.timeout(6000);
     var ids = [];
-    afterEach(function () { ids.forEach(function (id) { client.del(id); }); ids = []; });
+    afterEach(function () { ids.forEach(function (id) { client.del(id).catch(function () {}); }); ids = []; });
 
     it('emits completed with parsed results when the job is completed', function (done) {
       var id = 'cov-resub-done-' + process.pid;
       ids.push(id);
       var results = { foo: 'bar', n: 3 };
-      client.hset(id, 'status', 'completed', function () {
-        client.hset(id, 'results', JSON.stringify(results), function () {
+      seedHash(id, 'status', 'completed', function () {
+        seedHash(id, 'results', JSON.stringify(results), function () {
           var sock = recSocket();
           new job.resubscribe(sock, id);
           setTimeout(function () {
@@ -79,17 +94,17 @@ describe('coverage-gaps: job lifecycle & utilities', function () {
     it('re-attaches a ClientSocket (subscribes) when the job is still pending', function (done) {
       var id = 'cov-resub-pending-' + process.pid;
       ids.push(id);
-      client.hset(id, 'status', 'queued', function () {
+      seedHash(id, 'status', 'queued', function () {
         var sock = recSocket();
         new job.resubscribe(sock, id);
         setTimeout(function () {
-          // pending path opens a subscriber on the job channel
-          var c = redis.createClient({ host: config.redis_host, port: config.redis_port });
-          c.send_command('pubsub', ['numsub', id], function (err, res) {
-            c.quit();
+          // pending path opens a subscriber on the job channel. redis@5: PUBSUB
+          // NUMSUB via sendCommand on the shared connected client (no
+          // send_command / callback form).
+          client.sendCommand(['PUBSUB', 'NUMSUB', id]).then(function (res) {
             parseInt(res[1], 10).should.be.aboveOrEqual(1);
             done();
-          });
+          }).catch(done);
         }, 300);
       });
     });
@@ -100,8 +115,8 @@ describe('coverage-gaps: job lifecycle & utilities', function () {
       // status === "exiting" (not completed, and the pending guard is false).
       var id = 'cov-resub-exit-' + process.pid;
       ids.push(id);
-      client.hset(id, 'status', 'exiting', function () {
-        client.hset(id, 'error', 'boom', function () {
+      seedHash(id, 'status', 'exiting', function () {
+        seedHash(id, 'error', 'boom', function () {
           var sock = recSocket();
           new job.resubscribe(sock, id);
           setTimeout(function () {
@@ -131,7 +146,7 @@ describe('coverage-gaps: job lifecycle & utilities', function () {
     beforeEach(function () { origJobDelete = jobdel.jobDelete; });
     afterEach(function () {
       jobdel.jobDelete = origJobDelete;
-      ids.forEach(function (id) { client.del(id); }); ids = [];
+      ids.forEach(function (id) { client.del(id).catch(function () {}); }); ids = [];
     });
 
     it('calls jobDelete and emits cancelled ok for a pending job', function (done) {
@@ -139,8 +154,8 @@ describe('coverage-gaps: job lifecycle & utilities', function () {
       ids.push(id);
       var deleted = null;
       jobdel.jobDelete = function (tid, cb) { deleted = tid; cb(); };
-      client.hset(id, 'status', 'queued', function () {
-        client.hset(id, 'torque_id', JSON.stringify({ torque_id: '999999' }), function () {
+      seedHash(id, 'status', 'queued', function () {
+        seedHash(id, 'torque_id', JSON.stringify({ torque_id: '999999' }), function () {
           var sock = recSocket();
           new job.cancel(sock, id);
           setTimeout(function () {
@@ -157,8 +172,8 @@ describe('coverage-gaps: job lifecycle & utilities', function () {
       ids.push(id);
       var called = false;
       jobdel.jobDelete = function () { called = true; };
-      client.hset(id, 'status', 'completed', function () {
-        client.hset(id, 'torque_id', JSON.stringify({ torque_id: '1' }), function () {
+      seedHash(id, 'status', 'completed', function () {
+        seedHash(id, 'torque_id', JSON.stringify({ torque_id: '1' }), function () {
           var sock = recSocket();
           new job.cancel(sock, id);
           setTimeout(function () {
@@ -173,8 +188,8 @@ describe('coverage-gaps: job lifecycle & utilities', function () {
     it('emits cancelled failure when torque_id is malformed (JSON.parse catch)', function (done) {
       var id = 'cov-cancel-badtid-' + process.pid;
       ids.push(id);
-      client.hset(id, 'status', 'queued', function () {
-        client.hset(id, 'torque_id', 'not-json', function () {
+      seedHash(id, 'status', 'queued', function () {
+        seedHash(id, 'torque_id', 'not-json', function () {
           var sock = recSocket();
           new job.cancel(sock, id);
           setTimeout(function () {

--- a/test/jobqueue.js
+++ b/test/jobqueue.js
@@ -2,14 +2,25 @@ var fs = require('fs'),
     spawn = require('child_process').spawn,
     should = require('should'),
     path = require('path'),
-    redis = require('redis'),
-    _ = require('underscore'),
+    redisClient = require('../lib/redis-client.js'),
     config = require('../config.json');
 
-var client = redis.createClient({
-  host: config.redis_host, port: config.redis_port
-});
+// redis@5 migration: reuse the shared connected client from lib/redis-client.js
+// (was `redis.createClient({host,port})`); commands are camelCased and
+// promise-returning (hset->hSet). underscore migration: `_.after(n, fn)` and
+// `_.delay(fn, ms)` replaced with native equivalents below.
+var client = redisClient.client;
 var JobQueue = require(path.join(__dirname, '/../lib/jobqueue.js')).JobQueue;
+
+// Native replacement for underscore's `_.after(count, fn)`: returns a function
+// that invokes `fn` only on the `count`-th (and subsequent) call.
+function after(count, fn) {
+  return function () {
+    if (--count < 1) {
+      return fn.apply(this, arguments);
+    }
+  };
+}
 
 describe('job queue', function() {
 
@@ -19,8 +30,9 @@ describe('job queue', function() {
 
   before(function(done) {
 
-    var after_five = _.after(5, function() {
-      _.delay(done, 1000);
+    var after_five = after(5, function() {
+      // _.delay(done, 1000) -> native setTimeout
+      setTimeout(done, 1000);
     });
 
     for (var i=0; i< 5; i++) {
@@ -31,7 +43,9 @@ describe('job queue', function() {
         if (match) {
           var slurm_id = match[1];
           submitted_ids.push(slurm_id);
-          client.hset(slurm_id, 'type', 'test');
+          // redis@5: hset->hSet, promise-returning; swallow errors for this
+          // best-effort seed (v5 buffers until the shared socket connects).
+          client.hSet(slurm_id, 'type', 'test').catch(function () {});
         }
         after_five();
       });

--- a/test/mock/lifecycle.js
+++ b/test/mock/lifecycle.js
@@ -34,8 +34,7 @@
 var should  = require('should'),
     fs      = require('fs'),
     path    = require('path'),
-    redis   = require('redis'),
-    config  = require(__dirname + '/../../config.json'),
+    redisClient = require(__dirname + '/../../lib/redis-client.js'),
     harness = require(__dirname + '/../helpers/socketharness.js'),
     busted  = require(__dirname + '/../../app/busted/busted.js'),
     job     = require(__dirname + '/../../app/job.js'),
@@ -48,24 +47,40 @@ var PORT = 5341;
 var MOCK_TORQUE_ID = 'mock123';
 
 // ---- live-redis helpers (mirror test/regression/leaks.js) -----------------
+//
+// redis@5 migration: use the shared connected client from lib/redis-client.js
+// instead of a throwaway `redis.createClient({host,port})` per call. Commands
+// are camelCased and promise-returning: `send_command('pubsub',...)` ->
+// `sendCommand(['PUBSUB','NUMSUB', channel])`; `lrange` -> `lRange`. The
+// callback signatures of these helpers are preserved so the specs are unchanged.
 
 // Count Redis clients currently subscribed to a pub/sub channel.
 function subscriberCount(channel, cb) {
-  var c = redis.createClient({ host: config.redis_host, port: config.redis_port });
-  c.send_command('pubsub', ['numsub', channel], function (err, res) {
-    c.quit();
-    // res = [channel, "<count>"]
-    cb(err ? 0 : parseInt(res[1], 10));
-  });
+  redisClient.ready
+    .then(function () {
+      return redisClient.client.sendCommand(['PUBSUB', 'NUMSUB', channel]);
+    })
+    .then(function (res) {
+      // res = [channel, "<count>"]
+      cb(parseInt(res[1], 10));
+    })
+    .catch(function () {
+      cb(0);
+    });
 }
 
 // Is `id` currently present in the active_jobs list?
 function activeJobsHas(id, cb) {
-  var c = redis.createClient({ host: config.redis_host, port: config.redis_port });
-  c.lrange('active_jobs', 0, -1, function (err, list) {
-    c.quit();
-    cb(!err && list && list.indexOf(id) !== -1);
-  });
+  redisClient.ready
+    .then(function () {
+      return redisClient.client.lRange('active_jobs', 0, -1);
+    })
+    .then(function (list) {
+      cb(!!list && list.indexOf(id) !== -1);
+    })
+    .catch(function () {
+      cb(false);
+    });
 }
 
 // Build a minimal-but-complete busted params object with a UNIQUE analysis id

--- a/test/regression/leaks.js
+++ b/test/regression/leaks.js
@@ -12,9 +12,8 @@
  */
 
 var should  = require('should'),
-    redis   = require('redis'),
     EventEmitter = require('events').EventEmitter,
-    config  = require(__dirname + '/../../config.json'),
+    redisClient = require(__dirname + '/../../lib/redis-client.js'),
     cs      = require(__dirname + '/../../lib/clientsocket.js'),
     jobRegistry = require(__dirname + '/../../lib/jobregistry.js');
 
@@ -26,13 +25,26 @@ function fakeSocket(id) {
 }
 
 // Count Redis clients currently in pub/sub subscribe mode for a channel.
+//
+// redis@5 migration: the old v3 helper opened a throwaway
+// `redis.createClient({host,port})` and used `send_command('pubsub',...)` with
+// a callback. In v5 there is no callback form and no `send_command`; PUBSUB is
+// issued via `client.sendCommand(['PUBSUB','NUMSUB', channel])` on a CONNECTED
+// client, which returns a promise resolving to `[channel, count]`. We reuse the
+// shared, already-connecting client from lib/redis-client.js rather than
+// spinning up (and leaking) a fresh connection per call.
 function subscriberCount(channel, cb) {
-  var c = redis.createClient({ host: config.redis_host, port: config.redis_port });
-  c.send_command('pubsub', ['numsub', channel], function (err, res) {
-    c.quit();
-    // res = [channel, "<count>"]
-    cb(err ? 0 : parseInt(res[1], 10));
-  });
+  redisClient.ready
+    .then(function () {
+      return redisClient.client.sendCommand(['PUBSUB', 'NUMSUB', channel]);
+    })
+    .then(function (res) {
+      // res = [channel, "<count>"] (count may be a string or number)
+      cb(parseInt(res[1], 10));
+    })
+    .catch(function () {
+      cb(0);
+    });
 }
 
 describe('regression: resource leaks', function () {
@@ -135,19 +147,31 @@ describe('regression: resource leaks', function () {
   describe('#403 hivtrace hset tolerates object params', function () {
     this.timeout(5000);
 
-    it('does not throw when params is an object (node-redis 3 rejects raw objects)', function () {
-      var client = redis.createClient({ host: config.redis_host, port: config.redis_port });
+    // redis@5 migration: `hset`->`hSet`, promise-returning (no callback), and
+    // the shared connected client from lib/redis-client.js replaces the
+    // per-test `createClient`. The #403 fix is that params is JSON.stringify'd
+    // before being written, so hSet receives a string (a raw object would
+    // reject). We assert the call resolves (does not reject).
+    it('does not reject when params is an object (must be stringified first)', function () {
       var params = { type: 'hivtrace', msa: [{ _id: 'x' }], analysis: { _id: 'y' } };
-      // Mirror the fixed hivtrace.spawn() call. Pre-fix this threw synchronously.
-      (function () {
-        client.hset(
-          'regr403-' + process.pid,
-          'params',
-          typeof params === 'string' ? params : JSON.stringify(params)
-        );
-      }).should.not.throw();
-      client.del('regr403-' + process.pid);
-      client.quit();
+      var key = 'regr403-' + process.pid;
+      // Mirror the fixed hivtrace.spawn() call. Pre-fix an object was passed raw.
+      return redisClient.ready
+        .then(function () {
+          return redisClient.client.hSet(
+            key,
+            'params',
+            typeof params === 'string' ? params : JSON.stringify(params)
+          );
+        })
+        .then(function () {
+          // Round-trip: the stored value must be the stringified object.
+          return redisClient.client.hGet(key, 'params');
+        })
+        .then(function (stored) {
+          stored.should.equal(JSON.stringify(params));
+          return redisClient.client.del(key);
+        });
     });
   });
 });


### PR DESCRIPTION
## Phase 1 (#410) — tests group

Migrates every **test** file that used the node-redis **v3** API to **redis@5**, consuming the shared factory from `lib/redis-client.js` (Foundation PR #416). **Test files only** — no production code touched, so no conflict with the sibling Phase 1 PRs.

Base is `feature/v4-modernization` (NOT master), branched off `v4/phase1-redis-foundation`.

### Files
- `test/regression/leaks.js`
- `test/mock/lifecycle.js`
- `test/coverage-gaps/job-lifecycle.js`
- `test/busted/busted.js`
- `test/jobqueue.js`

### What changed (assertions preserved — nothing weakened)
- **PUBSUB subscriber counts**: `send_command('pubsub', ['numsub', ch], cb)` → `client.sendCommand(['PUBSUB','NUMSUB', ch])` (promise) on the shared connected client. Still asserts the exact same NUMSUB values (0 before / 1 during / 0 after) and listener counts.
- **Hash writes/reads**: `hset(cb)` → `hSet` (promise), `hgetall`/`hget` → `hGetAll`/`hGet`, `lrange` → `lRange`, `del` unchanged (now promise). Callback-shaped seed helpers wrap the promises so the spec bodies are unchanged (`seedHash()`, and the preserved `subscriberCount(ch, cb)` / `activeJobsHas(id, cb)` signatures).
- **#403** now also round-trips `hGet` to assert the object was stored **stringified** (the actual fix).
- **Per-test throwaway `redis.createClient({host,port})`** removed everywhere in favor of the shared `lib/redis-client.js` client.
- **underscore removed** from `test/jobqueue.js`: `_.after(n, fn)` → a small local `after()`; `_.delay(fn, ms)` → `setTimeout`.

### Verification
- `node -c` clean on all 5 files.
- Redis-direct / jobregistry-only specs are **green**: `leaks.js` **#400** (one process listener, idempotent broadcast-cancel) and **#403** (hSet stores stringified object), plus `coverage-gaps` `cleanTreeToNewick` utilities.
- `squeue -u sweaver` empty — no stray SLURM jobs.

### Known-red until sibling PRs land (NOT this group's code)
The remaining `test:ci` / `test:mcp` failures are all `TypeError: client.hset is not a function` (and the leak-test `during===1` timeout) thrown from **still-v3 production code** that other Phase 1 groups own:
`lib/clientsocket.js`, `app/hyphyjob.js`, `app/job.js`, `app/busted/busted.js`, `lib/jobqueue.js`, `lib/jobstatus.js`, `lib/mcp/*`.
These go green once those sibling PRs merge into `feature/v4-modernization` (the documented model from Foundation PR #416: "Those green up in the sibling Phase 1 PRs that build on this factory"). This PR must NOT edit those files (would conflict with the parallel groups).

Refs #410.