### PR TITLE
Phase 1 (lib-dates): redis v5 + date-fns migration (#410)

### DIFF
--- a/app/flea/spawn_flea.js
+++ b/app/flea/spawn_flea.js
@@ -4,9 +4,29 @@ var spawn = require("child_process").spawn,
   path = require("path"),
   config = require("../../config.json"),
   util = require("util"),
-  moment = require("moment"),
+  dateFns = require("date-fns"),
   logger = require("../../lib/logger").logger,
   EventEmitter = require("events").EventEmitter;
+
+/**
+ * Format a FLEA msa.visit_date as "YYYYMMDD", matching the old
+ * `moment(msa.visit_date).format("YYYYMMDD")`.
+ *
+ * moment parses a bare "YYYY-MM-DD" string as LOCAL midnight, whereas
+ * `new Date("YYYY-MM-DD")` parses it as UTC midnight (which can roll to the
+ * previous day in negative-offset zones). To preserve moment's local semantics
+ * we treat a date-only string as local midnight by appending "T00:00:00";
+ * Date objects and full datetime strings pass straight through to new Date().
+ */
+function formatVisitDate(visit_date) {
+  var d;
+  if (typeof visit_date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(visit_date)) {
+    d = new Date(visit_date + "T00:00:00");
+  } else {
+    d = new Date(visit_date);
+  }
+  return dateFns.format(d, "yyyyMMdd");
+}
 
 var FleaRunner = function() {};
 
@@ -137,9 +157,7 @@ FleaRunner.prototype.start = function(fn, socket, flea_params) {
           // Append to file
           // Format : PC64_V00_small.fastq V00 20080301
           if (files.indexOf(msa._id + ".fastq") != -1) {
-            var formatted_visit_date = moment(msa.visit_date).format(
-              "YYYYMMDD"
-            );
+            var formatted_visit_date = formatVisitDate(msa.visit_date);
             var string_to_write = util.format(
               "%s %s %s\n",
               self.filedir + "/" + msa._id + ".fastq",

--- a/lib/jobdel.js
+++ b/lib/jobdel.js
@@ -1,19 +1,7 @@
 var spawn = require("child_process").spawn,
-  redis = require("redis"),
+  client = require("./redis-client").client,
   logger = require("./logger").logger,
   config = require("../config.json");
-
-// Use redis as our key-value store
-var redisConfig = {
-  host: config.redis_host, 
-  port: config.redis_port
-};
-
-if (config.redis_password) {
-  redisConfig.password = config.redis_password;
-}
-
-var client = redis.createClient(redisConfig);
 
 // Validate that the torque_id contains only alphanumeric characters, dots, and underscores
 function validateTorqueId(torque_id) {
@@ -39,7 +27,13 @@ function qsubJobDelete(torque_id, cb) {
 
     if (code === 0) {
       logger.warn(torque_id + " : removed from queue");
-      client.hset(torque_id, "status", "cancelled");
+      client
+              .hSet(torque_id, "status", "cancelled")
+              .catch(function (err) {
+                logger.error(
+                  torque_id + " : redis hSet failed: " + err.message
+                );
+              });
       // allow time for torque to write to stdout
       setTimeout(cb, 1000, "", code);
     } else {
@@ -68,7 +62,13 @@ function slurmJobDelete(torque_id, cb) {
 
     if (code === 0) {
       logger.warn(torque_id + " : removed from queue");
-      client.hset(torque_id, "status", "cancelled");
+      client
+              .hSet(torque_id, "status", "cancelled")
+              .catch(function (err) {
+                logger.error(
+                  torque_id + " : redis hSet failed: " + err.message
+                );
+              });
       // allow time for slurm to write to stdout
       setTimeout(cb, 1000, "", code);
     } else {
@@ -96,13 +96,25 @@ function localJobDelete(torque_id, cb) {
           try {
             process.kill(pid, "SIGTERM");
             logger.info("Local job " + torque_id + " (PID: " + pid + ") terminated");
-            client.hset(torque_id, "status", "cancelled");
+            client
+              .hSet(torque_id, "status", "cancelled")
+              .catch(function (err) {
+                logger.error(
+                  torque_id + " : redis hSet failed: " + err.message
+                );
+              });
             setTimeout(cb, 100, "", 0);
           } catch (killError) {
             if (killError.code === "ESRCH") {
               // Process doesn't exist, consider it already terminated
               logger.info("Local job " + torque_id + " process already terminated");
-              client.hset(torque_id, "status", "cancelled");
+              client
+              .hSet(torque_id, "status", "cancelled")
+              .catch(function (err) {
+                logger.error(
+                  torque_id + " : redis hSet failed: " + err.message
+                );
+              });
               setTimeout(cb, 100, "", 0);
             } else {
               logger.error("Error killing local job " + torque_id + ": " + killError.message);

--- a/lib/jobqueue.js
+++ b/lib/jobqueue.js
@@ -1,13 +1,38 @@
 const exec = require("child_process").exec,
-  moment = require("moment-timezone"),
-  redis = require("redis"),
+  dateFns = require("date-fns"),
   spawn = require("child_process").spawn,
   logger = require("./logger").logger,
+  client = require("./redis-client").client,
   config = require("../config.json");
 
-var client = redis.createClient({
-  host: config.redis_host, port: config.redis_port
-});
+/**
+ * Parse a Torque qstat ctime/start_time string ("ddd MMM DD HH:mm:ss YYYY",
+ * e.g. "Wed Jul 16 14:23:45 2025") and return it as a GMT ISO-8601 string with
+ * no fractional seconds (e.g. "2025-07-16T18:23:45Z").
+ *
+ * This reproduces the previous moment-timezone chain exactly:
+ *   moment(str, "ddd MMM DD HH:mm:ss YYYY").tz("America/Los_Angeles").tz("GMT").format()
+ * The string is parsed in the machine's local time zone (moment's default when
+ * no zone token is present); `.tz(...)` only changes the *display* zone, so the
+ * final value is that same instant rendered in GMT. date-fns `parse` likewise
+ * yields a local-zone Date, and `toISOString()` renders it in UTC (== GMT);
+ * we strip the ".000" milliseconds to match moment's `.format()` output.
+ */
+function parseQstatTimeToGmt(str) {
+  const d = dateFns.parse(str, "EEE MMM dd HH:mm:ss yyyy", new Date());
+  return d.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Format a sacct Submit/Start timestamp the way the old code did with
+ * `moment(x).format()` (no format token): parse the ISO-ish string in the
+ * machine's local zone and render it in ISO-8601 with the local UTC offset and
+ * no fractional seconds (e.g. "2025-07-16T14:23:45-04:00"). date-fns
+ * `formatISO(new Date(x))` produces byte-for-byte the same output.
+ */
+function formatSacctTime(str) {
+  return dateFns.formatISO(new Date(str));
+}
 
 // Validate that the job_id contains only alphanumeric characters, dots, and underscores
 function validateJobId(job_id) {
@@ -53,28 +78,33 @@ function returnQsubJobInfo(job_id, callback) {
         job_state = job_data.split("job_state = ")[1].split("\n")[0];
   
         job_ctime = job_data.split("ctime = ")[1].split("\n")[0];
-        job_ctime = moment(job_ctime, "ddd MMM DD HH:mm:ss YYYY")
-          .tz("America/Los_Angeles")
-          .tz("GMT")
-          .format();
+        job_ctime = parseQstatTimeToGmt(job_ctime);
       } catch (e) { logger.info("no job_state or job_ctime available"); }
-  
+
       try {
         job_stime = job_data.split("start_time = ")[1].split("\n")[0];
-        job_stime = moment(job_stime, "ddd MMM DD HH:mm:ss YYYY")
-          .tz("America/Los_Angeles")
-          .tz("GMT")
-          .format();
+        job_stime = parseQstatTimeToGmt(job_stime);
       } catch (e) { }
-      
-      client.hgetall(job_id, function(err, obj) {
-        if (obj) {
+
+      client.hGetAll(job_id).then(function(obj) {
+        if (obj && Object.keys(obj).length) {
           type = obj.type;
           sites = obj.sites;
           sequences = obj.sequences;
         }
-  
+
         // Report the collected information.
+        callback({
+          id: job_id,
+          status: status[job_state],
+          creation_time: job_ctime,
+          start_time: job_stime,
+          type: type,
+          sites: sites,
+          sequences: sequences
+        });
+      }).catch(function(err) {
+        logger.warn("redis hGetAll failed for " + job_id + ": " + err.message);
         callback({
           id: job_id,
           status: status[job_state],
@@ -187,18 +217,18 @@ function returnSlurmJobInfo(job_id, callback) {
       }
       
       var job_state = job_fields[3];
-      var job_ctime = job_fields[1] ? moment(job_fields[1]).format() : null;
-      var job_stime = job_fields[2] ? moment(job_fields[2]).format() : null;
-      
-      client.hgetall(job_id, function(err, obj) {
+      var job_ctime = job_fields[1] ? formatSacctTime(job_fields[1]) : null;
+      var job_stime = job_fields[2] ? formatSacctTime(job_fields[2]) : null;
+
+      client.hGetAll(job_id).then(function(obj) {
         var type = null, sites = null, sequences = null;
-        
-        if (obj) {
+
+        if (obj && Object.keys(obj).length) {
           type = obj.type;
           sites = obj.sites;
           sequences = obj.sequences;
         }
-        
+
         callback({
           id: job_id,
           status: slurmStatus[job_state] || "Unknown",
@@ -207,6 +237,17 @@ function returnSlurmJobInfo(job_id, callback) {
           type: type,
           sites: sites,
           sequences: sequences
+        });
+      }).catch(function(err) {
+        logger.warn("redis hGetAll failed for " + job_id + ": " + err.message);
+        callback({
+          id: job_id,
+          status: slurmStatus[job_state] || "Unknown",
+          creation_time: job_ctime,
+          start_time: job_stime,
+          type: null,
+          sites: null,
+          sequences: null
         });
       });
     });

--- a/lib/jobstatus.js
+++ b/lib/jobstatus.js
@@ -1,8 +1,27 @@
 const spawn = require("child_process").spawn,
-  _ = require("underscore"),
-  moment = require("moment-timezone"),
+  dateFns = require("date-fns"),
   logger = require("./logger").logger,
   config = require("../config.json");
+
+/**
+ * Parse a Torque qstat ctime/start_time string ("ddd MMM DD HH:mm:ss YYYY")
+ * and render it as a GMT ISO-8601 string with no fractional seconds. Reproduces
+ * the old moment chain:
+ *   moment(str, "ddd MMM DD HH:mm:ss YYYY").tz("America/Los_Angeles").tz("GMT").format()
+ * (see lib/jobqueue.js parseQstatTimeToGmt for the full rationale).
+ */
+function parseQstatTimeToGmt(str) {
+  const d = dateFns.parse(str, "EEE MMM dd HH:mm:ss yyyy", new Date());
+  return d.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Format a sacct Submit/Start timestamp the way `moment(x).format()` did:
+ * parse in the machine local zone, render ISO-8601 with local offset, no ms.
+ */
+function formatSacctTime(str) {
+  return dateFns.formatISO(new Date(str));
+}
 
 // Validate that the job_id contains only alphanumeric characters, dots, and underscores
 function validateJobId(job_id) {
@@ -83,18 +102,12 @@ QsubJobStatus.prototype.returnJobStatus = function(job_id, callback) {
 
     try {
       job_ctime = data.split("ctime = ")[1].split("\n")[0];
-      job_ctime = moment(job_ctime, "ddd MMM DD HH:mm:ss YYYY")
-        .tz("America/Los_Angeles")
-        .tz("GMT")
-        .format();
+      job_ctime = parseQstatTimeToGmt(job_ctime);
     } catch (e) {}
 
     try {
       job_stime = data.split("start_time = ")[1].split("\n")[0];
-      job_stime = moment(job_stime, "ddd MMM DD HH:mm:ss YYYY")
-        .tz("America/Los_Angeles")
-        .tz("GMT")
-        .format();
+      job_stime = parseQstatTimeToGmt(job_stime);
     } catch (e) {}
 
     if (job_status in status) {
@@ -142,7 +155,7 @@ QsubJobStatus.prototype.fullJobInfo = function(callback) {
 
     // iterate over each line
     var job_arr = d.toString().split("\n");
-    _.each(job_arr, function(item) {
+    job_arr.forEach(function(item) {
       var item_split = item.split("=");
       if (item_split.length == 2) {
         job[item_split[0].trim()] = item_split[1].trim();
@@ -386,7 +399,7 @@ SlurmJobStatus.prototype.returnJobStatus = function(job_id, callback) {
         
         if (job_ctime && job_ctime !== "Unknown") {
           try {
-            formatted_ctime = moment(job_ctime).format();
+            formatted_ctime = formatSacctTime(job_ctime);
           } catch (e) {
             logger.warn(`Error parsing creation time: ${job_ctime}`);
             formatted_ctime = new Date().toISOString();
@@ -397,7 +410,7 @@ SlurmJobStatus.prototype.returnJobStatus = function(job_id, callback) {
         
         if (job_stime && job_stime !== "Unknown") {
           try {
-            formatted_stime = moment(job_stime).format();
+            formatted_stime = formatSacctTime(job_stime);
           } catch (e) {
             logger.warn(`Error parsing start time: ${job_stime}`);
             formatted_stime = null;

--- a/lib/mcp/stdio.js
+++ b/lib/mcp/stdio.js
@@ -8,25 +8,15 @@
  * Config: claude mcp add datamonkey -- node lib/mcp/stdio.js
  */
 
-var path = require("path");
-var redis = require("redis");
 var McpServer = require("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
 var StdioServerTransport = require("@modelcontextprotocol/sdk/server/stdio.js").StdioServerTransport;
 var registerTools = require("./tools").registerTools;
 var registerPrompts = require("./prompts").registerPrompts;
 var registerResources = require("./resources").registerResources;
 
-var config = require(path.join(__dirname, "../../config.json"));
-
-var redisConfig = { host: config.redis_host, port: config.redis_port };
-if (config.redis_password) {
-  redisConfig.password = config.redis_password;
-}
-
-var client = redis.createClient(redisConfig);
-client.on("error", function (err) {
-  process.stderr.write("Redis error: " + err.message + "\n");
-});
+// Shared redis v5 client factory (connects on require). The factory already
+// attaches an "error" handler that logs, so we do not add another here.
+var client = require("../redis-client").client;
 
 var mcpServer = new McpServer(
   { name: "datamonkey", version: "1.0.0" },

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -1,0 +1,136 @@
+/**
+ * Shared redis v5 (node-redis) client factory.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Historically every module did its own `var client = redis.createClient(...)`
+ * at module scope (server.js, app/job.js, lib/jobqueue.js, app/hivtrace/*, ...).
+ * redis@5 is promise-native and requires an explicit `await client.connect()`
+ * after `createClient`, so the old pattern no longer works verbatim. This module
+ * centralizes connection setup so every caller shares one consistent, connected
+ * client and one consistent config shape.
+ *
+ * HOW TO USE IT (the pattern every sibling PR must follow)
+ * --------------------------------------------------------
+ *   const { client } = require("../lib/redis-client");
+ *   // ...later, inside an async function or a .then():
+ *   const obj = await client.hGetAll(job_id);   // commands are camelCased
+ *   await client.hSet(job_id, "status", "done");
+ *   await client.rPush("active_jobs", job_id);
+ *
+ * The exported `client` begins connecting the moment this module is first
+ * required (mirroring the old module-scope `createClient` behaviour). Because
+ * redis@5 buffers commands issued before the socket is ready, callers may issue
+ * commands immediately; they resolve once the connection is established. If you
+ * need to be certain the socket is up, `await client.connect()` is idempotent-ish
+ * only when NOT already connecting — prefer `await ready` (also exported) which
+ * resolves when the initial connect() settles.
+ *
+ * v5 API NOTES (vs the old v3 API this replaces)
+ * ----------------------------------------------
+ *   - createClient({ url } | { socket: { host, port }, password }) — no callbacks.
+ *   - Commands are camelCased: hgetall->hGetAll, hset->hSet, hget->hGet,
+ *     lrem->lRem, rpush->rPush, llen->lLen, del->del.
+ *   - Commands return promises; there is no (err, reply) callback form.
+ *
+ * PUB/SUB — SUBSCRIBER DUPLICATE PATTERN (read carefully)
+ * -------------------------------------------------------
+ * In redis@5 a connection that is in subscriber mode CANNOT issue normal
+ * commands, so a subscriber MUST be a SEPARATE connection. Use the exported
+ * `createSubscriber()` helper, which does `client.duplicate()` + `connect()`.
+ *
+ * There is NO more `.on("message", ...)`. The listener is passed directly to
+ * `.subscribe()`, and the message is the FIRST argument:
+ *
+ *   const sub = await createSubscriber();
+ *   await sub.subscribe(channel, (message, channel) => {
+ *     const packet = JSON.parse(message);
+ *     // ...
+ *   });
+ *
+ * Teardown (preserve this exactly — see leak fixes #397/#400):
+ *
+ *   await sub.unsubscribe(channel);
+ *   await sub.quit();              // graceful; falls back to sub.destroy() on error
+ *
+ * `createSubscriber()` returns a promise resolving to a CONNECTED duplicate
+ * client. It attaches an "error" handler so a broken subscriber socket logs
+ * instead of crashing the process.
+ */
+
+const redis = require("redis"),
+  logger = require("./logger").logger,
+  config = require("../config.json");
+
+/**
+ * Build the redis@5 client options from config.json.
+ * config.redis_host, config.redis_port, and optional config.redis_password.
+ */
+function buildClientOptions() {
+  const options = {
+    socket: {
+      host: config.redis_host,
+      port: config.redis_port,
+    },
+  };
+  if (config.redis_password) {
+    options.password = config.redis_password;
+  }
+  return options;
+}
+
+// Create the shared client at module scope, mirroring the historical
+// `var client = redis.createClient(...)` behaviour. In redis@5 this does NOT
+// open the socket by itself — connect() below does that.
+const client = redis.createClient(buildClientOptions());
+
+// Always attach an error handler so a transient redis error logs instead of
+// throwing an unhandled 'error' event and crashing the process.
+client.on("error", function (err) {
+  logger.error("Redis client error: " + err.message);
+});
+
+// Kick off the connection immediately on load. redis@5 queues commands issued
+// before the socket is ready and flushes them once connected, so callers can
+// require this module and issue commands without awaiting `ready` first.
+// We expose `ready` for callers that want to be sure the socket is up.
+const ready = client
+  .connect()
+  .then(function () {
+    logger.info("Redis shared client connected");
+  })
+  .catch(function (err) {
+    logger.error("Redis shared client failed to connect: " + err.message);
+  });
+
+/**
+ * Create and connect a dedicated subscriber connection.
+ *
+ * redis@5 requires pub/sub to run on its own connection (a subscribed client
+ * cannot run normal commands), so we duplicate the shared client's config and
+ * connect the copy. Returns a promise resolving to a CONNECTED client.
+ *
+ * Callers own the returned client's lifetime and MUST tear it down when done:
+ *   await sub.unsubscribe(channel);
+ *   await sub.quit();
+ * (see lib/clientsocket.js and app/hivtrace/hivtrace.js for the leak-safe
+ * teardown enforced by #397/#400 and the live-PUBSUB regression tests.)
+ *
+ * @returns {Promise<import('redis').RedisClientType>} connected subscriber
+ */
+function createSubscriber() {
+  const subscriber = client.duplicate();
+  subscriber.on("error", function (err) {
+    logger.error("Redis subscriber error: " + err.message);
+  });
+  return subscriber.connect().then(function () {
+    return subscriber;
+  });
+}
+
+module.exports = {
+  client,
+  ready,
+  createSubscriber,
+  buildClientOptions,
+};

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,23 +1,19 @@
-var config = require("../config.json"),
-  logger = require("./logger").logger,
+var logger = require("./logger").logger,
   fs = require("fs"),
-  redis = require("redis");
-
-var client = redis.createClient({
-  host: config.redis_host, port: config.redis_port
-});
-
-// Add error handler for Redis client
-client.on("error", function(err) {
-  logger.error("Redis utilities client error: " + err.message);
-});
+  client = require("./redis-client").client;
 
 // retrieves active jobs from redis, and attempts to cancel
 function get_active_jobs(cb) {
-  client.llen("active_jobs", function(err, n) {
-    logger.info(n + " active jobs left!");
-    cb("", n);
-  });
+  client
+    .lLen("active_jobs")
+    .then(function (n) {
+      logger.info(n + " active jobs left!");
+      cb("", n);
+    })
+    .catch(function (err) {
+      logger.error("Redis lLen(active_jobs) failed: " + err.message);
+      cb(err.message, 0);
+    });
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
   "name": "datamonkey-js-server",
-  "version": "3.3.4",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datamonkey-js-server",
-      "version": "3.3.4",
+      "version": "3.4.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "commander": "^6.0.0",
+        "date-fns": "^4.4.0",
         "express": "^5.2.1",
         "moment": "2.x.x",
         "moment-timezone": "0.5.37",
         "q": "^1.2.1",
-        "redis": "^3.1.2",
+        "redis": "^5.12.1",
         "should": "^13.2.3",
         "socket.io": "4.6.2",
         "tail": "0.4.x",
@@ -28,11 +29,12 @@
         "chai": "^4.3.7",
         "eslint": "^7.32.0",
         "mocha": "^11.7.1",
+        "prettier": "^3.9.5",
         "socket.io-client": "^4.5.4",
         "socket.io-stream": "^0.9.1"
       },
       "engines": {
-        "node": ">=13"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -309,6 +311,78 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -885,6 +959,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "license": "MIT",
@@ -1092,6 +1175,16 @@
         "whatwg-url": "^6.4.0"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.2",
       "license": "MIT",
@@ -1147,13 +1240,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "1.5.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -3505,13 +3591,19 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.11.1",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-data": {
@@ -3644,49 +3736,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
       "dependencies": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-redis"
-      }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-      "license": "MIT"
-    },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/regexpp": {
@@ -4660,6 +4722,18 @@
       },
       "bin": {
         "translate-gard": "cli.js"
+      }
+    },
+    "node_modules/translate-gard/node_modules/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/translate-gard/node_modules/should": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^6.0.0",
+    "date-fns": "^4.4.0",
     "express": "^5.2.1",
     "moment": "2.x.x",
     "moment-timezone": "0.5.37",
     "q": "^1.2.1",
-    "redis": "^3.1.2",
+    "redis": "^5.12.1",
     "should": "^13.2.3",
     "socket.io": "4.6.2",
     "tail": "0.4.x",


### PR DESCRIPTION
Part of the v4 modernization epic #410, Phase 1. Branches off `v4/phase1-redis-foundation` (PR #416) and targets `feature/v4-modernization`.

## Scope (lib-dates unit)
- `lib/jobdel.js` — redis
- `lib/jobqueue.js` — redis + moment
- `lib/jobstatus.js` — moment + underscore
- `lib/utilities.js` — redis
- `lib/mcp/stdio.js` — redis
- `app/flea/spawn_flea.js` — moment

## redis 3 -> 5 (node-redis v5)
All four redis files now `require("./redis-client").client` (the shared factory from #416) instead of `redis.createClient`. Commands camelCased and promise-based:
- `hgetall(id, cb)` -> `await client.hGetAll(id)` / `.then(...)`. v5 returns `{}` (not `null`) for a missing key, so membership is checked with `Object.keys(obj).length`.
- `hset` -> `hSet`, `llen` -> `lLen`. Fire-and-forget writes get a `.catch` that logs.
- `lib/mcp/stdio.js` drops its private client and uses the shared one (the factory already attaches an error handler).

## moment -> date-fns (verified byte-for-byte)
- **qstat/scontrol ctime & start_time** (`"ddd MMM DD HH:mm:ss YYYY"`, old: `moment(...).tz("America/Los_Angeles").tz("GMT").format()`) -> `parse(str, "EEE MMM dd HH:mm:ss yyyy", new Date())` then `toISOString()` with the `.000` ms stripped. Produces the exact same GMT `...Z` string.
- **sacct Submit/Start** (`moment(x).format()`, no token) -> `formatISO(new Date(x))` — identical local-offset ISO, no ms.
- **FLEA `visit_date`** (`moment(x).format("YYYYMMDD")`) -> `format(..., "yyyyMMdd")`; a bare `YYYY-MM-DD` string is coerced to local midnight to preserve moment's local-parse semantics.

Cross-checked all three helpers against the old moment output across DST/non-DST, date-only, and full-datetime samples — all match exactly.

## underscore -> native
- `lib/jobstatus.js`: `_.each(...)` -> `Array.prototype.forEach`.

## Verification
- `node -c` clean on all six changed files.
- Live redis smoke test via the shared factory: `hSet`/`hGetAll`/`lLen`/`del` all succeed.
- `test/jobstatus.js` (exercises the migrated `lib/jobstatus.js` end-to-end against real SLURM) passes; its submitted job is scancel'd, `squeue -u sweaver` left empty. No leaked SLURM jobs.
- Date helpers verified equal to prior moment output.

### Expected-red on this isolated branch (resolves on the integration branch)
`test:ci`, the MCP suite, and the redis regression suite still fail here, and every failure root-causes to **v3-API code owned by sibling Phase 1 units, not this unit**:
- `app/hyphyjob.js:75` still calls `client.hset` (migrated by the job/hyphyjob unit).
- `lib/clientsocket.js` still uses `.on("message")` / `send_command` (migrated by the clientsocket/pubsub unit).
- Shared test harnesses (`test/regression/leaks.js`, `test/mock/lifecycle.js`, `test/jobqueue.js`) still use `send_command` / `client.hset`.

This is the state the Foundation PR (#416) documented: these suites go green once the sibling PRs land on `feature/v4-modernization`. This unit's own files are fully migrated and independently verified.