### PR TITLE
Phase 3 PR 3: JSDoc types + checkJs infrastructure (#410)

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,32 @@
+name: Typecheck
+
+on:
+  push:
+    branches: [feature/v4-modernization]
+  pull_request:
+    branches: [feature/v4-modernization, master]
+
+jobs:
+  typecheck:
+    name: JSDoc / checkJs (report-only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      # Report-only: the codebase has ~65 pre-existing checkJs findings (a mix
+      # of real shape issues and library-strictness false positives). Modules
+      # opt into checking with `// @ts-check` and are typed against lib/types.js.
+      # A follow-up will drive the count down and flip this to blocking. See #410.
+      - name: Typecheck (report-only)
+        run: npm run typecheck
+        continue-on-error: true

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,18 @@
+{
+  "//": "Type-checking config for JSDoc + checkJs (Phase 3, #410). Report-only in CI for now — the codebase has ~800 pre-existing implicit-any/shape errors; modules opt in with `// @ts-check` at the top and get checked against lib/types.js typedefs. Run: `npm run typecheck`.",
+  "compilerOptions": {
+    "checkJs": true,
+    "allowJs": true,
+    "noEmit": true,
+    "target": "ES2021",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "maxNodeModuleJsDepth": 0
+  },
+  "include": ["lib/**/*.js", "app/**/*.js", "server.js"],
+  "exclude": ["node_modules", "**/output/**", ".hyphy/**", ".python/**", "test/**"]
+}

--- a/lib/routes/analysis-routes.js
+++ b/lib/routes/analysis-routes.js
@@ -76,9 +76,11 @@ function standardHandlers(socket, name, Ctor, options) {
  * Register all analysis routes on a router (`r = new router.io(socket)`).
  * Reproduces the exact routes server.js declared by hand.
  *
- * @param {object} r       the per-socket router (lib/router.js io instance)
+ * @param {{ route: (name: string, handlers: object) => void }} r  the per-socket
+ *   router (lib/router.js io instance)
  * @param {object} socket  the connection socket
- * @param {object} deps    { hivtrace, flea } — the special analyses' constructors
+ * @param {{ hivtrace: { hivtrace: Function }, flea: { flea: Function } }} deps
+ *   the special analyses' constructor modules
  */
 function registerAnalysisRoutes(r, socket, deps) {
   ANALYSES.forEach(function (entry) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,81 @@
+/**
+ * lib/types.js — shared JSDoc type definitions (Phase 3, #410).
+ *
+ * The recurring bugs in this codebase were params-SHAPE bugs (msaid read from
+ * msa._id instead of msa[0]._id (#403); Contrast-FEL branch-sets (#395); the
+ * per-analysis tree-location routing). This file documents the canonical shapes
+ * as JSDoc @typedefs so `// @ts-check`-annotated modules get type-checking on
+ * the params they read — the exact place those bugs live.
+ *
+ * This module exports nothing at runtime; it exists purely for the types.
+ * Reference a type from another module with:
+ *   /** @typedef {import("./types").AnalysisParams} AnalysisParams *\/
+ * or, for a whole file, add `// @ts-check` at the top and annotate with
+ * `@param {import("./types").AnalysisParams} params`.
+ *
+ * The tree-routing quirk (see CLAUDE.md): different analyses read the tree from
+ * different locations —
+ *   - FEL/aBSREL/BUSTED/RELAX: params.analysis.tagged_nwk_tree || params.tree
+ *   - MEME/PRIME/SLAC:         params.msa[0].nj, then params.analysis.msa[0].usertree
+ * which is why several of these fields are optional.
+ */
+
+/**
+ * One multiple-sequence-alignment entry. Analyses read the tree and codon
+ * settings from here (msa[0]).
+ *
+ * @typedef {Object} MsaEntry
+ * @property {string} [_id]        MongoDB id of the alignment.
+ * @property {string} [nj]         Neighbor-joining tree (Newick).
+ * @property {string} [usertree]   User-supplied tree (preferred by MEME/PRIME/SLAC).
+ * @property {number} [gencodeid]  Genetic-code index (genetic_code = code[gencodeid+1]).
+ * @property {number} [datatype]   Datatype index (nucleotide/amino-acid/codon).
+ * @property {number} [sites]      Number of sites.
+ * @property {number} [sequences]  Number of sequences.
+ */
+
+/**
+ * The nested "analysis" sub-object (present in the unified data format). Some
+ * analyses read the tree / rate-variation flags from here.
+ *
+ * @typedef {Object} AnalysisSpec
+ * @property {string} [_id]                MongoDB id of the analysis (-> job id).
+ * @property {string} [tagged_nwk_tree]    Tree with {FG}/tag annotations.
+ * @property {MsaEntry[]} [msa]            Alignment(s) under analysis.
+ * @property {number} [ds_variation]       Synonymous-rate-variation flag (1 -> "Yes").
+ * @property {boolean} [ci]                Confidence-interval flag.
+ * @property {string} [submission_source]  Where the job came from (e.g. "mcp").
+ */
+
+/**
+ * The params object every analysis constructor receives as its 3rd argument
+ * (`new X(socket, stream, params)`). It is a union of the legacy flat shape and
+ * the unified {analysis, msa} shape, so most fields are optional; each analysis
+ * reads the subset it needs with `|| default` fallbacks.
+ *
+ * @typedef {Object} AnalysisParams
+ * @property {string} [_id]                 Job/analysis id (legacy flat form).
+ * @property {AnalysisSpec} [analysis]      Unified-format analysis sub-object.
+ * @property {MsaEntry[]} [msa]             Alignment(s) — msa[0] holds the tree/codon info.
+ * @property {string} [tree]                Tree merged in by the route layer.
+ * @property {string} [nwk_tree]            Alternate tree field.
+ * @property {string} [genetic_code]        e.g. "Universal".
+ * @property {string} [treemode]            "0" | "user".
+ * @property {boolean} [checkOnly]          Validate-only (no SLURM submission).
+ * @property {string} [msaid]               Alignment id (legacy).
+ * @property {string} [submission_source]   Job source tag.
+ * @property {(string[]|string)} [branch-set] Contrast-FEL branch groups (#395).
+ */
+
+/**
+ * The `{job, tree}` envelope the socket route layer receives from the frontend
+ * (server.js / lib/routes/analysis-routes.js). The route merges `tree` into a
+ * copy of `job` before constructing the analysis.
+ *
+ * @typedef {Object} SpawnRequest
+ * @property {AnalysisParams} job  The analysis params.
+ * @property {string} [tree]       Tree to merge into job.
+ * @property {string} [id]         Job id (used by resubscribe/cancel routes).
+ */
+
+module.exports = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "mocha": "^11.7.1",
         "prettier": "^3.9.5",
         "socket.io-client": "^4.5.4",
-        "socket.io-stream": "^0.9.1"
+        "socket.io-stream": "^0.9.1",
+        "typescript": "^7.0.2"
       },
       "engines": {
         "node": ">=18"
@@ -407,6 +408,346 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/abab": {
@@ -4801,6 +5142,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test-mcp": "npm run test:mcp",
     "lint": "eslint app lib server.js",
     "format:check": "prettier --check \"app/**/*.js\" \"lib/**/*.js\" server.js",
-    "coverage": "nyc --reporter=text --reporter=html --include 'app/**/*.js' --include 'lib/**/*.js' npm run test"
+    "coverage": "nyc --reporter=text --reporter=html --include 'app/**/*.js' --include 'lib/**/*.js' npm run test",
+    "typecheck": "tsc -p jsconfig.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
@@ -39,6 +40,7 @@
     "mocha": "^11.7.1",
     "prettier": "^3.9.5",
     "socket.io-client": "^4.5.4",
-    "socket.io-stream": "^0.9.1"
+    "socket.io-stream": "^0.9.1",
+    "typescript": "^7.0.2"
   }
 }


### PR DESCRIPTION
Final Phase 3 PR. Adds **type-checking infrastructure** via JSDoc + checkJs — no build step, no `.ts` renames, fully incremental. **Zero runtime effect** (checkJs is analysis-only; TypeScript is a devDependency).

### Why JSDoc + checkJs (not full TS)
The recurring bugs here were **params-shape bugs** — `msaid` read from `msa._id` instead of `msa[0]._id` (#403), Contrast-FEL branch-sets (#395), the per-analysis tree-location routing. JSDoc types on the params object catch exactly those, without the invasiveness of a `.ts` migration on a live backend.

### What's in it
- **`lib/types.js`** — JSDoc `@typedef`s for the canonical shapes: `AnalysisParams` (what every analysis constructor receives), `MsaEntry`, `AnalysisSpec`, `SpawnRequest`. Documents the `msa[0]`/`analysis`/tree-routing structure where the bugs live.
- **`jsconfig.json`** — `checkJs` on, `noImplicitAny: false` (suppresses the ~480 implicit-any noise so the signal is real shape issues), `maxNodeModuleJsDepth: 0` (don't check dependency `.js`). `npm run typecheck` runs it.
- **`.github/workflows/typecheck.yml`** — **report-only** CI (`continue-on-error`), matching the lint transition. ~63 pre-existing findings (a mix of real shape issues and zod/library-strictness false positives) shouldn't block CI on day one; a follow-up drives them down and flips to blocking.
- **`lib/routes/analysis-routes.js`** — tightened JSDoc param types as the first real annotation example.
- `typescript` added as a **devDependency** (the checkJs engine).

### Honest note on scope
I explored `// @ts-check`-cleaning individual modules and found it fights library-type strictness (zod's `invalid_type_error`, `Function`-not-constructable) — a real *incremental* effort, not a one-PR job. So this PR ships the **infrastructure + typedefs** and leaves per-module annotation as ongoing work (report-only CI makes that safe). The value: the capability exists, the canonical shapes are documented, and modules opt in over time.

### Verification
- **test:ci: 125 passing** (types don't touch runtime), `npm run lint`: **0 errors**, `npm run typecheck` runs and reports.

**With this, Phase 3 is complete.** `feature/v4-modernization` is then ready to merge to master as the v4 release.