### PR TITLE
Phase 4a: fix MCP tools redis v3 API (get_job_status/results/cancel broken) (#410)

### DIFF
--- a/lib/mcp/tools.js
+++ b/lib/mcp/tools.js
@@ -233,14 +233,9 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: get_job_status job_id=" + args.job_id);
-        var jobData = await new Promise(function (resolve, reject) {
-          redisClient.hgetall(args.job_id, function (err, data) {
-            if (err) return reject(err);
-            resolve(data);
-          });
-        });
+        var jobData = await redisClient.hGetAll(args.job_id);
 
-        if (!jobData) {
+        if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP get_job_status: job_id=" + args.job_id + " not found");
           return {
             content: [{ type: "text", text: JSON.stringify({ status: "not_found" }) }]
@@ -303,14 +298,9 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: get_job_results job_id=" + args.job_id);
-        var jobData = await new Promise(function (resolve, reject) {
-          redisClient.hgetall(args.job_id, function (err, data) {
-            if (err) return reject(err);
-            resolve(data);
-          });
-        });
+        var jobData = await redisClient.hGetAll(args.job_id);
 
-        if (!jobData) {
+        if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP get_job_results: job_id=" + args.job_id + " not found");
           return {
             content: [{ type: "text", text: JSON.stringify({ error: "Job not found" }) }],
@@ -379,14 +369,9 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: cancel_job job_id=" + args.job_id);
-        var jobData = await new Promise(function (resolve, reject) {
-          redisClient.hgetall(args.job_id, function (err, data) {
-            if (err) return reject(err);
-            resolve(data);
-          });
-        });
+        var jobData = await redisClient.hGetAll(args.job_id);
 
-        if (!jobData) {
+        if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP cancel_job: job_id=" + args.job_id + " not found");
           return {
             content: [{ type: "text", text: JSON.stringify({ success: false, error: "Job not found" }) }],
@@ -435,8 +420,8 @@ function registerTools(mcpServer, redisClient) {
           });
         });
 
-        redisClient.hset(args.job_id, "status", "aborted");
-        redisClient.lrem("active_jobs", 1, args.job_id);
+        await redisClient.hSet(args.job_id, "status", "aborted");
+        await redisClient.lRem("active_jobs", 1, args.job_id);
 
         logger.info("MCP cancel_job: job_id=" + args.job_id + " cancelled (torque_id=" + torqueId + ")");
         return {

--- a/test/mcp/mcp.test.js
+++ b/test/mcp/mcp.test.js
@@ -14,19 +14,22 @@ const pkg = require("../../package.json");
 // ── Mock Redis ────────────────────────────────────────────────────────
 function createMockRedis(store) {
   return {
-    hgetall: function (id, cb) {
-      cb(null, store[id] || null);
+    // redis@5 promise API: hGetAll returns {} for a missing key (never null)
+    hGetAll: function (id) {
+      return Promise.resolve(store[id] || {});
     },
-    hset: function () {
+    hSet: function () {
       // record calls for assertions
       var args = Array.prototype.slice.call(arguments);
       this._hsetCalls = this._hsetCalls || [];
       this._hsetCalls.push(args);
+      return Promise.resolve();
     },
-    lrem: function () {
+    lRem: function () {
       var args = Array.prototype.slice.call(arguments);
       this._lremCalls = this._lremCalls || [];
       this._lremCalls.push(args);
+      return Promise.resolve();
     },
     _hsetCalls: [],
     _lremCalls: []


### PR DESCRIPTION
## Phase 4a — correctness fix (part of #410)

`lib/mcp/tools.js` used the **dead redis v3 callback API** (`hgetall`/`hset`/`lrem`), which throws at runtime under `redis@5` (promise-native, camelCase). Three MCP tools were broken in production:

- `get_job_status` (:237)
- `get_job_results` (:307)
- `cancel_job` (:383 read; :438/:439 write)

They only *appeared* to work because the MCP test mock provided a fake callback-style `hgetall`.

### Changes
- **`lib/mcp/tools.js`** (only source file touched):
  - Replace `await new Promise(cb => redisClient.hgetall(id, cb))` with `await redisClient.hGetAll(args.job_id)` in all three tools.
  - `redis@5` `hGetAll` returns `{}` (not `null`) for a missing key, so not-found is now `!jobData || Object.keys(jobData).length === 0`. Response payloads and error handling are otherwise identical.
  - `cancel_job`: `await redisClient.hSet(id, "status", "aborted")` and `await redisClient.lRem("active_jobs", 1, id)` so a failed terminal write is surfaced rather than leaving a zombie job.
- **`test/mcp/mcp.test.js`**: update the redis mock to the `redis@5` promise API (`hGetAll`/`hSet`/`lRem`, returns `{}` for missing keys) so the suite exercises the real code path.

### Verification
- `mocha --exit test/mcp/mcp.test.js`: **53 passing, 0 failing** (was 43 passing / 10 failing once the source was fixed against the old mock).
- `npm run test:ci`: **122 passing / 1 pending / 3 failing** — unchanged vs. the base branch. The 3 failures (`validation: derived parameters + results delivery`) are pre-existing on `feature/v4-modernization` and unrelated to this change (confirmed identical with the change stashed).
- Zero leftover SLURM jobs.

Refs #410.