### PR TITLE
Phase 4a: guard worker-crash vectors (JSON.parse + async writeFile throws) (#410)

### DIFF
--- a/app/absrel/descriptor.js
+++ b/app/absrel/descriptor.js
@@ -84,7 +84,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.nwk, function (err) {
       if (err) {
         logger.error("ABSREL job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("ABSREL job " + self.id + ": Tree file written successfully");
     });

--- a/app/busted/descriptor.js
+++ b/app/busted/descriptor.js
@@ -100,7 +100,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.nwk_tree, function (err) {
       if (err) {
         logger.error("BUSTED job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("BUSTED job " + self.id + ": Tree file written successfully");
     });

--- a/app/difFubar/difFubar.js
+++ b/app/difFubar/difFubar.js
@@ -178,7 +178,13 @@ var difFubar = function(socket, stream, params) {
 
   // Write tree to a file
   fs.writeFile(self.tree_fn, self.nwk_tree, function(err) {
-    if (err) throw err;
+    if (err) {
+      logger.error(`difFUBAR ${self.id}: Error writing tree file: ${err.message}`);
+      self.socket.emit("script error", {
+        error: "Failed to write tree file: " + err.message
+      });
+      return;
+    }
   });
 
   // Ensure the progress file exists

--- a/app/fel/descriptor.js
+++ b/app/fel/descriptor.js
@@ -85,7 +85,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.nwk_tree, function (err) {
       if (err) {
         logger.error("FEL job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("FEL job " + self.id + ": Tree file written successfully");
     });

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -204,9 +204,12 @@ hyphyJob.prototype.spawn = function() {
   fs.writeFile(self.fn, dataToWrite, err => {
     if (err) {
       logger.error(`Job ${self.id}: Error writing input file: ${err.message}`);
-      throw err;
+      self.socket.emit("script error", {
+        error: "Failed to write input file: " + err.message
+      });
+      return;
     }
-    
+
     logger.info(`Job ${self.id}: Input file written successfully, submitting job`);
     
     // Pass filename in as opposed to generating it in spawn_hyphyJob

--- a/app/meme/descriptor.js
+++ b/app/meme/descriptor.js
@@ -103,7 +103,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.selectedTree, function (err) {
       if (err) {
         logger.error("MEME job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("MEME job " + self.id + ": Tree file written successfully");
     });

--- a/app/prime/descriptor.js
+++ b/app/prime/descriptor.js
@@ -101,7 +101,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.selectedTree, function (err) {
       if (err) {
         logger.error("PRIME job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("PRIME job " + self.id + ": Tree file written successfully");
     });

--- a/app/relax/descriptor.js
+++ b/app/relax/descriptor.js
@@ -97,7 +97,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.nwk_tree, function (err) {
       if (err) {
         logger.error("RELAX job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("RELAX job " + self.id + ": Tree file written successfully");
     });

--- a/app/slac/descriptor.js
+++ b/app/slac/descriptor.js
@@ -84,7 +84,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.selectedTree, function (err) {
       if (err) {
         logger.error("SLAC job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("SLAC job " + self.id + ": Tree file written successfully");
     });

--- a/lib/clientsocket.js
+++ b/lib/clientsocket.js
@@ -52,12 +52,20 @@ ClientSocket.prototype.initializeServer = function() {
         logger.info(`[DEBUG REDIS] Received message on channel ${channel} for socket ${self.socket.id}`);
         logger.info(`[DEBUG REDIS] Message length: ${message.length} bytes`);
 
-        var redis_packet = JSON.parse(message);
-        logger.info(`[DEBUG REDIS] Message type: ${redis_packet.type}`);
-        logger.info("emitting " + message);
+        try {
+          var redis_packet = JSON.parse(message);
+          logger.info(`[DEBUG REDIS] Message type: ${redis_packet.type}`);
+          logger.info("emitting " + message);
 
-        self.socket.emit(redis_packet.type, redis_packet);
-        logger.info(`[DEBUG REDIS] Emitted ${redis_packet.type} event to client socket`);
+          self.socket.emit(redis_packet.type, redis_packet);
+          logger.info(`[DEBUG REDIS] Emitted ${redis_packet.type} event to client socket`);
+        } catch (err) {
+          // A malformed pub/sub message must not crash the worker. Log and drop it.
+          logger.error(
+            `Error handling Redis message on channel ${channel} for socket ${self.socket.id}: ${err.message}`
+          );
+          return;
+        }
       });
     })
     .catch(function(err) {


### PR DESCRIPTION
## Phase 4a — crash-guards unit (#410)

Correctness-only fix (no refactors). Closes two worker-crash vectors that could take down a PM2 worker on a single bad input.

### Changes

1. **`lib/clientsocket.js`** — wrap `JSON.parse(message)` and the following `self.socket.emit(...)` in try/catch inside the redis subscribe callback. A malformed pub/sub message now logs via `logger.error` and returns (message dropped) instead of throwing out of the async callback and crashing the worker. The successful path is byte-identical.

2. **Async `fs.writeFile` callbacks** — replaced `throw err` (which throws inside an async callback → uncaught → worker crash) with a graceful per-job failure: log the error and `self.socket.emit("script error", { error: "Failed to write <file>: " + err.message })`, then `return`. Success-path logging preserved. Covers:
   - `app/hyphyjob.js` (input file write)
   - `app/difFubar/difFubar.js` (tree file write)
   - `app/{fel,meme,slac,busted,absrel,relax,prime}/descriptor.js` (tree file write)

The 7 **sync** (`writeFileSync`) descriptors (fade/bgm/multihit/nrm/bstill/fubar/contrast-fel) are intentionally left untouched — their throw is caught by the router.

### Verification
- `node -c` clean on all 10 changed files.
- `npm run test:ci`: **125 passing**, 1 pending.
- `mocha --exit test/mcp/mcp.test.js`: **53 passing**.
- No leftover SLURM jobs (scancel run, `squeue` empty).