### PR TITLE
Phase 4b: fix SLURM-leaking + racy jobqueue/jobstatus tests (#410)

### DIFF
--- a/test/helpers/slurm-cleanup.js
+++ b/test/helpers/slurm-cleanup.js
@@ -1,0 +1,87 @@
+/**
+ * slurm-cleanup.js — SLURM-leak backstop for the real-scheduler test suites.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS EXISTS
+ * ---------------------------------------------------------------------------
+ * test/jobqueue.js and test/jobstatus.js submit real jobs to the live
+ * `datamonkey` SLURM partition (multi-day walltimes). Their per-suite cleanup
+ * used a fire-and-forget `spawn('scancel', ids)` in an `after`/`afterEach`
+ * hook. Under `mocha --exit`, mocha force-kills the process the instant the
+ * last test's callback returns — before the detached `scancel` child has a
+ * chance to run — so the submitted jobs SURVIVE on the partition. A crashing
+ * test (throw before its own cleanup) leaks the same way.
+ *
+ * This module provides two things:
+ *
+ *   1. `track(id)` — register a slurm job id the moment it is known, so it can
+ *      be cleaned up even if the test that created it never reaches its own
+ *      afterEach/after (e.g. it throws or times out).
+ *
+ *   2. A mocha ROOT-LEVEL `after` hook (registered on require) that runs a
+ *      single BLOCKING `execSync('scancel <tracked ids>')` after ALL suites in
+ *      the process finish. Because it is synchronous, it completes before
+ *      `--exit` tears the process down. It is intentionally conservative: it
+ *      only cancels the specific ids this suite tracked (never `scancel -u`,
+ *      never other users' jobs).
+ *
+ * The per-suite hooks in jobqueue.js / jobstatus.js ALSO switch to a blocking
+ * `execSync` scancel; this root hook is a backstop for ids that slipped past
+ * those hooks (crashes, untracked-but-registered ids).
+ */
+var execSync = require("child_process").execSync;
+
+// Set of slurm job ids (as strings) that this test process has submitted and
+// is responsible for cancelling.
+var tracked = new Set();
+
+/**
+ * Register a slurm job id for backstop cleanup. Ids are normalized to strings
+ * so lookups line up regardless of numeric/string origin.
+ * @param {string|number} id
+ */
+function track(id) {
+  if (id === null || id === undefined) return;
+  tracked.add(String(id));
+}
+
+/**
+ * Forget an id once the owning test has already cancelled it (keeps the
+ * backstop's scancel list minimal). Safe to call with an unknown id.
+ * @param {string|number} id
+ */
+function untrack(id) {
+  if (id === null || id === undefined) return;
+  tracked.delete(String(id));
+}
+
+/**
+ * Blocking cancel of the supplied ids (defaults to everything tracked). Wrapped
+ * so a scancel failure (e.g. job already gone) never fails the suite. Returns
+ * the list of ids it attempted to cancel.
+ * @param {Array<string|number>} [ids]
+ * @returns {string[]}
+ */
+function cancel(ids) {
+  var list = (ids || Array.from(tracked)).map(String).filter(Boolean);
+  if (!list.length) return [];
+  try {
+    // Blocking so it finishes before mocha's `--exit` kills the process.
+    execSync("scancel " + list.join(" "), { stdio: "ignore" });
+  } catch (e) {
+    // Best-effort: job may already be gone / cancelled. Do not fail cleanup.
+  }
+  list.forEach(untrack);
+  return list;
+}
+
+// Mocha root-level backstop. Registering a top-level `after` (outside any
+// describe) attaches it to the root suite, so it runs once after every suite
+// in the process — even if an individual test crashed before its own cleanup.
+if (typeof after === "function") {
+  after(function slurmCleanupBackstop() {
+    cancel();
+  });
+}
+
+module.exports = { track: track, untrack: untrack, cancel: cancel };

--- a/test/jobqueue.js
+++ b/test/jobqueue.js
@@ -1,9 +1,11 @@
 var fs = require('fs'),
     spawn = require('child_process').spawn,
+    execSync = require('child_process').execSync,
     should = require('should'),
     path = require('path'),
     redisClient = require('../lib/redis-client.js'),
-    config = require('../lib/config');
+    config = require('../lib/config'),
+    slurmCleanup = require('./helpers/slurm-cleanup');
 
 // redis@5 migration: reuse the shared connected client from lib/redis-client.js
 // (was `redis.createClient({host,port})`); commands are camelCased and
@@ -43,6 +45,9 @@ describe('job queue', function() {
         if (match) {
           var slurm_id = match[1];
           submitted_ids.push(slurm_id);
+          // Register with the root-hook backstop the instant the id is known,
+          // so a crash before `after()` still gets this job cancelled.
+          slurmCleanup.track(slurm_id);
           // redis@5: hset->hSet, promise-returning; swallow errors for this
           // best-effort seed (v5 buffers until the shared socket connects).
           client.hSet(slurm_id, 'type', 'test').catch(function () {});
@@ -55,19 +60,37 @@ describe('job queue', function() {
 
   after(function() {
     if (submitted_ids.length) {
-      spawn('scancel', submitted_ids);
+      // BLOCKING cancel: the previous fire-and-forget `spawn('scancel', ids)`
+      // was force-killed by `mocha --exit` before it ran, leaking jobs onto the
+      // live partition. execSync completes before the process exits.
+      try {
+        execSync('scancel ' + submitted_ids.join(' '), { stdio: 'ignore' });
+      } catch (e) {
+        // Best-effort: jobs may already be gone; do not fail the suite.
+      }
+      submitted_ids.forEach(function (id) { slurmCleanup.untrack(id); });
     }
   });
 
   it('return the job queue', function(done) {
     JobQueue(function(jobs) {
-      jobs[0].should.have.property('id');
-      jobs[0].should.have.property('status');
-      jobs[0].should.have.property('creation_time');
-      jobs[0].should.have.property('start_time');
-      jobs[0].should.have.property('type');
-      jobs[0].should.have.property('sites');
-      jobs[0].should.have.property('sequences');
+      // The live SLURM queue is unfiltered and may contain jobs from other
+      // users / other tests, so asserting on jobs[0] is racy. Instead find
+      // THIS suite's own submitted job and assert on it. returnSlurmJobInfo
+      // sets `id` to squeue's %i (the sbatch-printed slurm id), so match on it.
+      var mine = jobs.find(function (j) {
+        return submitted_ids.indexOf(j.id) !== -1 ||
+               submitted_ids.indexOf(String(j.id)) !== -1;
+      });
+      should.exist(mine, 'none of this suite\'s submitted jobs appeared in the queue: ' +
+        JSON.stringify(submitted_ids));
+      mine.should.have.property('id');
+      mine.should.have.property('status');
+      mine.should.have.property('creation_time');
+      mine.should.have.property('start_time');
+      mine.should.have.property('type');
+      mine.should.have.property('sites');
+      mine.should.have.property('sequences');
       done();
     });
   });

--- a/test/jobstatus.js
+++ b/test/jobstatus.js
@@ -1,18 +1,27 @@
-var spawn   = require('child_process').spawn,
-    winston = require('winston'),
-    should  = require('should');
+var spawn    = require('child_process').spawn,
+    execSync = require('child_process').execSync,
+    winston  = require('winston'),
+    should   = require('should');
 
 var JobStatus = require(__dirname + '/../lib/jobstatus.js').JobStatus;
+var slurmCleanup = require('./helpers/slurm-cleanup');
 
 describe('job status', function() {
 
   var jobId = null;
 
   // Ensure any submitted SLURM job is cancelled so it does not occupy the
-  // datamonkey partition (jobs have a multi-day walltime).
+  // datamonkey partition (jobs have a multi-day walltime). BLOCKING execSync:
+  // the previous fire-and-forget `spawn('scancel', [jobId])` was force-killed
+  // by `mocha --exit` before it ran, leaking the job onto the live partition.
   afterEach(function() {
     if (jobId) {
-      spawn('scancel', [jobId]);
+      try {
+        execSync('scancel ' + jobId, { stdio: 'ignore' });
+      } catch (e) {
+        // Best-effort: job may already be gone; do not fail the suite.
+      }
+      slurmCleanup.untrack(jobId);
       jobId = null;
     }
   });
@@ -40,6 +49,9 @@ describe('job status', function() {
       should.exist(match, 'could not parse job id from: ' + out);
       var id = match[1];
       jobId = id;
+      // Register with the root-hook backstop the instant the id is known, so a
+      // crash/timeout before afterEach still gets this job cancelled.
+      slurmCleanup.track(id);
       winston.info('submitted SLURM job ' + id);
 
       var job_status = new JobStatus(id);


### PR DESCRIPTION
Phase 4b of the v4 modernization (#410) — **test hygiene only, no production-code changes**. Targets `feature/v4-modernization` (not master).

## Problem
`test/jobqueue.js` and `test/jobstatus.js` submit real jobs to the live `datamonkey` SLURM partition (multi-day walltimes). Both cleaned up with a fire-and-forget `spawn('scancel', ids)` in an `after`/`afterEach` hook. Under `mocha --exit`, mocha force-kills the process the instant the last test callback returns — before the detached `scancel` child runs — so **submitted jobs survived on the partition**. A crashing/timing-out test leaked the same way. `test/jobqueue.js` also asserted on `jobs[0]` of the unfiltered live squeue, which can contain other users'/other tests' jobs (racy).

## Changes
- **test/jobqueue.js `after()`** — fire-and-forget `spawn('scancel', ids)` → BLOCKING `execSync('scancel ...')` in try/catch, so cleanup completes before `--exit` tears the process down.
- **test/jobqueue.js assertion** — instead of racy `jobs[0]`, find THIS suite's own submitted job (`returnSlurmJobInfo`'s `id` == squeue `%i`, matched against `submitted_ids`) and assert the properties on `mine` after `should.exist(mine)`.
- **test/jobstatus.js `afterEach()`** — same blocking `execSync` scancel fix.
- **test/helpers/slurm-cleanup.js (new)** — mocha ROOT-level `after` backstop that blocking-`scancel`s a tracked id-set, so a crashed/timed-out test still cleans up. Conservative: only cancels ids this suite registered via `track()` (never `scancel -u`, never other users' jobs). Both suites `track()` ids the moment `sbatch` prints them and `untrack()` after their own cancel.

## Verification
`jobqueue.js` and `jobstatus.js` each run 3× (plus one combined run) on the live `datamonkey` partition — all passing. `squeue -u sweaver` **empty after every run**.