### PR TITLE
Phase 2 PR 1: golden qsub_params snapshot (migration oracle) (#410)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "test": "npm run test:ci && npm run test:slurm",
-    "test:ci": "mocha -R spec --exit test/regression/leaks.js test/error-paths/validation.js test/validation/results.js test/mock/lifecycle.js test/sanitize-names.test.js test/difFubar.test.js test/difFubar.integration.test.js test/fubar-redirection.test.js",
+    "test:ci": "mocha -R spec --exit test/regression/leaks.js test/error-paths/validation.js test/validation/results.js test/mock/lifecycle.js test/golden/qsub-params.js test/sanitize-names.test.js test/difFubar.test.js test/difFubar.integration.test.js test/fubar-redirection.test.js",
     "test:slurm": "npm run test:analyses && npm run test:slurm-unit && npm run test:integration",
     "test:analyses": "mocha -R spec --exit test/absrel/absrel.js test/busted/busted.js test/contrast-fel/contrast-fel.js test/fade/fade.js test/fubar/fubar.js test/gard/gard.js test/hivtrace/hivtrace.js test/meme/meme.js test/multihit/multihit.js test/prime/prime.js test/relax/relax.js test/slac/slac.js",
     "test:slurm-unit": "mocha -R spec --exit test/jobstatus.js test/jobqueue.js test/coverage-gaps/job-lifecycle.js test/coverage-gaps/hivtrace-checkjob.js",

--- a/test/golden/qsub-params.js
+++ b/test/golden/qsub-params.js
@@ -1,0 +1,136 @@
+/**
+ * Golden snapshot of every declarative analysis's qsub_params (Phase 2 oracle).
+ *
+ * Phase 2 collapses the 14 near-identical HyPhy analysis modules into a shared
+ * factory + per-analysis descriptors. This test pins the EXACT job-submission
+ * parameters each analysis produces TODAY (for both slurm and local submit
+ * types), so the factory migration can be proven byte-identical: if a migrated
+ * analysis builds a different qsub_params array (missing key, wrong default,
+ * reordered), this test fails.
+ *
+ * How it works:
+ *   - Each analysis builds self.qsub_params in its constructor (from
+ *     config.submit_type), BEFORE init(). We construct with checkOnly:true so
+ *     init() routes to validateParameters() and never submits a SLURM job.
+ *   - config.submit_type is a shared cached object (require('../../config.json')),
+ *     so we flip it to 'slurm' then 'local' and capture both.
+ *   - Volatile bits (the "check-<timestamp>" id and absolute repo paths) are
+ *     normalized to stable placeholders so the snapshot is deterministic.
+ *
+ * The snapshot lives in test/golden/qsub-params.snapshot.json. Regenerate it
+ * intentionally with GOLDEN_UPDATE=1 (only when a param change is deliberate).
+ */
+
+var fs = require("fs"),
+  path = require("path"),
+  should = require("should"),
+  EventEmitter = require("events").EventEmitter,
+  config = require(__dirname + "/../../config.json");
+
+var ABS_ROOT = path.resolve(__dirname, "../..");
+var SNAPSHOT = path.join(__dirname, "qsub-params.snapshot.json");
+
+// The 14 declarative-candidate analyses: [label, module path, export key].
+var ANALYSES = [
+  ["fel", "../../app/fel/fel.js", "fel"],
+  ["meme", "../../app/meme/meme.js", "meme"],
+  ["slac", "../../app/slac/slac.js", "slac"],
+  ["busted", "../../app/busted/busted.js", "busted"],
+  ["absrel", "../../app/absrel/absrel.js", "absrel"],
+  ["relax", "../../app/relax/relax.js", "relax"],
+  ["prime", "../../app/prime/prime.js", "prime"],
+  ["fubar", "../../app/fubar/fubar.js", "fubar"],
+  ["fade", "../../app/fade/fade.js", "fade"],
+  ["bgm", "../../app/bgm/bgm.js", "bgm"],
+  ["multihit", "../../app/multihit/multihit.js", "multihit"],
+  ["nrm", "../../app/nrm/nrm.js", "nrm"],
+  ["bstill", "../../app/bstill/bstill.js", "bstill"],
+  ["cfel", "../../app/contrast-fel/cfel.js", "cfel"]
+];
+
+function fakeSocket() {
+  var s = new EventEmitter();
+  s.id = "golden";
+  s.disconnect = function () {};
+  s.emit = EventEmitter.prototype.emit.bind(s);
+  return s;
+}
+
+function mkParams() {
+  return {
+    checkOnly: true,
+    _id: "GOLDEN-ID",
+    analysis: { _id: "GOLDEN-ID" },
+    msa: [{ _id: "MSA-ID", nj: "(A,B);", gencodeid: 0 }],
+    genetic_code: "Universal"
+  };
+}
+
+// Replace per-run volatile substrings with stable placeholders so the snapshot
+// is deterministic: the "check-<timestamp>" id and absolute repo paths.
+function normalize(arr) {
+  return (arr || []).map(function (entry) {
+    return String(entry)
+      .split(ABS_ROOT).join("<ROOT>")
+      .replace(/check-\d+/g, "check-<TS>");
+  });
+}
+
+function capture(modPath, exportKey, submitType) {
+  config.submit_type = submitType;
+  var mod = require(modPath);
+  var Ctor = mod[exportKey];
+  var job = new Ctor(fakeSocket(), ">A\nACGT\n", mkParams());
+  return {
+    type: job.type,
+    resultsSuffix: job.results_fn ? path.basename(job.results_fn).replace(/^check-<?TS>?\.?/, "").replace(/check-\d+\.?/, "") : null,
+    qsub_params: normalize(job.qsub_params)
+  };
+}
+
+describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
+  this.timeout(20000);
+
+  var current = {};
+  before(function () {
+    ANALYSES.forEach(function (a) {
+      var label = a[0], modPath = a[1], key = a[2];
+      current[label] = {
+        slurm: capture(modPath, key, "slurm"),
+        local: capture(modPath, key, "local")
+      };
+    });
+    // restore a sane default so later suites aren't affected
+    config.submit_type = "slurm";
+  });
+
+  it("captures all 14 analyses for slurm and local", function () {
+    Object.keys(current).length.should.equal(14);
+    ANALYSES.forEach(function (a) {
+      current[a[0]].slurm.qsub_params.length.should.be.above(0);
+      current[a[0]].local.qsub_params.length.should.be.above(0);
+    });
+  });
+
+  if (process.env.GOLDEN_UPDATE === "1" || !fs.existsSync(SNAPSHOT)) {
+    it("writes the golden snapshot", function () {
+      fs.writeFileSync(SNAPSHOT, JSON.stringify(current, null, 2) + "\n");
+      // Sanity: file is valid + non-trivial.
+      var written = JSON.parse(fs.readFileSync(SNAPSHOT, "utf8"));
+      Object.keys(written).length.should.equal(14);
+    });
+  } else {
+    it("matches the committed golden snapshot (byte-for-byte per analysis)", function () {
+      var golden = JSON.parse(fs.readFileSync(SNAPSHOT, "utf8"));
+      ANALYSES.forEach(function (a) {
+        var label = a[0];
+        should.exist(golden[label], "missing golden entry for " + label);
+        current[label].slurm.qsub_params.should.eql(
+          golden[label].slurm.qsub_params, label + " slurm qsub_params drift");
+        current[label].local.qsub_params.should.eql(
+          golden[label].local.qsub_params, label + " local qsub_params drift");
+        current[label].slurm.type.should.equal(golden[label].slurm.type, label + " type drift");
+      });
+    });
+  }
+});

--- a/test/golden/qsub-params.snapshot.json
+++ b/test/golden/qsub-params.snapshot.json
@@ -1,0 +1,562 @@
+{
+  "fel": {
+    "slurm": {
+      "type": "fel",
+      "resultsSuffix": "FEL.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/fel/output/check-<TS>,tree_fn=<ROOT>/app/fel/output/check-<TS>.tre,sfn=<ROOT>/app/fel/output/check-<TS>.status,pfn=<ROOT>/app/fel/output/check-<TS>.fel.progress,rfn=<ROOT>/app/fel/output/check-<TS>.fel,treemode=0,bootstrap=false,resample=1,genetic_code=Universal,analysis_type=fel,rate_variation=No,ci=No,cwd=<ROOT>/app/fel,msaid=check,procs=32,multiple_hits=None,site_multihit=Estimate,branches=All",
+        "--output=<ROOT>/app/fel/output/fel_check-<TS>_%j.out",
+        "--error=<ROOT>/app/fel/output/fel_check-<TS>_%j.err",
+        "<ROOT>/app/fel/fel.sh"
+      ]
+    },
+    "local": {
+      "type": "fel",
+      "resultsSuffix": "FEL.json",
+      "qsub_params": [
+        "<ROOT>/app/fel/fel.sh",
+        "fn=<ROOT>/app/fel/output/check-<TS>",
+        "tree_fn=<ROOT>/app/fel/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/fel/output/check-<TS>.status",
+        "pfn=<ROOT>/app/fel/output/check-<TS>.fel.progress",
+        "rfn=<ROOT>/app/fel/output/check-<TS>.fel",
+        "treemode=0",
+        "bootstrap=false",
+        "resample=1",
+        "genetic_code=Universal",
+        "analysis_type=fel",
+        "rate_variation=No",
+        "ci=No",
+        "cwd=<ROOT>/app/fel",
+        "msaid=check",
+        "procs=32",
+        "multiple_hits=None",
+        "site_multihit=Estimate",
+        "branches=All"
+      ]
+    }
+  },
+  "meme": {
+    "slurm": {
+      "type": "meme",
+      "resultsSuffix": "MEME.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/meme/output/check-<TS>,tree_fn=<ROOT>/app/meme/output/check-<TS>.tre,sfn=<ROOT>/app/meme/output/check-<TS>.status,pfn=<ROOT>/app/meme/output/check-<TS>.meme.progress,rfn=<ROOT>/app/meme/output/check-<TS>.meme,treemode=0,bootstrap=false,resample=0,multiple_hits=None,site_multihit=Estimate,rates=2,impute_states=No,pvalue=0.1,genetic_code=Universal,analysis_type=meme,cwd=<ROOT>/app/meme,msaid=check,procs=32",
+        "--output=<ROOT>/app/meme/output/meme_check-<TS>_%j.out",
+        "--error=<ROOT>/app/meme/output/meme_check-<TS>_%j.err",
+        "<ROOT>/app/meme/meme.sh"
+      ]
+    },
+    "local": {
+      "type": "meme",
+      "resultsSuffix": "MEME.json",
+      "qsub_params": [
+        "<ROOT>/app/meme/meme.sh",
+        "fn=<ROOT>/app/meme/output/check-<TS>",
+        "tree_fn=<ROOT>/app/meme/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/meme/output/check-<TS>.status",
+        "pfn=<ROOT>/app/meme/output/check-<TS>.meme.progress",
+        "rfn=<ROOT>/app/meme/output/check-<TS>.meme",
+        "treemode=0",
+        "bootstrap=false",
+        "resample=0",
+        "multiple_hits=None",
+        "site_multihit=Estimate",
+        "rates=2",
+        "impute_states=No",
+        "pvalue=0.1",
+        "genetic_code=Universal",
+        "analysis_type=meme",
+        "cwd=<ROOT>/app/meme",
+        "msaid=check",
+        "procs=32"
+      ]
+    }
+  },
+  "slac": {
+    "slurm": {
+      "type": "slac",
+      "resultsSuffix": "SLAC.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/slac/output/check-<TS>,tree_fn=<ROOT>/app/slac/output/check-<TS>.tre,sfn=<ROOT>/app/slac/output/check-<TS>.status,pfn=<ROOT>/app/slac/output/check-<TS>.slac.progress,rfn=<ROOT>/app/slac/output/check-<TS>.slac,treemode=0,genetic_code=Universal,analysis_type=slac,branches=All,samples=100,pvalue=0.1,cwd=<ROOT>/app/slac,msaid=check,procs=32",
+        "--output=<ROOT>/app/slac/output/slac_check-<TS>_%j.out",
+        "--error=<ROOT>/app/slac/output/slac_check-<TS>_%j.err",
+        "<ROOT>/app/slac/slac.sh"
+      ]
+    },
+    "local": {
+      "type": "slac",
+      "resultsSuffix": "SLAC.json",
+      "qsub_params": [
+        "<ROOT>/app/slac/slac.sh",
+        "fn=<ROOT>/app/slac/output/check-<TS>",
+        "tree_fn=<ROOT>/app/slac/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/slac/output/check-<TS>.status",
+        "pfn=<ROOT>/app/slac/output/check-<TS>.slac.progress",
+        "rfn=<ROOT>/app/slac/output/check-<TS>.slac",
+        "treemode=0",
+        "genetic_code=Universal",
+        "analysis_type=slac",
+        "branches=All",
+        "samples=100",
+        "pvalue=0.1",
+        "cwd=<ROOT>/app/slac",
+        "msaid=check",
+        "procs=32"
+      ]
+    }
+  },
+  "busted": {
+    "slurm": {
+      "type": "busted",
+      "resultsSuffix": "BUSTED.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/busted/output/check-<TS>,tree_fn=<ROOT>/app/busted/output/check-<TS>.tre,sfn=<ROOT>/app/busted/output/check-<TS>.status,pfn=<ROOT>/app/busted/output/check-<TS>.BUSTED.progress,rfn=<ROOT>/app/busted/output/check-<TS>.BUSTED.json,treemode=0,genetic_code=Universal,synRateVariation=Yes,errorProtection=No,multihit=None,branches=All,rates=3,syn_rates=3,grid_size=250,starting_points=1,save_fit=/dev/null,cwd=<ROOT>/app/busted,msaid=check,procs=32",
+        "--output=<ROOT>/app/busted/output/busted_check-<TS>_%j.out",
+        "--error=<ROOT>/app/busted/output/busted_check-<TS>_%j.err",
+        "<ROOT>/app/busted/busted_submit.sh"
+      ]
+    },
+    "local": {
+      "type": "busted",
+      "resultsSuffix": "BUSTED.json",
+      "qsub_params": [
+        "<ROOT>/app/busted/busted_submit.sh",
+        "fn=<ROOT>/app/busted/output/check-<TS>",
+        "tree_fn=<ROOT>/app/busted/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/busted/output/check-<TS>.status",
+        "pfn=<ROOT>/app/busted/output/check-<TS>.BUSTED.progress",
+        "rfn=<ROOT>/app/busted/output/check-<TS>.BUSTED.json",
+        "treemode=0",
+        "genetic_code=Universal",
+        "synRateVariation=Yes",
+        "errorProtection=No",
+        "multihit=None",
+        "branches=All",
+        "rates=3",
+        "syn_rates=3",
+        "grid_size=250",
+        "starting_points=1",
+        "save_fit=/dev/null",
+        "analysis_type=busted",
+        "cwd=<ROOT>/app/busted",
+        "msaid=check",
+        "procs=32"
+      ]
+    }
+  },
+  "absrel": {
+    "slurm": {
+      "type": "absrel",
+      "resultsSuffix": "ABSREL.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/absrel/output/check-<TS>,tree_fn=<ROOT>/app/absrel/output/check-<TS>.tre,sfn=<ROOT>/app/absrel/output/check-<TS>.status,pfn=<ROOT>/app/absrel/output/check-<TS>.absrel.progress,rfn=<ROOT>/app/absrel/output/check-<TS>.absrel,treemode=0,genetic_code=Universal,multiple_hits=None,srv=Yes,blb=1,branches=All,analysis_type=absrel,cwd=<ROOT>/app/absrel,msaid=check,procs=32",
+        "--output=<ROOT>/app/absrel/output/absrel_check-<TS>_%j.out",
+        "--error=<ROOT>/app/absrel/output/absrel_check-<TS>_%j.err",
+        "<ROOT>/app/absrel/absrel.sh"
+      ]
+    },
+    "local": {
+      "type": "absrel",
+      "resultsSuffix": "ABSREL.json",
+      "qsub_params": [
+        "<ROOT>/app/absrel/absrel.sh",
+        "fn=<ROOT>/app/absrel/output/check-<TS>",
+        "tree_fn=<ROOT>/app/absrel/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/absrel/output/check-<TS>.status",
+        "pfn=<ROOT>/app/absrel/output/check-<TS>.absrel.progress",
+        "rfn=<ROOT>/app/absrel/output/check-<TS>.absrel",
+        "treemode=0",
+        "genetic_code=Universal",
+        "multiple_hits=None",
+        "srv=Yes",
+        "blb=1",
+        "branches=All",
+        "analysis_type=absrel",
+        "cwd=<ROOT>/app/absrel",
+        "msaid=check",
+        "procs=32"
+      ]
+    }
+  },
+  "relax": {
+    "slurm": {
+      "type": "relax",
+      "resultsSuffix": "RELAX.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/relax/output/check-<TS>,tree_fn=<ROOT>/app/relax/output/check-<TS>.tre,sfn=<ROOT>/app/relax/output/check-<TS>.status,pfn=<ROOT>/app/relax/output/check-<TS>.RELAX.progress,treemode=0,genetic_code=Universal,mode=Classic mode,test_branches=TEST,reference_branches=REFERENCE,models=All,rates=3,kill_zero_lengths=No,cwd=<ROOT>/app/relax,msaid=check,procs=32",
+        "--output=<ROOT>/app/relax/output/relax_check-<TS>_%j.out",
+        "--error=<ROOT>/app/relax/output/relax_check-<TS>_%j.err",
+        "<ROOT>/app/relax/relax.sh"
+      ]
+    },
+    "local": {
+      "type": "relax",
+      "resultsSuffix": "RELAX.json",
+      "qsub_params": [
+        "<ROOT>/app/relax/relax.sh",
+        "fn=<ROOT>/app/relax/output/check-<TS>",
+        "tree_fn=<ROOT>/app/relax/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/relax/output/check-<TS>.status",
+        "pfn=<ROOT>/app/relax/output/check-<TS>.RELAX.progress",
+        "treemode=0",
+        "genetic_code=Universal",
+        "mode=Classic mode",
+        "test_branches=TEST",
+        "reference_branches=REFERENCE",
+        "models=All",
+        "rates=3",
+        "kill_zero_lengths=No",
+        "cwd=<ROOT>/app/relax",
+        "msaid=check",
+        "procs=32"
+      ]
+    }
+  },
+  "prime": {
+    "slurm": {
+      "type": "prime",
+      "resultsSuffix": "PRIME.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/prime/output/check-<TS>,tree_fn=<ROOT>/app/prime/output/check-<TS>.tre,sfn=<ROOT>/app/prime/output/check-<TS>.status,pfn=<ROOT>/app/prime/output/check-<TS>.prime.progress,rfn=<ROOT>/app/prime/output/check-<TS>.prime,genetic_code=Universal,analysis_type=prime,cwd=<ROOT>/app/prime,msaid=check,procs=32,branches=All,property_set=5PROP,pvalue=0.1,impute_states=No",
+        "--output=<ROOT>/app/prime/output/prime_check-<TS>_%j.out",
+        "--error=<ROOT>/app/prime/output/prime_check-<TS>_%j.err",
+        "<ROOT>/app/prime/prime.sh"
+      ]
+    },
+    "local": {
+      "type": "prime",
+      "resultsSuffix": "PRIME.json",
+      "qsub_params": [
+        "<ROOT>/app/prime/prime.sh",
+        "fn=<ROOT>/app/prime/output/check-<TS>",
+        "tree_fn=<ROOT>/app/prime/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/prime/output/check-<TS>.status",
+        "pfn=<ROOT>/app/prime/output/check-<TS>.prime.progress",
+        "rfn=<ROOT>/app/prime/output/check-<TS>.prime",
+        "genetic_code=Universal",
+        "analysis_type=prime",
+        "cwd=<ROOT>/app/prime",
+        "msaid=check",
+        "procs=32",
+        "branches=All",
+        "property_set=5PROP",
+        "pvalue=0.1",
+        "impute_states=No"
+      ]
+    }
+  },
+  "fubar": {
+    "slurm": {
+      "type": "fubar",
+      "resultsSuffix": "FUBAR.json",
+      "qsub_params": [
+        "--ntasks=48",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/fubar/output/check-<TS>,tree_fn=<ROOT>/app/fubar/output/check-<TS>.tre,sfn=<ROOT>/app/fubar/output/check-<TS>.status,pfn=<ROOT>/app/fubar/output/check-<TS>.fubar.progress,rfn=<ROOT>/app/fubar/output/check-<TS>.fubar,treemode=0,genetic_code=Universal,analysis_type=fubar,cwd=<ROOT>/app/fubar,msaid=check,number_of_grid_points=20,concentration_of_dirichlet_prior=0.5,procs=48",
+        "--output=<ROOT>/app/fubar/output/fubar_check-<TS>_%j.out",
+        "--error=<ROOT>/app/fubar/output/fubar_check-<TS>_%j.err",
+        "<ROOT>/app/fubar/fubar.sh"
+      ]
+    },
+    "local": {
+      "type": "fubar",
+      "resultsSuffix": "FUBAR.json",
+      "qsub_params": [
+        "<ROOT>/app/fubar/fubar.sh",
+        "fn=<ROOT>/app/fubar/output/check-<TS>",
+        "tree_fn=<ROOT>/app/fubar/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/fubar/output/check-<TS>.status",
+        "pfn=<ROOT>/app/fubar/output/check-<TS>.fubar.progress",
+        "rfn=<ROOT>/app/fubar/output/check-<TS>.fubar",
+        "treemode=0",
+        "genetic_code=Universal",
+        "analysis_type=fubar",
+        "cwd=<ROOT>/app/fubar",
+        "msaid=check",
+        "number_of_grid_points=20",
+        "concentration_of_dirichlet_prior=0.5",
+        "procs=48"
+      ]
+    }
+  },
+  "fade": {
+    "slurm": {
+      "type": "fade",
+      "resultsSuffix": "FADE.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/fade/output/check-<TS>,tree_fn=<ROOT>/app/fade/output/check-<TS>.tre,sfn=<ROOT>/app/fade/output/check-<TS>.status,pfn=<ROOT>/app/fade/output/check-<TS>.fade.progress,rfn=<ROOT>/app/fade/output/check-<TS>.fade,treemode=0,genetic_code=Universal,substitution_model=LG,posterior_estimation_method=Metropolis-Hastings,branches=All,number_of_grid_points=20,number_of_mcmc_chains=5,length_of_each_chain=1000000,number_of_burn_in_samples=100000,number_of_samples=100,concentration_of_dirichlet_prior=0.5,analysis_type=fade,cwd=<ROOT>/app/fade,msaid=check,procs=32",
+        "--output=<ROOT>/app/fade/output/fade_check-<TS>_%j.out",
+        "--error=<ROOT>/app/fade/output/fade_check-<TS>_%j.err",
+        "<ROOT>/app/fade/fade.sh"
+      ]
+    },
+    "local": {
+      "type": "fade",
+      "resultsSuffix": "FADE.json",
+      "qsub_params": [
+        "<ROOT>/app/fade/fade.sh",
+        "fn=<ROOT>/app/fade/output/check-<TS>",
+        "tree_fn=<ROOT>/app/fade/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/fade/output/check-<TS>.status",
+        "pfn=<ROOT>/app/fade/output/check-<TS>.fade.progress",
+        "rfn=<ROOT>/app/fade/output/check-<TS>.fade",
+        "treemode=0",
+        "genetic_code=Universal",
+        "substitution_model=LG",
+        "posterior_estimation_method=Metropolis-Hastings",
+        "branches=All",
+        "number_of_grid_points=20",
+        "number_of_mcmc_chains=5",
+        "length_of_each_chain=1000000",
+        "number_of_burn_in_samples=100000",
+        "number_of_samples=100",
+        "concentration_of_dirichlet_prior=0.5",
+        "analysis_type=fade",
+        "cwd=<ROOT>/app/fade",
+        "msaid=check",
+        "procs=32"
+      ]
+    }
+  },
+  "bgm": {
+    "slurm": {
+      "type": "bgm",
+      "resultsSuffix": "BGM.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/bgm/output/check-<TS>,tree_fn=<ROOT>/app/bgm/output/check-<TS>.tre,sfn=<ROOT>/app/bgm/output/check-<TS>.status,pfn=<ROOT>/app/bgm/output/check-<TS>.bgm.progress,rfn=<ROOT>/app/bgm/output/check-<TS>.bgm,treemode=0,genetic_code=Universal,datatype=codon,substitution_model=,branches=All,length_of_each_chain=1000000,number_of_burn_in_samples=100000,number_of_samples=100,maximum_parents_per_node=1,minimum_subs_per_site=1,analysis_type=bgm,cwd=<ROOT>/app/bgm,msaid=check,procs=32",
+        "--output=<ROOT>/app/bgm/output/bgm_check-<TS>_%j.out",
+        "--error=<ROOT>/app/bgm/output/bgm_check-<TS>_%j.err",
+        "<ROOT>/app/bgm/bgm.sh"
+      ]
+    },
+    "local": {
+      "type": "bgm",
+      "resultsSuffix": "BGM.json",
+      "qsub_params": [
+        "<ROOT>/app/bgm/bgm.sh",
+        "fn=<ROOT>/app/bgm/output/check-<TS>",
+        "tree_fn=<ROOT>/app/bgm/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/bgm/output/check-<TS>.status",
+        "pfn=<ROOT>/app/bgm/output/check-<TS>.bgm.progress",
+        "rfn=<ROOT>/app/bgm/output/check-<TS>.bgm",
+        "treemode=0",
+        "genetic_code=Universal",
+        "datatype=codon",
+        "substitution_model=",
+        "branches=All",
+        "length_of_each_chain=1000000",
+        "number_of_burn_in_samples=100000",
+        "number_of_samples=100",
+        "maximum_parents_per_node=1",
+        "minimum_subs_per_site=1",
+        "analysis_type=bgm",
+        "cwd=<ROOT>/app/bgm",
+        "msaid=check",
+        "procs=32"
+      ]
+    }
+  },
+  "multihit": {
+    "slurm": {
+      "type": "multihit",
+      "resultsSuffix": "MULTI.json",
+      "qsub_params": [
+        "--ntasks=4",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/multihit/output/check-<TS>,tree_fn=<ROOT>/app/multihit/output/check-<TS>.tre,sfn=<ROOT>/app/multihit/output/check-<TS>.status,pfn=<ROOT>/app/multihit/output/check-<TS>.multihit.progress,rfn=<ROOT>/app/multihit/output/check-<TS>.MULTI.json,treemode=0,genetic_code=Universal,rate_classes=1,triple_islands=No,branches=All,analysis_type=multihit,cwd=<ROOT>/app/multihit,msaid=check,procs=4",
+        "--output=<ROOT>/app/multihit/output/multihit_check-<TS>_%j.out",
+        "--error=<ROOT>/app/multihit/output/multihit_check-<TS>_%j.err",
+        "<ROOT>/app/multihit/multihit.sh"
+      ]
+    },
+    "local": {
+      "type": "multihit",
+      "resultsSuffix": "MULTI.json",
+      "qsub_params": [
+        "<ROOT>/app/multihit/multihit.sh",
+        "fn=<ROOT>/app/multihit/output/check-<TS>",
+        "tree_fn=<ROOT>/app/multihit/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/multihit/output/check-<TS>.status",
+        "pfn=<ROOT>/app/multihit/output/check-<TS>.multihit.progress",
+        "rfn=<ROOT>/app/multihit/output/check-<TS>.MULTI.json",
+        "treemode=0",
+        "genetic_code=Universal",
+        "rate_classes=1",
+        "triple_islands=No",
+        "branches=All",
+        "analysis_type=multihit",
+        "cwd=<ROOT>/app/multihit",
+        "msaid=check",
+        "procs=4"
+      ]
+    }
+  },
+  "nrm": {
+    "slurm": {
+      "type": "nrm",
+      "resultsSuffix": "NRM.json",
+      "qsub_params": [
+        "--ntasks=4",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/nrm/output/check-<TS>,tree_fn=<ROOT>/app/nrm/output/check-<TS>.tre,sfn=<ROOT>/app/nrm/output/check-<TS>.status,pfn=<ROOT>/app/nrm/output/check-<TS>.nrm.progress,rfn=<ROOT>/app/nrm/output/check-<TS>.NRM.json,treemode=0,genetic_code=Universal,branches=All,analysis_type=nrm,cwd=<ROOT>/app/nrm,msaid=check,procs=4",
+        "--output=<ROOT>/app/nrm/output/nrm_check-<TS>_%j.out",
+        "--error=<ROOT>/app/nrm/output/nrm_check-<TS>_%j.err",
+        "<ROOT>/app/nrm/nrm.sh"
+      ]
+    },
+    "local": {
+      "type": "nrm",
+      "resultsSuffix": "NRM.json",
+      "qsub_params": [
+        "<ROOT>/app/nrm/nrm.sh",
+        "fn=<ROOT>/app/nrm/output/check-<TS>",
+        "tree_fn=<ROOT>/app/nrm/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/nrm/output/check-<TS>.status",
+        "pfn=<ROOT>/app/nrm/output/check-<TS>.nrm.progress",
+        "rfn=<ROOT>/app/nrm/output/check-<TS>.NRM.json",
+        "treemode=0",
+        "genetic_code=Universal",
+        "branches=All",
+        "analysis_type=nrm",
+        "cwd=<ROOT>/app/nrm",
+        "msaid=check",
+        "procs=4"
+      ]
+    }
+  },
+  "bstill": {
+    "slurm": {
+      "type": "bstill",
+      "resultsSuffix": "FUBAR-inv.json",
+      "qsub_params": [
+        "--ntasks=48",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/bstill/output/check-<TS>,tree_fn=<ROOT>/app/bstill/output/check-<TS>.tre,sfn=<ROOT>/app/bstill/output/check-<TS>.status,pfn=<ROOT>/app/bstill/output/check-<TS>.bstill.progress,rfn=<ROOT>/app/bstill/output/check-<TS>.bstill,treemode=0,genetic_code=Universal,analysis_type=bstill,cwd=<ROOT>/app/bstill,msaid=check,number_of_grid_points=20,concentration_of_dirichlet_prior=0.5,method=Variational-Bayes,ebf=10,radius_threshold=0.5,procs=48",
+        "--output=<ROOT>/app/bstill/output/bstill_check-<TS>_%j.out",
+        "--error=<ROOT>/app/bstill/output/bstill_check-<TS>_%j.err",
+        "<ROOT>/app/bstill/bstill.sh"
+      ]
+    },
+    "local": {
+      "type": "bstill",
+      "resultsSuffix": "FUBAR-inv.json",
+      "qsub_params": [
+        "<ROOT>/app/bstill/bstill.sh",
+        "fn=<ROOT>/app/bstill/output/check-<TS>",
+        "tree_fn=<ROOT>/app/bstill/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/bstill/output/check-<TS>.status",
+        "pfn=<ROOT>/app/bstill/output/check-<TS>.bstill.progress",
+        "rfn=<ROOT>/app/bstill/output/check-<TS>.bstill",
+        "treemode=0",
+        "genetic_code=Universal",
+        "analysis_type=bstill",
+        "cwd=<ROOT>/app/bstill",
+        "msaid=check",
+        "number_of_grid_points=20",
+        "concentration_of_dirichlet_prior=0.5",
+        "method=Variational-Bayes",
+        "ebf=10",
+        "radius_threshold=0.5",
+        "procs=48"
+      ]
+    }
+  },
+  "cfel": {
+    "slurm": {
+      "type": "cfel",
+      "resultsSuffix": "FEL.json",
+      "qsub_params": [
+        "--ntasks=32",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/contrast-fel/output/check-<TS>,tree_fn=<ROOT>/app/contrast-fel/output/check-<TS>.tre,sfn=<ROOT>/app/contrast-fel/output/check-<TS>.status,pfn=<ROOT>/app/contrast-fel/output/check-<TS>.cfel.progress,rfn=<ROOT>/app/contrast-fel/output/check-<TS>.cfel,treemode=0,genetic_code=Universal,branch_sets=,rate_variation=No,permutations=Yes,p_value=0.05,q_value=0.2,analysis_type=cfel,cwd=<ROOT>/app/contrast-fel,msaid=check,procs=32",
+        "--output=<ROOT>/app/contrast-fel/output/cfel_check-<TS>_%j.out",
+        "--error=<ROOT>/app/contrast-fel/output/cfel_check-<TS>_%j.err",
+        "<ROOT>/app/contrast-fel/cfel.sh"
+      ]
+    },
+    "local": {
+      "type": "cfel",
+      "resultsSuffix": "FEL.json",
+      "qsub_params": [
+        "<ROOT>/app/contrast-fel/cfel.sh",
+        "fn=<ROOT>/app/contrast-fel/output/check-<TS>",
+        "tree_fn=<ROOT>/app/contrast-fel/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/contrast-fel/output/check-<TS>.status",
+        "pfn=<ROOT>/app/contrast-fel/output/check-<TS>.cfel.progress",
+        "rfn=<ROOT>/app/contrast-fel/output/check-<TS>.cfel",
+        "treemode=0",
+        "genetic_code=Universal",
+        "branch_sets=",
+        "rate_variation=No",
+        "permutations=Yes",
+        "p_value=0.05",
+        "q_value=0.2",
+        "analysis_type=cfel",
+        "cwd=<ROOT>/app/contrast-fel",
+        "msaid=check",
+        "procs=32"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
First Phase 2 PR (#410) — **no behavior change**, pure test infrastructure. Establishes the regression oracle that makes the analysis-factory migration safe.

### What it does
`test/golden/qsub-params.js` constructs each of the **14 declarative-candidate analyses** (fel, meme, slac, busted, absrel, relax, prime, fubar, fade, bgm, multihit, nrm, bstill, cfel) with `checkOnly:true` — so `init()` routes to `validateParameters()` and **never submits a SLURM job** — under both `submit_type=slurm` and `=local`, and snapshots the exact `qsub_params` array + `type` to `test/golden/qsub-params.snapshot.json`.

Volatile bits (the `check-<timestamp>` id and absolute repo paths) are normalized to stable placeholders, so the snapshot is deterministic across runs and machines.

### Why
Phase 2 collapses those 14 near-identical modules (~3,600 LOC) into a shared factory + descriptors. This snapshot lets each migration PR prove the generated job params are **byte-for-byte identical** to today's — any drift (missing key, wrong default, reordering) fails this test with a precise `<analysis> <mode> qsub_params drift` message.

### Verification
- Snapshot generated + match-run passes (`✔ matches the committed golden snapshot`), **deterministic across repeated runs**.
- **Mutation-tested**: changing `fel`'s `branches` default from `"All"` to `"Internal"` fails the snapshot (`fel slurm qsub_params drift`); restoring passes. The oracle has teeth.
- Wired into `test:ci` (cluster-free): **91 passing**, SLURM queue empty.
- `npm run lint` clean (test/ is not in the lint scope, consistent with all existing test files).

Regenerate intentionally with `GOLDEN_UPDATE=1` (only when a param change is deliberate). The 4 bespoke analyses (gard/difFubar/hivtrace/flea) are out of Phase 2 scope.

Next: PR 2 adds the factory (no wiring), then batched descriptor migrations verified against this snapshot.