### PR TITLE
Phase 4a: correctness & deploy-safety fixes (#410)

### DIFF
--- a/app/absrel/descriptor.js
+++ b/app/absrel/descriptor.js
@@ -84,7 +84,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.nwk, function (err) {
       if (err) {
         logger.error("ABSREL job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("ABSREL job " + self.id + ": Tree file written successfully");
     });

--- a/app/busted/descriptor.js
+++ b/app/busted/descriptor.js
@@ -100,7 +100,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.nwk_tree, function (err) {
       if (err) {
         logger.error("BUSTED job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("BUSTED job " + self.id + ": Tree file written successfully");
     });

--- a/app/difFubar/difFubar.js
+++ b/app/difFubar/difFubar.js
@@ -178,7 +178,13 @@ var difFubar = function(socket, stream, params) {
 
   // Write tree to a file
   fs.writeFile(self.tree_fn, self.nwk_tree, function(err) {
-    if (err) throw err;
+    if (err) {
+      logger.error(`difFUBAR ${self.id}: Error writing tree file: ${err.message}`);
+      self.socket.emit("script error", {
+        error: "Failed to write tree file: " + err.message
+      });
+      return;
+    }
   });
 
   // Ensure the progress file exists

--- a/app/fel/descriptor.js
+++ b/app/fel/descriptor.js
@@ -85,7 +85,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.nwk_tree, function (err) {
       if (err) {
         logger.error("FEL job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("FEL job " + self.id + ": Tree file written successfully");
     });

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -204,9 +204,12 @@ hyphyJob.prototype.spawn = function() {
   fs.writeFile(self.fn, dataToWrite, err => {
     if (err) {
       logger.error(`Job ${self.id}: Error writing input file: ${err.message}`);
-      throw err;
+      self.socket.emit("script error", {
+        error: "Failed to write input file: " + err.message
+      });
+      return;
     }
-    
+
     logger.info(`Job ${self.id}: Input file written successfully, submitting job`);
     
     // Pass filename in as opposed to generating it in spawn_hyphyJob

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -325,21 +325,25 @@ hyphyJob.prototype.onComplete = function() {
         }
 
         // Store packet in redis and publish to channel
-        client.hSet(self.id, {
-          results: str_redis_packet,
-          status: "completed"
+        Promise.all([
+          client.hSet(self.id, {
+            results: str_redis_packet,
+            status: "completed"
+          }),
+          client.publish(self.id, str_redis_packet),
+          // Remove id from active_job queue
+          client.lRem("active_jobs", 1, self.id)
+        ]).catch(function(err) {
+          logger.error(
+            `[REDIS] Terminal completion write failed for job ${self.id} - job may be left as a zombie: ${err.message}`
+          );
         });
-        client.publish(self.id, str_redis_packet);
         logger.info(`[DEBUG REDIS] Published completion event to Redis channel: ${self.id}`);
 
-        // Remove id from active_job queue
-        client.lRem("active_jobs", 1, self.id);
         jobRegistry.unregister(self.id);
-        delete this;
       } else {
         // Empty results file
         self.onError("job seems to have completed, but no results found");
-        delete this;
       }
     }
   });
@@ -485,12 +489,18 @@ hyphyJob.prototype.onError = function(error) {
     self.warn("script error", str_redis_packet);
 
     // Publish error messages to redis
-    client.hSet(self.id, {
-      error: str_redis_packet,
-      status: "error"
+    Promise.all([
+      client.hSet(self.id, {
+        error: str_redis_packet,
+        status: "error"
+      }),
+      client.publish(self.id, str_redis_packet),
+      client.lRem("active_jobs", 1, self.id)
+    ]).catch(function(err) {
+      logger.error(
+        `[REDIS] Terminal error write failed for job ${self.id} - job may be left as a zombie: ${err.message}`
+      );
     });
-    client.publish(self.id, str_redis_packet);
-    client.lRem("active_jobs", 1, self.id);
     jobRegistry.unregister(self.id);
     // redis@5 lLen returns a promise instead of taking an (err, n) callback.
     client.lLen("active_jobs").then(function(n) {
@@ -498,8 +508,6 @@ hyphyJob.prototype.onError = function(error) {
     }).catch(function(err) {
       logger.error("Redis lLen active_jobs failed: " + err.message);
     });
-
-    delete this;
   });
 };
 

--- a/app/meme/descriptor.js
+++ b/app/meme/descriptor.js
@@ -103,7 +103,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.selectedTree, function (err) {
       if (err) {
         logger.error("MEME job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("MEME job " + self.id + ": Tree file written successfully");
     });

--- a/app/prime/descriptor.js
+++ b/app/prime/descriptor.js
@@ -101,7 +101,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.selectedTree, function (err) {
       if (err) {
         logger.error("PRIME job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("PRIME job " + self.id + ": Tree file written successfully");
     });

--- a/app/relax/descriptor.js
+++ b/app/relax/descriptor.js
@@ -97,7 +97,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.nwk_tree, function (err) {
       if (err) {
         logger.error("RELAX job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("RELAX job " + self.id + ": Tree file written successfully");
     });

--- a/app/slac/descriptor.js
+++ b/app/slac/descriptor.js
@@ -84,7 +84,10 @@ var descriptor = {
     fs.writeFile(self.tree_fn, self.selectedTree, function (err) {
       if (err) {
         logger.error("SLAC job " + self.id + ": Error writing tree file: " + err.message);
-        throw err;
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
       }
       logger.info("SLAC job " + self.id + ": Tree file written successfully");
     });

--- a/lib/clientsocket.js
+++ b/lib/clientsocket.js
@@ -52,12 +52,20 @@ ClientSocket.prototype.initializeServer = function() {
         logger.info(`[DEBUG REDIS] Received message on channel ${channel} for socket ${self.socket.id}`);
         logger.info(`[DEBUG REDIS] Message length: ${message.length} bytes`);
 
-        var redis_packet = JSON.parse(message);
-        logger.info(`[DEBUG REDIS] Message type: ${redis_packet.type}`);
-        logger.info("emitting " + message);
+        try {
+          var redis_packet = JSON.parse(message);
+          logger.info(`[DEBUG REDIS] Message type: ${redis_packet.type}`);
+          logger.info("emitting " + message);
 
-        self.socket.emit(redis_packet.type, redis_packet);
-        logger.info(`[DEBUG REDIS] Emitted ${redis_packet.type} event to client socket`);
+          self.socket.emit(redis_packet.type, redis_packet);
+          logger.info(`[DEBUG REDIS] Emitted ${redis_packet.type} event to client socket`);
+        } catch (err) {
+          // A malformed pub/sub message must not crash the worker. Log and drop it.
+          logger.error(
+            `Error handling Redis message on channel ${channel} for socket ${self.socket.id}: ${err.message}`
+          );
+          return;
+        }
       });
     })
     .catch(function(err) {

--- a/lib/mcp/tools.js
+++ b/lib/mcp/tools.js
@@ -233,14 +233,9 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: get_job_status job_id=" + args.job_id);
-        var jobData = await new Promise(function (resolve, reject) {
-          redisClient.hgetall(args.job_id, function (err, data) {
-            if (err) return reject(err);
-            resolve(data);
-          });
-        });
+        var jobData = await redisClient.hGetAll(args.job_id);
 
-        if (!jobData) {
+        if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP get_job_status: job_id=" + args.job_id + " not found");
           return {
             content: [{ type: "text", text: JSON.stringify({ status: "not_found" }) }]
@@ -303,14 +298,9 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: get_job_results job_id=" + args.job_id);
-        var jobData = await new Promise(function (resolve, reject) {
-          redisClient.hgetall(args.job_id, function (err, data) {
-            if (err) return reject(err);
-            resolve(data);
-          });
-        });
+        var jobData = await redisClient.hGetAll(args.job_id);
 
-        if (!jobData) {
+        if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP get_job_results: job_id=" + args.job_id + " not found");
           return {
             content: [{ type: "text", text: JSON.stringify({ error: "Job not found" }) }],
@@ -379,14 +369,9 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: cancel_job job_id=" + args.job_id);
-        var jobData = await new Promise(function (resolve, reject) {
-          redisClient.hgetall(args.job_id, function (err, data) {
-            if (err) return reject(err);
-            resolve(data);
-          });
-        });
+        var jobData = await redisClient.hGetAll(args.job_id);
 
-        if (!jobData) {
+        if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP cancel_job: job_id=" + args.job_id + " not found");
           return {
             content: [{ type: "text", text: JSON.stringify({ success: false, error: "Job not found" }) }],
@@ -435,8 +420,8 @@ function registerTools(mcpServer, redisClient) {
           });
         });
 
-        redisClient.hset(args.job_id, "status", "aborted");
-        redisClient.lrem("active_jobs", 1, args.job_id);
+        await redisClient.hSet(args.job_id, "status", "aborted");
+        await redisClient.lRem("active_jobs", 1, args.job_id);
 
         logger.info("MCP cancel_job: job_id=" + args.job_id + " cancelled (torque_id=" + torqueId + ")");
         return {

--- a/test/mcp/mcp.test.js
+++ b/test/mcp/mcp.test.js
@@ -14,19 +14,22 @@ const pkg = require("../../package.json");
 // ── Mock Redis ────────────────────────────────────────────────────────
 function createMockRedis(store) {
   return {
-    hgetall: function (id, cb) {
-      cb(null, store[id] || null);
+    // redis@5 promise API: hGetAll returns {} for a missing key (never null)
+    hGetAll: function (id) {
+      return Promise.resolve(store[id] || {});
     },
-    hset: function () {
+    hSet: function () {
       // record calls for assertions
       var args = Array.prototype.slice.call(arguments);
       this._hsetCalls = this._hsetCalls || [];
       this._hsetCalls.push(args);
+      return Promise.resolve();
     },
-    lrem: function () {
+    lRem: function () {
       var args = Array.prototype.slice.call(arguments);
       this._lremCalls = this._lremCalls || [];
       this._lremCalls.push(args);
+      return Promise.resolve();
     },
     _hsetCalls: [],
     _lremCalls: []

--- a/test/mcp/mcp.test.js
+++ b/test/mcp/mcp.test.js
@@ -716,6 +716,142 @@ describe("MCP tools – validate_alignment", function () {
 });
 
 // =====================================================================
+// Suite 12: tools driven against a REAL redis@5 client (regression)
+// =====================================================================
+//
+// WHY THIS SUITE EXISTS
+// ---------------------
+// The mock in createMockRedis() implements the redis@5 promise API
+// (hGetAll/hSet/lRem returning promises). But a mock can drift from reality:
+// the ORIGINAL bug (#410) was that lib/mcp/tools.js called the DEAD redis v3
+// callback API (redisClient.hgetall(id, cb), redisClient.hset, redisClient.lrem),
+// which THROWS at runtime on the real redis@5 client — yet the old mock faked a
+// callback-style hgetall, so 53 unit tests stayed green while the real tools
+// were broken.
+//
+// This suite closes that gap: it requires the SAME shared client the production
+// server uses (lib/redis-client), seeds a real hash with hSet, and drives
+// get_job_status / get_job_results / cancel_job through registerTools() against
+// that real client. If the tools ever call a method the real client doesn't
+// expose (e.g. hgetall/hset), these assertions FAIL — proving the tools work on
+// the real API, not just the mock.
+//
+// It does NOT submit SLURM jobs and never reaches jobdel.jobDelete: it exercises
+// only the not_found / running / completed / already-aborted paths that read and
+// write redis directly.
+describe("MCP tools – live redis@5 client (regression #410)", function () {
+  this.timeout(10000);
+
+  var redisMod = require("../../lib/redis-client");
+  var realClient = redisMod.client;
+  var mcpServer;
+  var seededIds = [];
+
+  // Unique key prefix so we never collide with real jobs / other test runs.
+  var prefix = "mcp-live-test-" + process.pid + "-" + Date.now() + "-";
+  var idStatus = prefix + "status";
+  var idResults = prefix + "results";
+  var idAborted = prefix + "aborted";
+
+  async function seed(id, hash) {
+    await realClient.hSet(id, hash);
+    seededIds.push(id);
+  }
+
+  before(async function () {
+    await redisMod.ready;
+
+    // A running job with a torque_id and a live status line.
+    await seed(idStatus, {
+      status: "running",
+      torque_id: JSON.stringify({ torque_id: "77777.scheduler" }),
+      current_status: "Phase 3 of 4"
+    });
+
+    // A completed job with double-nested results, exactly as onComplete writes.
+    var inner = JSON.stringify({ sites: [10, 20, 30] });
+    await seed(idResults, {
+      status: "completed",
+      results: JSON.stringify({ results: inner, type: "completed" })
+    });
+
+    // An already-aborted job — cancel_job should short-circuit without touching
+    // the scheduler, so this stays inside the redis-only code path.
+    await seed(idAborted, {
+      status: "aborted"
+    });
+
+    mcpServer = new McpServer(
+      { name: "test", version: "1.0.0" },
+      { capabilities: { tools: {} } }
+    );
+    // Register the tools against the REAL shared redis@5 client.
+    registerTools(mcpServer, realClient);
+  });
+
+  after(async function () {
+    // Remove every hash this suite created; leave redis as we found it.
+    for (var i = 0; i < seededIds.length; i++) {
+      try {
+        await realClient.del(seededIds[i]);
+      } catch (e) {
+        /* best-effort cleanup */
+      }
+    }
+  });
+
+  it("get_job_status returns not_found for a missing job (real hGetAll -> {})", async function () {
+    var result = await callTool(mcpServer, "get_job_status", {
+      job_id: prefix + "missing"
+    });
+    var parsed = JSON.parse(result.content[0].text);
+    expect(parsed.status).to.equal("not_found");
+  });
+
+  it("get_job_status reads a real seeded hash and parses torque_id", async function () {
+    var result = await callTool(mcpServer, "get_job_status", {
+      job_id: idStatus
+    });
+    expect(result.isError).to.not.be.true;
+    var parsed = JSON.parse(result.content[0].text);
+    expect(parsed.status).to.equal("running");
+    expect(parsed.torque_id).to.equal("77777.scheduler");
+    expect(parsed.current_status).to.equal("Phase 3 of 4");
+  });
+
+  it("get_job_results unwraps double-nested results from a real hash", async function () {
+    var result = await callTool(mcpServer, "get_job_results", {
+      job_id: idResults
+    });
+    expect(result.isError).to.not.be.true;
+    var parsed = JSON.parse(result.content[0].text);
+    expect(parsed).to.deep.equal({ sites: [10, 20, 30] });
+  });
+
+  it("cancel_job on an already-aborted job succeeds without a real hSet/lRem write", async function () {
+    var result = await callTool(mcpServer, "cancel_job", {
+      job_id: idAborted
+    });
+    expect(result.isError).to.not.be.true;
+    var parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).to.be.true;
+    expect(parsed.message).to.equal("Job already cancelled");
+  });
+
+  it("cancel_job hSet/lRem exist and resolve on the real redis@5 client", async function () {
+    // Directly prove the two write commands cancel_job uses on its success path
+    // (hSet status=aborted, lRem active_jobs) are the redis@5 promise API and
+    // do NOT throw the way the removed v3 hset/lrem would have.
+    expect(realClient.hSet).to.be.a("function");
+    expect(realClient.lRem).to.be.a("function");
+    await realClient.hSet(idStatus, "status", "aborted");
+    await realClient.lRem("active_jobs", 1, idStatus);
+    var back = await realClient.hGetAll(idStatus);
+    expect(back.status).to.equal("aborted");
+  });
+});
+
+// =====================================================================
 // Suite 11: tools – spawn_analysis with validation
 // =====================================================================
 describe("MCP tools – spawn_analysis with validation", function () {


### PR DESCRIPTION
## Phase 4a — correctness & deploy-safety fixes (#410)

Integration branch merging the three Phase 4a fix sub-branches, plus a regression test that would have caught the MCP bug. **Correctness only — no refactors.**

### What landed

**1. MCP tools use the dead redis v3 API (`v4/phase4a-mcp-redis`)**
`lib/mcp/tools.js` `get_job_status` / `get_job_results` / `cancel_job` called `redisClient.hgetall(id, cb)` / `hset` / `lrem` — the redis **v3** callback API. redis@5 has no such methods, so every one of these tools **threw at runtime** in production. Switched to the redis@5 promise API (`hGetAll` / `hSet` / `lRem`).

Why the bug hid: the MCP test mock faked a callback-style `hgetall`, so 53 tests stayed green against an API the real client doesn't have.

**2. Worker-crash guards (`v4/phase4a-crash-guards`)**
- `lib/clientsocket.js`: the pub/sub `JSON.parse(message)` in the subscribe callback was unguarded — a single malformed message crashed the PM2 worker. Now wrapped in try/catch: bad messages are logged and dropped, valid ones still emit.
- Async `fs.writeFile` callbacks that did `throw err` (which kills the worker) now emit a `script error` and return: `app/hyphyjob.js` (spawn input file), `app/difFubar/difFubar.js` (tree file), and the 7 async descriptors (`fel`/`meme`/`slac`/`busted`/`absrel`/`relax`/`prime`). The 7 sync `writeFileSync` descriptors were left untouched (their throw is already router-caught).

**3. Zombie terminal writes (`v4/phase4a-zombie-writes`)**
`hyphyjob.onComplete` / `onError` fired the terminal redis status writes (`hSet` / `publish` / `lRem`) without awaiting — a failed write silently left a zombie job. Now wrapped in `Promise.all([...]).catch(...)` so a failed terminal write is logged. Also removed the three no-op `delete this;` statements (already covered by `jobRegistry.unregister`).

The `hyphyjob.js` overlap between crash-guards (spawn write) and zombie-writes (onComplete/onError) auto-merged cleanly into disjoint regions; both fixes are present.

### New regression test
`test/mcp/mcp.test.js`: mock corrected to the redis@5 promise shape, plus a new **live redis@5 suite** that requires the shared `lib/redis-client`, seeds a real hash, and drives `get_job_status` / `get_job_results` / `cancel_job` through `registerTools` against the real client. Verified it fails with `redisClient.hgetall is not a function` when the v3 API is reintroduced.

### Verification
- `npm run test:ci` — **125 passing**
- `npm run test:mcp` — **58 passing** (was 53; +5 live-redis)
- `test/regression/leaks.js` — **5 passing**
- `npm run lint` — **0 errors** (31 pre-existing warnings)
- `node -c` clean on all changed files
- **Functional crash-guard proofs:**
  - (a) publishing 3 malformed (non-JSON) messages to a `ClientSocket` channel via real redis pub/sub does **not** crash the process, and a subsequent valid message is still emitted. Confirmed the harness FAILS against the unguarded code.
  - (b) an async `writeFile` failure in `hyphyjob.spawn` emits `script error` (`"Failed to write input file: ..."`) instead of throwing.
- Zero leaked SLURM jobs (`squeue` empty).