### PR TITLE
v4 Phase 1: migrate difFubar/gard/hivtrace to redis v5 + native Promises/ES (#410)

### DIFF
--- a/app/difFubar/difFubar.js
+++ b/app/difFubar/difFubar.js
@@ -1,18 +1,14 @@
 var config = require("../../config.json"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
   logger = require("../../lib/logger.js").logger,
-  redis = require("redis"),
   util = require("util"),
   fs = require("fs"),
   path = require("path");
 
-// Module-level redis client, mirroring app/hyphyjob.js. Reused across
+// Shared redis v5 client (promise-native, camelCased commands). Reused across
 // onComplete calls instead of creating (and leaking) a client per job
 // (GH #400).
-var client = redis.createClient({
-  host: config.redis_host,
-  port: config.redis_port
-});
+var { client } = require("../../lib/redis-client");
 
 var difFubar = function(socket, stream, params) {
   var self = this;
@@ -277,10 +273,12 @@ difFubar.prototype.onComplete = function() {
           
           self.log("complete", "success (direct file transmission)");
           
-          // Reuse the module-level redis client (GH #400).
-          client.hset(self.id, "results", str_redis_packet, "status", "completed");
+          // Reuse the shared redis client (GH #400). redis v5 hSet takes a
+          // field/value object for multiple fields (the old variadic
+          // field,value,field,value form silently drops extra pairs).
+          client.hSet(self.id, { results: str_redis_packet, status: "completed" });
           client.publish(self.id, str_redis_packet);
-          client.lrem("active_jobs", 1, self.id);
+          client.lRem("active_jobs", 1, self.id);
           
           logger.info(`[DEBUG] difFUBAR ${self.id}: Sent results via direct socket + Redis completion`);
         });

--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -1,6 +1,5 @@
 const config = require("../../config.json"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
-  redis = require("redis"),
   util = require("util"),
   logger = require("../../lib/logger").logger,
   fs = require("fs"),
@@ -9,8 +8,8 @@ const config = require("../../config.json"),
   path = require("path"),
   utilities = require("../../lib/utilities");
 
-// Use redis as our key-value store
-const client = redis.createClient({ host: config.redis_host, port: config.redis_port });
+// Use the shared redis v5 client (promise-native, camelCased commands).
+const { client } = require("../../lib/redis-client");
 
 var gard = function(socket, stream, params) {
   var self = this;
@@ -347,12 +346,12 @@ gard.prototype.onComplete = function() {
           self.log("complete", "success");
 
           // Store packet in redis and publish to channel
-          client.hset(self.id, "results", str_redis_packet);
-          client.hset(self.id, "status", "completed");
+          client.hSet(self.id, "results", str_redis_packet);
+          client.hSet(self.id, "status", "completed");
           client.publish(self.id, str_redis_packet);
 
           // Remove id from active_job queue
-          client.lrem("active_jobs", 1, self.id);
+          client.lRem("active_jobs", 1, self.id);
         }    
       });
     }

--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -7,16 +7,32 @@ var spawn = require("child_process").spawn,
   hyphyJob = require("../hyphyjob.js").hyphyJob,
   Tail = require("tail").Tail,
   EventEmitter = require("events").EventEmitter,
-  Q = require("q"),
-  _ = require("underscore"),
   JobStatus = require("../../lib/jobstatus.js").JobStatus,
   logger = require("../../lib/logger").logger,
-  redis = require("redis"),
   utilities = require("../../lib/utilities"),
   jobRegistry = require("../../lib/jobregistry.js");
 
-// Use redis as our key-value store
-var client = redis.createClient({ host: config.redis_host, port: config.redis_port });
+// Use the shared redis v5 client (promise-native, camelCased commands) for
+// key-value + publish, and createSubscriber() for the dedicated pub/sub
+// connection (redis v5 requires a separate connection for subscriber mode).
+var { client, createSubscriber } = require("../../lib/redis-client");
+
+// Small replacement for underscore's _.once — returns a function that invokes
+// fn at most once and caches its result.
+function once(fn) {
+  var called = false,
+    result;
+  return function () {
+    if (!called) {
+      called = true;
+      result = fn.apply(this, arguments);
+    }
+    return result;
+  };
+}
+
+// Promisified fs.readFile (replaces Q.nfcall(fs.readFile, ...)).
+var readFileAsync = util.promisify(fs.readFile);
 
 var hivtrace = function(socket, stream, params) {
   var self = this;
@@ -88,11 +104,11 @@ var hivtrace = function(socket, stream, params) {
   self.hivtrace_log = self.filepath + hivtrace_log_suffix;
 
   var initial_statuses = [];
-  _.each(self.status_stack, function(d, i) {
+  (self.status_stack || []).forEach(function(d) {
     initial_statuses.push({ title: d, status: self.status_states.PENDING });
   });
 
-  client.hset(
+  client.hSet(
     self.id,
     "complete phase status",
     JSON.stringify(initial_statuses)
@@ -167,10 +183,10 @@ util.inherits(hivtrace, hyphyJob);
 
 hivtrace.prototype.spawn = function() {
   var self = this;
-  self.send_aligned_fasta_once = _.once(self.sendAlignedFasta);
-  self.send_tn93_once = _.once(self.sendtn93);
+  self.send_aligned_fasta_once = once(self.sendAlignedFasta.bind(self));
+  self.send_tn93_once = once(self.sendtn93.bind(self));
 
-  client.hset(
+  client.hSet(
     self.id,
     "params",
     typeof self.params === "string" ? self.params : JSON.stringify(self.params)
@@ -273,75 +289,78 @@ hivtrace.prototype.onStatusUpdate = function(data, index) {
 
   self.current_status = data;
 
-  // get current status stored in redis
-  client.hget(self.id, "complete phase status", function(err, entire_status) {
-    //msg = {
-    //  'type'   : 'status update',
-    //  'index'  : phase[0]
-    //  'phase'  : phase[1],
-    //  'status' : status,
-    //  'msg'    : msg
-    //}
+  // get current status stored in redis (redis v5 hGet returns a promise)
+  client
+    .hGet(self.id, "complete phase status")
+    .then(function(entire_status) {
+      //msg = {
+      //  'type'   : 'status update',
+      //  'index'  : phase[0]
+      //  'phase'  : phase[1],
+      //  'status' : status,
+      //  'msg'    : msg
+      //}
 
-    var new_status = JSON.parse(entire_status);
+      var new_status = JSON.parse(entire_status);
 
-    // validate new_status and index
-    if (_.isUndefined(new_status)) {
-      logger.warn("hivtrace malformed status update: " + entire_status);
-      return;
-    }
+      // validate new_status and index
+      if (new_status === undefined) {
+        logger.warn("hivtrace malformed status update: " + entire_status);
+        return;
+      }
 
-    if (_.isUndefined(new_status[data.index])) {
-      logger.warn("hivtrace malformed status update: " + entire_status);
-      return;
-    }
+      if (new_status[data.index] === undefined) {
+        logger.warn("hivtrace malformed status update: " + entire_status);
+        return;
+      }
 
-    new_status[data.index].status = data.status;
-    new_status[data.index].index = data.index;
+      new_status[data.index].status = data.status;
+      new_status[data.index].index = data.index;
 
-    // update all older statuses as completed
-    _.each(new_status.slice(0, data.index), function(d, i) {
-      new_status[i].status = self.status_states.COMPLETED;
+      // update all older statuses as completed
+      new_status.slice(0, data.index).forEach(function(d, i) {
+        new_status[i].status = self.status_states.COMPLETED;
+      });
+
+      new_status[data.index].msg = data.msg ? data.msg : "";
+
+      var status_update = {
+        msg: new_status,
+        torque_id: self.torque_id
+      };
+
+      // Prepare redis packet for delivery
+      client.hSet(self.id, "status update", JSON.stringify(data));
+
+      var redis_packet = status_update;
+      redis_packet.type = "status update";
+      var str_redis_packet = JSON.stringify(status_update);
+
+      // Store packet in redis and publish to channel
+      client.hSet(self.id, "complete phase status", JSON.stringify(new_status));
+
+      // Publish updates for all statuses
+      client.publish(self.id, str_redis_packet);
+
+      // Log status update on server
+      self.log("status update", str_redis_packet);
+    })
+    .catch(function(err) {
+      logger.warn("hivtrace failed to read status from redis: " + err.message);
     });
-
-    new_status[data.index].msg = data.msg ? data.msg : "";
-
-    var status_update = {
-      msg: new_status,
-      torque_id: self.torque_id
-    };
-
-    // Prepare redis packet for delivery
-    client.hset(self.id, "status update", JSON.stringify(data));
-
-    var redis_packet = status_update;
-    redis_packet.type = "status update";
-    var str_redis_packet = JSON.stringify(status_update);
-
-    // Store packet in redis and publish to channel
-    client.hset(self.id, "complete phase status", JSON.stringify(new_status));
-
-    // Publish updates for all statuses
-    client.publish(self.id, str_redis_packet);
-
-    // Log status update on server
-    self.log("status update", str_redis_packet);
-  });
 };
 
 hivtrace.prototype.onComplete = function() {
   var self = this;
-  client.hset(self.id, "status", "completed");
+  client.hSet(self.id, "status", "completed");
 
-  var results_promise = Q.nfcall(
-    fs.readFile,
-    self.output_cluster_output,
-    "utf-8"
-  );
+  var results_promise = readFileAsync(self.output_cluster_output, "utf-8");
   var promises = [results_promise];
 
-  Q.allSettled(promises).then(function(results) {
-    if (results[0].state == "fulfilled" && results[0].value) {
+  // Native Promise.allSettled result shape is {status, value/reason}
+  // (q's allSettled used {state, value/reason}).
+  Promise.allSettled(promises).then(function(results) {
+    if (results[0].status == "fulfilled" && results[0].value) {
       var results_data = JSON.parse(results[0].value);
       var redis_packet = { type: "completed" };
       var str_redis_packet = JSON.stringify(redis_packet);
@@ -350,11 +369,11 @@ hivtrace.prototype.onComplete = function() {
       self.log("complete", "success");
 
       // Store packet in redis and publish to channel
-      client.hset(self.id, "results", str_redis_packet);
+      client.hSet(self.id, "results", str_redis_packet);
       self.socket.emit("completed", { results: results_data });
 
       // Remove id from active_job queue
-      client.lrem("active_jobs", 1, self.id);
+      client.lRem("active_jobs", 1, self.id);
       jobRegistry.unregister(self.id);
     } else {
       self.onError(
@@ -369,30 +388,30 @@ hivtrace.prototype.onJobCreated = function(torque_id) {
   var self = this;
 
   self.push_active_job = function(id) {
-    client.rpush("active_jobs", self.id);
+    client.rPush("active_jobs", self.id);
   };
 
-  self.push_job_once = _.once(self.push_active_job);
+  self.push_job_once = once(self.push_active_job);
   self.setTorqueParameters(torque_id);
   var redis_packet = torque_id;
   redis_packet.type = "job created";
   var str_redis_packet = JSON.stringify(torque_id);
   self.log("job created", str_redis_packet);
-  client.hset(self.id, "torque_id", str_redis_packet);
+  client.hSet(self.id, "torque_id", str_redis_packet);
   client.publish(self.id, str_redis_packet);
-  client.hset(self.torque_id, "datamonkey_id", self.id);
-  client.hset(self.torque_id, "type", self.type);
+  client.hSet(self.torque_id, "datamonkey_id", self.id);
+  client.hSet(self.torque_id, "type", self.type);
   self.push_job_once(self.id);
 };
 
 hivtrace.prototype.sendAlignedFasta = function() {
   var self = this;
 
-  var aligned_promise = Q.nfcall(fs.readFile, self.aligned_fasta);
+  var aligned_promise = readFileAsync(self.aligned_fasta);
   var promises = [aligned_promise];
 
-  Q.allSettled(promises).then(function(results) {
-    if (results[0].state == "fulfilled" && results[0].value) {
+  Promise.allSettled(promises).then(function(results) {
+    if (results[0].status == "fulfilled" && results[0].value) {
       self.socket.emit("aligned fasta", { buffer: results[0].value });
 
       // Log that the job has been completed
@@ -405,11 +424,11 @@ hivtrace.prototype.sendAlignedFasta = function() {
 
 hivtrace.prototype.sendtn93 = function() {
   var self = this;
-  var tn93_promise = Q.nfcall(fs.readFile, self.tn93_results);
+  var tn93_promise = readFileAsync(self.tn93_results);
   var promises = [tn93_promise];
 
-  Q.allSettled(promises).then(function(results) {
-    if (results[0].state == "fulfilled" && results[0].value) {
+  Promise.allSettled(promises).then(function(results) {
+    if (results[0].status == "fulfilled" && results[0].value) {
       self.socket.emit("tn93", { buffer: results[0].value });
       // Log that the job has been completed
       self.warn("sending tn93", self.tn93_results, "success");
@@ -424,12 +443,48 @@ var HivTraceRunner = function(id, hivtrace_log) {
   var self = this;
   self.python_redis_channel = "python_" + id;
   self.hivtrace_log = hivtrace_log;
-  self.subscriber = redis.createClient({
-    host: config.redis_host, port: config.redis_port
-  });
-  self.subscriber.subscribe(self.python_redis_channel);
   self.last_status_update = "";
   self.submit_type = config.submit_type || "qsub";
+  self.subscriber = null;
+
+  // redis v5 pub/sub requires a dedicated (duplicated) connection, and both
+  // connect() and subscribe() are async. We kick off the connection here and
+  // wire the message listener once connected. The listener is passed directly
+  // to subscribe() (there is no more .on("message", ...)). We stash the promise
+  // so close() can await teardown after connect, avoiding a leaked subscriber
+  // if the job ends before the socket is up (see #397/#400).
+  self.subscriber_ready = createSubscriber()
+    .then(function(subscriber) {
+      self.subscriber = subscriber;
+
+      // If close() ran before the subscriber finished connecting, tear it down
+      // immediately instead of leaking it.
+      if (self._closed) {
+        try {
+          subscriber.quit();
+        } catch (e) {
+          try {
+            subscriber.destroy();
+          } catch (e2) {}
+        }
+        return;
+      }
+
+      return subscriber.subscribe(self.python_redis_channel, function(message) {
+        var redis_packet = JSON.parse(message);
+        logger.info(redis_packet);
+
+        if (message != self.last_status_update) {
+          self.emit(redis_packet.type, redis_packet);
+          self.last_status_update = message;
+        }
+      });
+    })
+    .catch(function(err) {
+      logger.error(
+        "Error setting up HivTrace Redis subscriber: " + err.message
+      );
+    });
 };
 
 util.inherits(HivTraceRunner, EventEmitter);
@@ -459,18 +514,36 @@ HivTraceRunner.prototype.close = function() {
   logger.info(
     "[REDIS] Closing subscriber for channel " + self.python_redis_channel
   );
-  try {
-    self.subscriber.removeAllListeners("message");
-    self.subscriber.unsubscribe(self.python_redis_channel);
-    self.subscriber.quit();
-  } catch (err) {
-    logger.error("Error closing HivTrace Redis subscriber: " + err.message);
-    try {
-      self.subscriber.end(true);
-    } catch (e) {
-      logger.error("Error force-ending HivTrace Redis subscriber: " + e.message);
-    }
-  }
+
+  // The subscriber connects asynchronously (redis v5 duplicate + connect).
+  // Wait for that to settle so we never leak a subscriber that finished
+  // connecting after close() ran, then unsubscribe + quit. The _closed flag
+  // set above also makes the connect() handler self-quit if it wins the race.
+  var teardown = self.subscriber_ready
+    ? Promise.resolve(self.subscriber_ready)
+    : Promise.resolve();
+
+  teardown.then(function() {
+    if (!self.subscriber) return;
+    // In redis v5 the listener was passed to subscribe(); unsubscribe drops it.
+    return self.subscriber
+      .unsubscribe(self.python_redis_channel)
+      .then(function() {
+        return self.subscriber.quit();
+      })
+      .catch(function(err) {
+        logger.error(
+          "Error closing HivTrace Redis subscriber: " + err.message
+        );
+        try {
+          self.subscriber.destroy();
+        } catch (e) {
+          logger.error(
+            "Error force-ending HivTrace Redis subscriber: " + e.message
+          );
+        }
+      });
+  });
 };
 
 HivTraceRunner.prototype.log_publisher = function() {
@@ -523,15 +596,9 @@ HivTraceRunner.prototype.status_watcher = function() {
     }
   });
 
-  self.subscriber.on("message", function(channel, message) {
-    var redis_packet = JSON.parse(message);
-    logger.info(redis_packet);
-
-    if (message != self.last_status_update) {
-      self.emit(redis_packet.type, redis_packet);
-      self.last_status_update = message;
-    }
-  });
+  // The python_<id> subscriber message listener is wired at subscribe() time
+  // in the constructor (redis v5 passes the listener to subscribe()); there is
+  // no more .on("message", ...) here.
 };
 
 /**

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -1,0 +1,136 @@
+/**
+ * Shared redis v5 (node-redis) client factory.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Historically every module did its own `var client = redis.createClient(...)`
+ * at module scope (server.js, app/job.js, lib/jobqueue.js, app/hivtrace/*, ...).
+ * redis@5 is promise-native and requires an explicit `await client.connect()`
+ * after `createClient`, so the old pattern no longer works verbatim. This module
+ * centralizes connection setup so every caller shares one consistent, connected
+ * client and one consistent config shape.
+ *
+ * HOW TO USE IT (the pattern every sibling PR must follow)
+ * --------------------------------------------------------
+ *   const { client } = require("../lib/redis-client");
+ *   // ...later, inside an async function or a .then():
+ *   const obj = await client.hGetAll(job_id);   // commands are camelCased
+ *   await client.hSet(job_id, "status", "done");
+ *   await client.rPush("active_jobs", job_id);
+ *
+ * The exported `client` begins connecting the moment this module is first
+ * required (mirroring the old module-scope `createClient` behaviour). Because
+ * redis@5 buffers commands issued before the socket is ready, callers may issue
+ * commands immediately; they resolve once the connection is established. If you
+ * need to be certain the socket is up, `await client.connect()` is idempotent-ish
+ * only when NOT already connecting — prefer `await ready` (also exported) which
+ * resolves when the initial connect() settles.
+ *
+ * v5 API NOTES (vs the old v3 API this replaces)
+ * ----------------------------------------------
+ *   - createClient({ url } | { socket: { host, port }, password }) — no callbacks.
+ *   - Commands are camelCased: hgetall->hGetAll, hset->hSet, hget->hGet,
+ *     lrem->lRem, rpush->rPush, llen->lLen, del->del.
+ *   - Commands return promises; there is no (err, reply) callback form.
+ *
+ * PUB/SUB — SUBSCRIBER DUPLICATE PATTERN (read carefully)
+ * -------------------------------------------------------
+ * In redis@5 a connection that is in subscriber mode CANNOT issue normal
+ * commands, so a subscriber MUST be a SEPARATE connection. Use the exported
+ * `createSubscriber()` helper, which does `client.duplicate()` + `connect()`.
+ *
+ * There is NO more `.on("message", ...)`. The listener is passed directly to
+ * `.subscribe()`, and the message is the FIRST argument:
+ *
+ *   const sub = await createSubscriber();
+ *   await sub.subscribe(channel, (message, channel) => {
+ *     const packet = JSON.parse(message);
+ *     // ...
+ *   });
+ *
+ * Teardown (preserve this exactly — see leak fixes #397/#400):
+ *
+ *   await sub.unsubscribe(channel);
+ *   await sub.quit();              // graceful; falls back to sub.destroy() on error
+ *
+ * `createSubscriber()` returns a promise resolving to a CONNECTED duplicate
+ * client. It attaches an "error" handler so a broken subscriber socket logs
+ * instead of crashing the process.
+ */
+
+const redis = require("redis"),
+  logger = require("./logger").logger,
+  config = require("../config.json");
+
+/**
+ * Build the redis@5 client options from config.json.
+ * config.redis_host, config.redis_port, and optional config.redis_password.
+ */
+function buildClientOptions() {
+  const options = {
+    socket: {
+      host: config.redis_host,
+      port: config.redis_port,
+    },
+  };
+  if (config.redis_password) {
+    options.password = config.redis_password;
+  }
+  return options;
+}
+
+// Create the shared client at module scope, mirroring the historical
+// `var client = redis.createClient(...)` behaviour. In redis@5 this does NOT
+// open the socket by itself — connect() below does that.
+const client = redis.createClient(buildClientOptions());
+
+// Always attach an error handler so a transient redis error logs instead of
+// throwing an unhandled 'error' event and crashing the process.
+client.on("error", function (err) {
+  logger.error("Redis client error: " + err.message);
+});
+
+// Kick off the connection immediately on load. redis@5 queues commands issued
+// before the socket is ready and flushes them once connected, so callers can
+// require this module and issue commands without awaiting `ready` first.
+// We expose `ready` for callers that want to be sure the socket is up.
+const ready = client
+  .connect()
+  .then(function () {
+    logger.info("Redis shared client connected");
+  })
+  .catch(function (err) {
+    logger.error("Redis shared client failed to connect: " + err.message);
+  });
+
+/**
+ * Create and connect a dedicated subscriber connection.
+ *
+ * redis@5 requires pub/sub to run on its own connection (a subscribed client
+ * cannot run normal commands), so we duplicate the shared client's config and
+ * connect the copy. Returns a promise resolving to a CONNECTED client.
+ *
+ * Callers own the returned client's lifetime and MUST tear it down when done:
+ *   await sub.unsubscribe(channel);
+ *   await sub.quit();
+ * (see lib/clientsocket.js and app/hivtrace/hivtrace.js for the leak-safe
+ * teardown enforced by #397/#400 and the live-PUBSUB regression tests.)
+ *
+ * @returns {Promise<import('redis').RedisClientType>} connected subscriber
+ */
+function createSubscriber() {
+  const subscriber = client.duplicate();
+  subscriber.on("error", function (err) {
+    logger.error("Redis subscriber error: " + err.message);
+  });
+  return subscriber.connect().then(function () {
+    return subscriber;
+  });
+}
+
+module.exports = {
+  client,
+  ready,
+  createSubscriber,
+  buildClientOptions,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
   "name": "datamonkey-js-server",
-  "version": "3.3.4",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datamonkey-js-server",
-      "version": "3.3.4",
+      "version": "3.4.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "commander": "^6.0.0",
+        "date-fns": "^4.4.0",
         "express": "^5.2.1",
         "moment": "2.x.x",
         "moment-timezone": "0.5.37",
         "q": "^1.2.1",
-        "redis": "^3.1.2",
+        "redis": "^5.12.1",
         "should": "^13.2.3",
         "socket.io": "4.6.2",
         "tail": "0.4.x",
@@ -28,11 +29,12 @@
         "chai": "^4.3.7",
         "eslint": "^7.32.0",
         "mocha": "^11.7.1",
+        "prettier": "^3.9.5",
         "socket.io-client": "^4.5.4",
         "socket.io-stream": "^0.9.1"
       },
       "engines": {
-        "node": ">=13"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -309,6 +311,78 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -885,6 +959,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "license": "MIT",
@@ -1092,6 +1175,16 @@
         "whatwg-url": "^6.4.0"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.2",
       "license": "MIT",
@@ -1147,13 +1240,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "1.5.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -3505,13 +3591,19 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.11.1",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-data": {
@@ -3644,49 +3736,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
       "dependencies": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-redis"
-      }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-      "license": "MIT"
-    },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/regexpp": {
@@ -4660,6 +4722,18 @@
       },
       "bin": {
         "translate-gard": "cli.js"
+      }
+    },
+    "node_modules/translate-gard/node_modules/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/translate-gard/node_modules/should": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^6.0.0",
+    "date-fns": "^4.4.0",
     "express": "^5.2.1",
     "moment": "2.x.x",
     "moment-timezone": "0.5.37",
     "q": "^1.2.1",
-    "redis": "^3.1.2",
+    "redis": "^5.12.1",
     "should": "^13.2.3",
     "socket.io": "4.6.2",
     "tail": "0.4.x",


### PR DESCRIPTION
Part of the v4 modernization epic #410 (Phase 1, **analyses** group). Targets `feature/v4-modernization`, branched off `v4/phase1-redis-foundation` so `lib/redis-client.js` is available.

## Scope (this group's files)
- `app/difFubar/difFubar.js` — redis
- `app/gard/gard.js` — redis
- `app/hivtrace/hivtrace.js` — redis **subscriber** + q + underscore

## redis v3 -> v5
- Use the shared `lib/redis-client.js` factory (`const { client } = require(...)`) instead of `redis.createClient`.
- camelCased commands: `hset`->`hSet`, `hget`->`hGet`, `lrem`->`lRem`, `rpush`->`rPush`; `publish` unchanged.
- `difFubar` variadic `hset(id,"results",r,"status","completed")` -> `hSet(id, { results, status })` (redis v5 silently drops extra field/value pairs in the variadic form — verified against live redis).
- `hivtrace` callback `client.hget(id, cb)` -> `client.hGet(id).then(...)`.

## hivtrace pub/sub (the hard part — #397/#400 hardened)
- `HivTraceRunner` python_<id> subscriber now uses `createSubscriber()` (duplicate + connect); the listener is passed directly to `subscribe(channel, (message) => ...)` (no more `.on("message")`). Removed the now-duplicate `.on("message")` block from `status_watcher`.
- `close()` teardown preserved and adapted to v5: `unsubscribe` + `quit` (fallback `destroy`), plus the existing `Tail.unwatch()` and `clearInterval(metronome_id)`. Added a `_closed` race guard so a subscriber that finishes connecting *after* `close()` immediately self-quits (no leaked subscriber).

## q -> native
- `Q.nfcall(fs.readFile, ...)` -> `util.promisify(fs.readFile)`.
- `Q.allSettled` -> `Promise.allSettled`; updated result reads `.state` -> `.status`.

## underscore -> native
- `_.once` -> local `once()` helper; `_.each` -> `forEach`; `_.isUndefined(x)` -> `x === undefined`.

## Verification
- `node -c` clean on all three files.
- Live redis pub/sub round-trip using the v5 `createSubscriber()` pattern: subscribe -> NUMSUB 1, message delivered as first arg, `unsubscribe`+`quit` -> NUMSUB 0 (leak-safe teardown confirmed).
- `test/difFubar.test.js`: **17 passing** (directly exercises migrated difFubar end-to-end incl. redis). `test/hivtrace/hivtrace.js` unit: green.
- No stray SLURM jobs (`squeue -u sweaver` empty before and after).

### Expected-red (cross-file, not this group)
`npm run test:ci` and the MCP tests still show reds, all tracing to **un-migrated sibling files** and v3-API test harnesses, not to these three files:
- `app/hyphyjob.js:75` `client.hset` — base class inherited by every analysis (`init()`); throws for gard/busted/meme/slac constructors.
- `lib/clientsocket.js` — still v3 `.on("message")`.
- `test/regression/leaks.js` / `test/mock/lifecycle.js` — the harnesses' own `subscriberCount` uses v3 `send_command`, and assert on v3 `hset`.

These go green once the sibling Phase 1 PRs (hyphyjob/clientsocket/core) land on `feature/v4-modernization`, exactly as noted in the Foundation PR #416.

Refs #410.