### PR TITLE
Phase 2 PR 2: analysis factory + fel descriptor (no wiring) (#410)

### DIFF
--- a/app/fel/descriptor.js
+++ b/app/fel/descriptor.js
@@ -1,0 +1,85 @@
+/**
+ * FEL analysis descriptor (Phase 2, #410).
+ *
+ * Declares the analysis-specific pieces the shared lib/analysis-factory.js
+ * needs to reproduce the original app/fel/fel.js job-submission params exactly
+ * (pinned by test/golden/qsub-params.js).
+ */
+
+var factory = require("../../lib/analysis-factory.js");
+
+var descriptor = {
+  type: "fel",
+  dir: __dirname,
+  script: "fel.sh",
+  suffixes: { short: "fel", results: "FEL", progress: "fel" },
+  procsKey: "fel_procs",
+  walltimeKey: "fel_walltime",
+
+  // Set analysis-specific self.<field> values. In checkOnly mode `src` is the
+  // raw params; in normal mode it is params.analysis (or params). This mirrors
+  // the original fel.js branches.
+  fields: function (self, params, src) {
+    self.multiple_hits = src.multiple_hits || "None";
+    self.site_multihit = src.site_multihit || "Estimate";
+    self.branches = src.branches || "All";
+    self.bootstrap = src.bootstrap || false;
+    self.resample = src.resample || 1;
+
+    var isCheckOnly = params.checkOnly || false;
+    if (isCheckOnly) {
+      self.genetic_code = params.genetic_code || "Universal";
+      self.rate_variation = "No";
+      self.ci = "No";
+      self.nwk_tree = params.nwk_tree || params.tree || "";
+    } else {
+      if (self.params.msa) {
+        self.genetic_code = self.params.msa[0]
+          ? require("../code").code[self.params.msa[0].gencodeid + 1]
+          : "Universal";
+      } else {
+        self.genetic_code = self.params.genetic_code || "Universal";
+      }
+      if (self.params.analysis) {
+        self.nwk_tree =
+          self.params.analysis.tagged_nwk_tree || self.params.nwk_tree || self.params.tree;
+        self.rate_variation = self.params.analysis.ds_variation == 1 ? "Yes" : "No";
+        self.ci = self.params.analysis.ci == true ? "Yes" : "No";
+      } else {
+        self.nwk_tree = self.params.nwk_tree || self.params.tree || "";
+        self.rate_variation = self.params.rate_variation || "No";
+        self.ci = self.params.ci || "No";
+      }
+    }
+  },
+
+  // The {FG} tagged-tree special case.
+  afterFields: function (self) {
+    if (self.nwk_tree && self.nwk_tree.indexOf("{FG}") !== -1 && self.branches === "All") {
+      self.branches = "FG";
+    }
+  },
+
+  // The ordered export keys AFTER the common fn/tree_fn/sfn/pfn/rfn/treemode
+  // prefix — exactly matching the original fel.js order (golden-pinned).
+  exportKeys: [
+    ["bootstrap", function (self) { return self.bootstrap; }],
+    ["resample", function (self) { return self.resample; }],
+    ["genetic_code", function (self) { return self.genetic_code; }],
+    ["analysis_type", function (self) { return self.type; }],
+    ["rate_variation", function (self) { return self.rate_variation; }],
+    ["ci", function (self) { return self.ci; }],
+    ["cwd", function (self) { return __dirname; }],
+    ["msaid", function (self) { return self.msaid; }],
+    ["procs", function (self, config) { return config.fel_procs; }],
+    ["multiple_hits", function (self) { return self.multiple_hits; }],
+    ["site_multihit", function (self) { return self.site_multihit; }],
+    ["branches", function (self) { return self.branches; }]
+  ]
+};
+
+var fel = factory.makeAnalysis(descriptor);
+
+// Preserve the original module's export shape: exports.fel is the constructor.
+exports.fel = fel;
+exports.descriptor = descriptor;

--- a/lib/analysis-factory.js
+++ b/lib/analysis-factory.js
@@ -1,0 +1,205 @@
+/**
+ * analysis-factory.js — shared builder for the declarative HyPhy analyses.
+ *
+ * Phase 2 (#410) collapses the 14 near-identical analysis modules
+ * (fel, meme, slac, busted, absrel, relax, prime, fubar, fade, bgm, multihit,
+ * nrm, bstill, cfel) into one factory + per-analysis descriptors. Each of those
+ * modules today repeats the same shape:
+ *
+ *   1. read params (with defaults) into self.<field>, in a checkOnly branch and
+ *      a normal branch;
+ *   2. derive file paths (fn/output_dir/status_fn/results_short_fn/results_fn/
+ *      progress_fn/tree_fn) — identical except for a few suffixes;
+ *   3. build self.qsub_params for config.submit_type (local | slurm | qsub);
+ *   4. call self.init().
+ *
+ * This factory generates steps 2-4 from a descriptor; the descriptor supplies
+ * the analysis-specific bits of steps 1-3.
+ *
+ * IMPORTANT — byte-identical requirement: the generated qsub_params must match
+ * the pre-migration output exactly (test/golden/qsub-params.js pins this).
+ * The SLURM `--export=ALL,...` key ORDER is analysis-specific (analysis_type and
+ * genetic_code land in different positions per analysis), so the descriptor
+ * declares the FULL ordered export-key list rather than the factory assuming
+ * one. See a descriptor (e.g. app/fel/descriptor.js) for the shape.
+ *
+ * DESCRIPTOR SHAPE
+ * ----------------
+ * {
+ *   type: "fel",                       // self.type / analysis_type
+ *   dir: __dirname,                    // the analysis app dir (for cwd + script + output)
+ *   script: "fel.sh",                  // qsub_script_name
+ *   suffixes: {                        // file suffixes (results_short/results/progress)
+ *     short: "fel",                    // rfn -> <fn>.fel
+ *     results: "FEL",                  // results_fn -> <fn>.FEL.json
+ *     progress: "fel"                  // progress_fn -> <fn>.fel.progress
+ *   },
+ *   procsKey: "fel_procs",             // config.<procsKey> (fallback 4)
+ *   walltimeKey: "fel_walltime",       // config.<walltimeKey>
+ *   // Resolve analysis-specific self.<field> values. Called with (self, params,
+ *   // analysisParams, ctx) where ctx = { code, model }. Runs in BOTH checkOnly
+ *   // and normal mode; use params vs analysisParams as the module did.
+ *   fields: function (self, params, analysisParams, ctx) { ... set self.X ... },
+ *   // Ordered list of the analysis-specific export keys (between the common
+ *   // rfn/treemode prefix and the common cwd/msaid/procs — but note some
+ *   // analyses interleave analysis_type/genetic_code, so this list is the FULL
+ *   // ordered set AFTER treemode and BEFORE the --output flag). Each entry is
+ *   // [key, fn(self, config)] producing the value string.
+ *   exportKeys: [ ["bootstrap", function(self){ return self.bootstrap; }], ... ],
+ *   // Optional post-field hook (e.g. the {FG} tagged-tree branch override).
+ *   afterFields: function (self) { ... }
+ * }
+ */
+
+var path = require("path");
+var util = require("util");
+var config = require("../config.json");
+var logger = require("./logger").logger;
+var hyphyJob = require("../app/hyphyjob.js").hyphyJob;
+var code = require("../app/code").code;
+var model = require("../app/model").model;
+
+// Convert a PBS walltime (D:HH:MM:SS or HH:MM:SS) to SLURM format, matching the
+// per-analysis inline logic exactly.
+function toSlurmTime(walltime) {
+  var slurmTime = "72:00:00";
+  if (walltime) {
+    var parts = walltime.split(":");
+    if (parts.length === 4) {
+      var days = parseInt(parts[0]);
+      var hours = parseInt(parts[1]) + days * 24;
+      slurmTime = hours + ":" + parts[2] + ":" + parts[3];
+    } else if (parts.length === 3) {
+      slurmTime = walltime;
+    }
+  }
+  return slurmTime;
+}
+
+/**
+ * Build an analysis constructor from a descriptor. Returns a function usable as
+ * `new AnalysisCtor(socket, stream, params)` that behaves like the original
+ * hand-written module.
+ */
+function makeAnalysis(descriptor) {
+  var ctx = { code: code, model: model };
+
+  function Analysis(socket, stream, params) {
+    var self = this;
+    self.socket = socket;
+    self.stream = stream;
+    self.params = params;
+
+    var isCheckOnly = params.checkOnly || false;
+    self.type = descriptor.type;
+
+    // --- resolve analysis-specific fields (checkOnly reads params; normal reads
+    // analysisParams). The descriptor decides which; we pass both. ---
+    var analysisParams = isCheckOnly ? params : (self.params.analysis || self.params);
+    descriptor.fields(self, params, analysisParams, ctx);
+
+    // --- id / msaid / genetic_code / tree (the common fallback dance) ---
+    if (isCheckOnly) {
+      self.id = "check-" + Date.now();
+      self.msaid = "check";
+    } else {
+      if (self.params.msa) {
+        self.msaid = self.params.msa._id;
+      } else {
+        self.msaid = self.params.msaid || "unknown";
+      }
+      if (self.params.analysis) {
+        self.id =
+          self.params.analysis._id ||
+          (self.params.job && self.params.job.id) ||
+          self.params.id ||
+          "unknown-" + Date.now();
+      } else {
+        self.id =
+          (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
+      }
+    }
+
+    if (descriptor.afterFields) descriptor.afterFields(self);
+
+    // --- file-path derivation (identical across analyses except suffixes) ---
+    self.fn = descriptor.dir + "/output/" + self.id;
+    self.output_dir = path.dirname(self.fn);
+    self.status_fn = self.fn + ".status";
+    self.results_short_fn = self.fn + "." + descriptor.suffixes.short;
+    self.results_fn = self.fn + "." + descriptor.suffixes.results + ".json";
+    self.progress_fn = self.fn + "." + descriptor.suffixes.progress + ".progress";
+    self.tree_fn = self.fn + ".tre";
+
+    self.treemode = self.params.treemode || "0";
+
+    self.qsub_script_name = descriptor.script;
+    self.qsub_script = descriptor.dir + "/" + self.qsub_script_name;
+
+    self.qsub_params = buildQsubParams(self, descriptor);
+
+    self.init();
+  }
+
+  util.inherits(Analysis, hyphyJob);
+  return Analysis;
+}
+
+// Assemble the export="ALL,..." key=value string from the descriptor's ordered
+// list, preceded by the common prefix and using each entry's value fn.
+function buildExport(self, descriptor) {
+  var procs = config[descriptor.procsKey];
+  var pairs = [
+    "slurm_mpi_type=" + (config.slurm_mpi_type || "pmix"),
+    "fn=" + self.fn,
+    "tree_fn=" + self.tree_fn,
+    "sfn=" + self.status_fn,
+    "pfn=" + self.progress_fn,
+    "rfn=" + self.results_short_fn,
+    "treemode=" + self.treemode
+  ];
+  descriptor.exportKeys.forEach(function (entry) {
+    var key = entry[0];
+    var valFn = entry[1];
+    pairs.push(key + "=" + valFn(self, config, procs));
+  });
+  return "ALL," + pairs.join(",");
+}
+
+function buildQsubParams(self, descriptor) {
+  var procs = config[descriptor.procsKey] || 4;
+  if (config.submit_type === "slurm") {
+    var slurmTime = toSlurmTime(config[descriptor.walltimeKey]);
+    logger.info(
+      "Converted walltime from " + config[descriptor.walltimeKey] + " to SLURM format: " + slurmTime
+    );
+    return [
+      "--ntasks=" + procs,
+      "--cpus-per-task=1",
+      "--time=" + slurmTime,
+      "--partition=" + (config.slurm_partition || "datamonkey"),
+      "--nodes=1",
+      "--export=" + buildExport(self, descriptor),
+      "--output=" + self.output_dir + "/" + descriptor.type + "_" + self.id + "_%j.out",
+      "--error=" + self.output_dir + "/" + descriptor.type + "_" + self.id + "_%j.err",
+      self.qsub_script
+    ];
+  }
+  // local (and any non-slurm) path: script first, then bare key=val pairs.
+  var params = [self.qsub_script];
+  var procsLocal = config[descriptor.procsKey];
+  var pairs = [
+    "fn=" + self.fn,
+    "tree_fn=" + self.tree_fn,
+    "sfn=" + self.status_fn,
+    "pfn=" + self.progress_fn,
+    "rfn=" + self.results_short_fn,
+    "treemode=" + self.treemode
+  ];
+  descriptor.exportKeys.forEach(function (entry) {
+    pairs.push(entry[0] + "=" + entry[1](self, config, procsLocal));
+  });
+  return params.concat(pairs);
+}
+
+module.exports = { makeAnalysis: makeAnalysis, toSlurmTime: toSlurmTime };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "test": "npm run test:ci && npm run test:slurm",
-    "test:ci": "mocha -R spec --exit test/regression/leaks.js test/error-paths/validation.js test/validation/results.js test/mock/lifecycle.js test/golden/qsub-params.js test/sanitize-names.test.js test/difFubar.test.js test/difFubar.integration.test.js test/fubar-redirection.test.js",
+    "test:ci": "mocha -R spec --exit test/regression/leaks.js test/error-paths/validation.js test/validation/results.js test/mock/lifecycle.js test/golden/qsub-params.js test/golden/factory-parity.js test/sanitize-names.test.js test/difFubar.test.js test/difFubar.integration.test.js test/fubar-redirection.test.js",
     "test:slurm": "npm run test:analyses && npm run test:slurm-unit && npm run test:integration",
     "test:analyses": "mocha -R spec --exit test/absrel/absrel.js test/busted/busted.js test/contrast-fel/contrast-fel.js test/fade/fade.js test/fubar/fubar.js test/gard/gard.js test/hivtrace/hivtrace.js test/meme/meme.js test/multihit/multihit.js test/prime/prime.js test/relax/relax.js test/slac/slac.js",
     "test:slurm-unit": "mocha -R spec --exit test/jobstatus.js test/jobqueue.js test/coverage-gaps/job-lifecycle.js test/coverage-gaps/hivtrace-checkjob.js",

--- a/test/golden/factory-parity.js
+++ b/test/golden/factory-parity.js
@@ -1,0 +1,67 @@
+/**
+ * Factory parity test (Phase 2, #410).
+ *
+ * Proves that an analysis built by lib/analysis-factory.js from a descriptor
+ * produces qsub_params BYTE-IDENTICAL to the golden snapshot captured from the
+ * original hand-written module. This is the gate every batch-migration PR must
+ * pass: migrate an analysis to a descriptor, then this test confirms no drift.
+ *
+ * PR 2 wires only the fel descriptor as the proving case (fel.js itself is not
+ * yet switched over — that happens in the batch PRs). As each analysis gains a
+ * descriptor, add it to DESCRIPTORS below.
+ */
+
+var path = require("path"),
+    should = require("should"),
+    EventEmitter = require("events").EventEmitter,
+    config = require(__dirname + "/../../config.json");
+
+var ABS_ROOT = path.resolve(__dirname, "../..");
+var GOLDEN = require(__dirname + "/qsub-params.snapshot.json");
+
+// Descriptor-built constructors to check against golden. Grows as analyses migrate.
+var DESCRIPTORS = [
+  ["fel", require(__dirname + "/../../app/fel/descriptor.js").fel]
+];
+
+function fakeSocket() {
+  var s = new EventEmitter();
+  s.id = "golden";
+  s.disconnect = function () {};
+  s.emit = EventEmitter.prototype.emit.bind(s);
+  return s;
+}
+function mkParams() {
+  return {
+    checkOnly: true,
+    _id: "GOLDEN-ID",
+    analysis: { _id: "GOLDEN-ID" },
+    msa: [{ _id: "MSA-ID", nj: "(A,B);", gencodeid: 0 }],
+    genetic_code: "Universal"
+  };
+}
+function normalize(arr) {
+  return (arr || []).map(function (e) {
+    return String(e).split(ABS_ROOT).join("<ROOT>").replace(/check-\d+/g, "check-<TS>");
+  });
+}
+
+describe("golden: factory parity (Phase 2 migration gate)", function () {
+  this.timeout(20000);
+
+  after(function () { config.submit_type = "slurm"; });
+
+  DESCRIPTORS.forEach(function (d) {
+    var label = d[0], Ctor = d[1];
+    ["slurm", "local"].forEach(function (submitType) {
+      it(label + " factory build matches golden (" + submitType + ")", function () {
+        config.submit_type = submitType;
+        var job = new Ctor(fakeSocket(), ">A\nACGT\n", mkParams());
+        normalize(job.qsub_params).should.eql(
+          GOLDEN[label][submitType].qsub_params,
+          label + " " + submitType + " factory output drifted from golden"
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Second Phase 2 PR (#410). Adds the shared analysis factory and proves it byte-identical on one analysis. **No behavior change** — no existing analysis is switched over yet.

### What it adds
- **`lib/analysis-factory.js`** — `makeAnalysis(descriptor)` returns a constructor that reproduces the original per-analysis module shape: checkOnly/normal field resolution, the common file-path derivation, and the `local`/`slurm` `qsub_params`. The descriptor supplies the analysis-specific bits.
- **`app/fel/descriptor.js`** — the proving descriptor (type, suffixes, procs/walltime keys, field resolvers, the `{FG}` tagged-tree hook, and the ordered `exportKeys`).
- **`test/golden/factory-parity.js`** — asserts the factory-built fel produces `qsub_params` **byte-identical** to the golden snapshot (#421) for both slurm and local. This is the gate every batch-migration PR must pass.

### Key design decision
The SLURM `--export=ALL,...` key **order is analysis-specific** — `analysis_type` and `genetic_code` land in different positions per analysis (verified across fel/meme/slac). So descriptors declare the **full ordered `exportKeys` list** rather than the factory assuming a fixed layout. This is what makes byte-identical output achievable.

### Verification
- Factory-built fel matches golden **exactly** (slurm + local): `2 passing` in factory-parity.
- Wired into `test:ci`: **93 passing**, SLURM queue empty.
- `npm run lint` clean (factory is in the blocking `lib/` scope).

### Not in this PR (deliberately)
`app/fel/fel.js` still runs its original code — the descriptor is validated but dormant. The **batch-migration PRs (3-5)** switch each analysis to `require('./descriptor')`, delete the old body, and rely on the parity + submit-and-cancel tests. Doing the factory as its own no-wiring PR keeps it reviewable in isolation.