### PR TITLE
Phase 4a: await terminal redis writes + remove delete-this litter (#410)

### DIFF
--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -325,21 +325,25 @@ hyphyJob.prototype.onComplete = function() {
         }
 
         // Store packet in redis and publish to channel
-        client.hSet(self.id, {
-          results: str_redis_packet,
-          status: "completed"
+        Promise.all([
+          client.hSet(self.id, {
+            results: str_redis_packet,
+            status: "completed"
+          }),
+          client.publish(self.id, str_redis_packet),
+          // Remove id from active_job queue
+          client.lRem("active_jobs", 1, self.id)
+        ]).catch(function(err) {
+          logger.error(
+            `[REDIS] Terminal completion write failed for job ${self.id} - job may be left as a zombie: ${err.message}`
+          );
         });
-        client.publish(self.id, str_redis_packet);
         logger.info(`[DEBUG REDIS] Published completion event to Redis channel: ${self.id}`);
 
-        // Remove id from active_job queue
-        client.lRem("active_jobs", 1, self.id);
         jobRegistry.unregister(self.id);
-        delete this;
       } else {
         // Empty results file
         self.onError("job seems to have completed, but no results found");
-        delete this;
       }
     }
   });
@@ -485,12 +489,18 @@ hyphyJob.prototype.onError = function(error) {
     self.warn("script error", str_redis_packet);
 
     // Publish error messages to redis
-    client.hSet(self.id, {
-      error: str_redis_packet,
-      status: "error"
+    Promise.all([
+      client.hSet(self.id, {
+        error: str_redis_packet,
+        status: "error"
+      }),
+      client.publish(self.id, str_redis_packet),
+      client.lRem("active_jobs", 1, self.id)
+    ]).catch(function(err) {
+      logger.error(
+        `[REDIS] Terminal error write failed for job ${self.id} - job may be left as a zombie: ${err.message}`
+      );
     });
-    client.publish(self.id, str_redis_packet);
-    client.lRem("active_jobs", 1, self.id);
     jobRegistry.unregister(self.id);
     // redis@5 lLen returns a promise instead of taking an (err, n) callback.
     client.lLen("active_jobs").then(function(n) {
@@ -498,8 +508,6 @@ hyphyJob.prototype.onError = function(error) {
     }).catch(function(err) {
       logger.error("Redis lLen active_jobs failed: " + err.message);
     });
-
-    delete this;
   });
 };
 


### PR DESCRIPTION
## Phase 4a (CORRECTNESS) — zombie-writes unit — #410

### Problem
In `app/hyphyjob.js`, `onComplete` (~:328) and `onError` (~:488) fired the terminal redis status-write sequence — `hSet(status)` / `publish` / `lRem("active_jobs")` — as fire-and-forget promises (redis@5 is promise-native). If any rejected on a redis hiccup, the job's status never reached `completed`/`error` and its id was never removed from `active_jobs`, silently leaving a **zombie job** with no diagnostic.

Additionally, three no-op `delete this;` statements (:338/:342/:502) were dead code — `jobRegistry.unregister(self.id)` above each already performs the real cleanup.

### Fix
- Wrap each terminal write trio in `Promise.all([...]).catch(...)` that logs a clear error naming the job id, so a redis failure is visible rather than producing a silent zombie.
- Remove the three no-op `delete this;` statements.

Minimal and behavior-preserving on the happy path; the method structure is otherwise unchanged.

### Verification
- `node -c app/hyphyjob.js` — OK
- `npm run test:ci` — **125 passing**, 1 pending, 0 failing
- `mocha --exit test/mcp/mcp.test.js` — **53 passing**
- `mocha --exit test/regression/leaks.js` — **5 passing**
- SLURM queue drained (0 leftover jobs)

Note: the fresh worktree lacks the gitignored `**/output` dirs; creating them (as they exist in the main checkout) is required for the difFUBAR validation tests to run — not related to this change.