### PR TITLE
Phase 4b: add golden coverage for bespoke analyses gard/difFubar/hivtrace (#410)

### DIFF
--- a/test/golden/qsub-params.js
+++ b/test/golden/qsub-params.js
@@ -28,6 +28,7 @@ var fs = require("fs"),
   config = require(__dirname + "/../../lib/config");
 
 var ABS_ROOT = path.resolve(__dirname, "../..");
+var HOME = require("os").homedir();
 var SNAPSHOT = path.join(__dirname, "qsub-params.snapshot.json");
 
 // The 14 declarative-candidate analyses: [label, module path, export key].
@@ -72,6 +73,7 @@ function normalize(arr) {
   return (arr || []).map(function (entry) {
     return String(entry)
       .split(ABS_ROOT).join("<ROOT>")
+      .split(HOME).join("<HOME>")
       .replace(/check-\d+/g, "check-<TS>");
   });
 }
@@ -88,11 +90,141 @@ function capture(modPath, exportKey, submitType) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Bespoke analyses (gard, difFubar, hivtrace).
+//
+// These are NOT part of the 14-analysis factory family and each is captured
+// specially:
+//   - gard      : supports checkOnly, so it routes through hyphyJob.init() ->
+//                 validateParameters() and never submits (like the factory
+//                 analyses). It exposes self.qsub_params.
+//   - difFubar  : has NO checkOnly branch of its own, but its constructor ends
+//                 in self.init() (inherited from hyphyJob), which DOES honour
+//                 params.checkOnly and routes to validateParameters() instead
+//                 of spawn(). So passing checkOnly:true captures qsub_params
+//                 without submitting a SLURM job. It exposes self.qsub_params.
+//   - hivtrace  : does NOT honour checkOnly at all — its constructor
+//                 unconditionally calls self.spawn(), which submits via sbatch.
+//                 We therefore STUB hivtrace.prototype.spawn to a no-op so the
+//                 constructor builds params but nothing is submitted. hivtrace
+//                 builds BOTH self.qsub_params (torque) AND self.slurm_params
+//                 (SLURM); for slurm mode we snapshot self.slurm_params (the
+//                 field its sbatch path actually submits).
+// ---------------------------------------------------------------------------
+
+var GARD_PATH = "../../app/gard/gard.js";
+var DIFFUBAR_PATH = "../../app/difFubar/difFubar.js";
+var HIVTRACE_PATH = "../../app/hivtrace/hivtrace.js";
+
+function captureGard(submitType) {
+  config.submit_type = submitType;
+  var Ctor = require(GARD_PATH).gard;
+  // checkOnly:true -> init() -> validateParameters(), never submits.
+  // We pass ONLY genetic_code + tree so GARD's own defaults (rate_classes,
+  // run_mode, datatype, max_breakpoints, model, site_to_site_variation) are
+  // exercised — that is what makes the mutation-check meaningful: flipping any
+  // GARD param default drifts this snapshot.
+  var job = new Ctor(fakeSocket(), ">A\nACGT\n", {
+    checkOnly: true,
+    genetic_code: "Universal",
+    nwk_tree: "(A,B);"
+  });
+  return {
+    type: job.type,
+    resultsSuffix: job.results_fn
+      ? path.basename(job.results_fn).replace(/^check-\d+\.?/, "")
+      : null,
+    field: "qsub_params",
+    qsub_params: normalize(job.qsub_params)
+  };
+}
+
+function captureDifFubar(submitType) {
+  config.submit_type = submitType;
+  var Ctor = require(DIFFUBAR_PATH).difFubar;
+  // difFubar has no checkOnly of its own, but the inherited init() honours it:
+  // checkOnly:true routes to validateParameters() and NEVER submits. A stable
+  // _id avoids any volatile timestamp in the snapshot.
+  var job = new Ctor(fakeSocket(), ">A\nACGT\n", {
+    checkOnly: true,
+    analysis: {
+      _id: "GOLDEN-ID",
+      number_of_grid_points: 20,
+      concentration_of_dirichlet_prior: 0.5,
+      mcmc_iterations: 2500,
+      burnin_samples: 500,
+      pos_threshold: 0.95
+    },
+    msa: [{ _id: "MSA-ID", nj: "(A,B);" }]
+  });
+  return {
+    type: job.type,
+    resultsSuffix: job.results_fn ? path.basename(job.results_fn) : null,
+    field: "qsub_params",
+    qsub_params: normalize(job.qsub_params)
+  };
+}
+
+function captureHivtrace(submitType) {
+  config.submit_type = submitType;
+  var mod = require(HIVTRACE_PATH);
+  var Ctor = mod.hivtrace;
+  // hivtrace does NOT honour checkOnly; its constructor unconditionally calls
+  // self.spawn() which submits via sbatch. STUB spawn so nothing is submitted
+  // while the constructor still builds qsub_params + slurm_params.
+  var origSpawn = Ctor.prototype.spawn;
+  Ctor.prototype.spawn = function () {};
+  var job;
+  try {
+    job = new Ctor(fakeSocket(), new EventEmitter(), {
+      _id: "GOLDEN-ID",
+      distance_threshold: 0.015,
+      ambiguity_handling: "Resolve",
+      fraction: 0.05,
+      reference: "HXB2_prrt",
+      filter_edges: "no",
+      reference_strip: "no",
+      min_overlap: 500,
+      status_stack: [],
+      lanl_compare: "no",
+      prealigned: "no",
+      strip_drams: "no"
+    });
+  } finally {
+    Ctor.prototype.spawn = origSpawn;
+  }
+  // hivtrace builds self.slurm_params for its sbatch path and self.qsub_params
+  // for torque. For slurm mode we snapshot the field it actually submits.
+  var field = submitType === "slurm" ? "slurm_params" : "qsub_params";
+  return {
+    type: job.type,
+    resultsSuffix: null,
+    field: field,
+    qsub_params: normalize(job[field])
+  };
+}
+
 describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
   this.timeout(20000);
 
+  // Bespoke analyses, keyed by label -> capture function. difFubar's
+  // constructor synchronously opens its progress file, so its output dir must
+  // exist before construction; ensure the output dirs for all three.
+  var utilities = require("../../lib/utilities");
+  var BESPOKE = {
+    gard: captureGard,
+    difFubar: captureDifFubar,
+    hivtrace: captureHivtrace
+  };
+  var BESPOKE_LABELS = Object.keys(BESPOKE);
+  var ALL_LABELS = ANALYSES.map(function (a) { return a[0]; }).concat(BESPOKE_LABELS);
+
   var current = {};
   before(function () {
+    utilities.ensureDirectoryExists(path.join(ABS_ROOT, "app/gard/output"));
+    utilities.ensureDirectoryExists(path.join(ABS_ROOT, "app/difFubar/output"));
+    utilities.ensureDirectoryExists(path.join(ABS_ROOT, "app/hivtrace/output"));
+
     ANALYSES.forEach(function (a) {
       var label = a[0], modPath = a[1], key = a[2];
       current[label] = {
@@ -100,15 +232,22 @@ describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
         local: capture(modPath, key, "local")
       };
     });
+    BESPOKE_LABELS.forEach(function (label) {
+      var fn = BESPOKE[label];
+      current[label] = {
+        slurm: fn("slurm"),
+        local: fn("local")
+      };
+    });
     // restore a sane default so later suites aren't affected
     config.submit_type = "slurm";
   });
 
-  it("captures all 14 analyses for slurm and local", function () {
-    Object.keys(current).length.should.equal(14);
-    ANALYSES.forEach(function (a) {
-      current[a[0]].slurm.qsub_params.length.should.be.above(0);
-      current[a[0]].local.qsub_params.length.should.be.above(0);
+  it("captures all 14 factory + 3 bespoke analyses for slurm and local", function () {
+    Object.keys(current).length.should.equal(17);
+    ALL_LABELS.forEach(function (label) {
+      current[label].slurm.qsub_params.length.should.be.above(0);
+      current[label].local.qsub_params.length.should.be.above(0);
     });
   });
 
@@ -117,13 +256,12 @@ describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
       fs.writeFileSync(SNAPSHOT, JSON.stringify(current, null, 2) + "\n");
       // Sanity: file is valid + non-trivial.
       var written = JSON.parse(fs.readFileSync(SNAPSHOT, "utf8"));
-      Object.keys(written).length.should.equal(14);
+      Object.keys(written).length.should.equal(17);
     });
   } else {
     it("matches the committed golden snapshot (byte-for-byte per analysis)", function () {
       var golden = JSON.parse(fs.readFileSync(SNAPSHOT, "utf8"));
-      ANALYSES.forEach(function (a) {
-        var label = a[0];
+      ALL_LABELS.forEach(function (label) {
         should.exist(golden[label], "missing golden entry for " + label);
         current[label].slurm.qsub_params.should.eql(
           golden[label].slurm.qsub_params, label + " slurm qsub_params drift");

--- a/test/golden/qsub-params.snapshot.json
+++ b/test/golden/qsub-params.snapshot.json
@@ -558,5 +558,118 @@
         "procs=32"
       ]
     }
+  },
+  "gard": {
+    "slurm": {
+      "type": "gard",
+      "resultsSuffix": "GARD.json",
+      "field": "qsub_params",
+      "qsub_params": [
+        "--ntasks=48",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/gard/output/check-<TS>,tree_fn=<ROOT>/app/gard/output/check-<TS>.tre,sfn=<ROOT>/app/gard/output/check-<TS>.status,pfn=<ROOT>/app/gard/output/check-<TS>.GARD.progress,rfn=<ROOT>/app/gard/output/check-<TS>.GARD.json,treemode=0,genetic_code=Universal,rate_var=None,rate_classes=2,datatype=codon,run_mode=Normal,max_breakpoints=10000,model=JTT,analysis_type=gard,cwd=<ROOT>/app/gard,msaid=check,procs=48",
+        "--output=<ROOT>/app/gard/output/gard_check-<TS>_%j.out",
+        "--error=<ROOT>/app/gard/output/gard_check-<TS>_%j.err",
+        "<ROOT>/app/gard/gard.sh"
+      ]
+    },
+    "local": {
+      "type": "gard",
+      "resultsSuffix": "GARD.json",
+      "field": "qsub_params",
+      "qsub_params": [
+        "<ROOT>/app/gard/gard.sh",
+        "fn=<ROOT>/app/gard/output/check-<TS>",
+        "tree_fn=<ROOT>/app/gard/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/gard/output/check-<TS>.status",
+        "pfn=<ROOT>/app/gard/output/check-<TS>.GARD.progress",
+        "rfn=<ROOT>/app/gard/output/check-<TS>.GARD.json",
+        "treemode=0",
+        "genetic_code=Universal",
+        "rate_var=None",
+        "rate_classes=2",
+        "datatype=codon",
+        "run_mode=Normal",
+        "max_breakpoints=10000",
+        "model=JTT",
+        "analysis_type=gard",
+        "cwd=<ROOT>/app/gard",
+        "msaid=check",
+        "procs=48"
+      ]
+    }
+  },
+  "difFubar": {
+    "slurm": {
+      "type": "difFubar",
+      "resultsSuffix": "GOLDEN-ID.difFubar.json",
+      "field": "qsub_params",
+      "qsub_params": [
+        "--ntasks=8",
+        "--cpus-per-task=1",
+        "--time=24:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--mem=32GB",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/difFubar/output/GOLDEN-ID,tree_fn=<ROOT>/app/difFubar/output/GOLDEN-ID.tre,pfn=<ROOT>/app/difFubar/output/GOLDEN-ID.difFubar.progress,rfn=<ROOT>/app/difFubar/output/GOLDEN-ID.difFubar,treemode=nj,analysis_type=difFubar,cwd=<ROOT>/app/difFubar,msaid=MSA-ID,number_of_grid_points=20,concentration_of_dirichlet_prior=0.5,mcmc_iterations=2500,burnin_samples=500,pos_threshold=0.95,julia_path=<HOME>/.juliaup/bin/julia,julia_project=<HOME>/programming/datamonkey-js-server/.julia_env/",
+        "--output=<ROOT>/app/difFubar/output/difFubar_GOLDEN-ID_%j.out",
+        "--error=<ROOT>/app/difFubar/output/difFubar_GOLDEN-ID_%j.err",
+        "<ROOT>/app/difFubar/difFubar.sh"
+      ]
+    },
+    "local": {
+      "type": "difFubar",
+      "resultsSuffix": "GOLDEN-ID.difFubar.json",
+      "field": "qsub_params",
+      "qsub_params": [
+        "<ROOT>/app/difFubar/difFubar.sh",
+        "<ROOT>/app/difFubar/output/GOLDEN-ID",
+        "<ROOT>/app/difFubar/output/GOLDEN-ID.tre",
+        "<ROOT>/app/difFubar/output/GOLDEN-ID.difFubar",
+        "<ROOT>/app/difFubar/output/GOLDEN-ID.difFubar.progress",
+        "0.95",
+        "2500",
+        "500",
+        "0.5",
+        "<HOME>/.juliaup/bin/julia",
+        "<HOME>/programming/datamonkey-js-server/.julia_env/"
+      ]
+    }
+  },
+  "hivtrace": {
+    "slurm": {
+      "type": "hivtrace",
+      "resultsSuffix": null,
+      "field": "slurm_params",
+      "qsub_params": [
+        "--ntasks=1",
+        "--cpus-per-task=16",
+        "--time=3:00:00:00",
+        "--output=<ROOT>/app/hivtrace/output/hivtrace_GOLDEN-ID_%j.out",
+        "--error=<ROOT>/app/hivtrace/output/hivtrace_GOLDEN-ID_%j.err",
+        "--export=fn=<ROOT>/app/hivtrace/output/GOLDEN-ID,python=<ROOT>/.python/env/bin/python,hivtrace=<ROOT>/.python/env/bin/hivtrace,dt=0.015,ambiguity_handling=Resolve,fraction=0.05,reference=HXB2_prrt,mo=500,filter=no,comparelanl=no,reference_strip=no,strip_drams=false,prealigned=no,output=<ROOT>/app/hivtrace/output/GOLDEN-ID_user.trace.json,hivtrace_log=<ROOT>/app/hivtrace/output/GOLDEN-ID.hivtrace.log,custom_reference_fn=",
+        "<ROOT>/app/hivtrace/hivtrace_submit.sh"
+      ]
+    },
+    "local": {
+      "type": "hivtrace",
+      "resultsSuffix": null,
+      "field": "qsub_params",
+      "qsub_params": [
+        "-l walltime=3:00:00:00,nodes=1:ppn=16",
+        "-q",
+        "datamonkey",
+        "-v",
+        "fn=<ROOT>/app/hivtrace/output/GOLDEN-ID,python=<ROOT>/.python/env/bin/python,hivtrace=<ROOT>/.python/env/bin/hivtrace,dt=0.015,ambiguity_handling=Resolve,fraction=0.05,reference=HXB2_prrt,mo=500,filter=no,comparelanl=no,reference_strip=no,strip_drams=false,prealigned=no,output=<ROOT>/app/hivtrace/output/GOLDEN-ID_user.trace.json,hivtrace_log=<ROOT>/app/hivtrace/output/GOLDEN-ID.hivtrace.log,custom_reference_fn=",
+        "-o",
+        "<ROOT>/app/hivtrace/output/hivtrace_GOLDEN-ID.o",
+        "-e",
+        "<ROOT>/app/hivtrace/output/hivtrace_GOLDEN-ID.e",
+        "<ROOT>/app/hivtrace/hivtrace_submit.sh"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Phase 4b — test hygiene (no production-code changes)

Adds the three bespoke (non-factory) analyses to the qsub_params golden oracle (`test/golden/qsub-params.js` + `qsub-params.snapshot.json`). These were the only analyses missing from the snapshot. **flea is excluded** — it is a Nextflow analysis with no sbatch qsub_params.

### Which field each analysis exposes
| analysis | checkOnly? | submission prevented by | field snapshotted (slurm) | field snapshotted (local) |
|---|---|---|---|---|
| **gard** | yes | its own checkOnly branch -> `init()` -> `validateParameters()` | `self.qsub_params` | `self.qsub_params` |
| **difFubar** | no branch of its own, but inherited `hyphyJob.init()` honours `params.checkOnly` -> `validateParameters()` | inherited init | `self.qsub_params` | `self.qsub_params` |
| **hivtrace** | no — constructor unconditionally calls `spawn()` (sbatch) | **stubbed** `hivtrace.prototype.spawn` to a no-op during capture | `self.slurm_params` | `self.qsub_params` |

hivtrace builds both `self.qsub_params` (torque) and `self.slurm_params` (sbatch); for slurm mode the snapshot pins `self.slurm_params`, the field its sbatch path actually submits.

### Notes
- `captureGard` constructs with only `genetic_code` + tree so GARD's own param defaults are exercised (makes the mutation-check meaningful).
- `normalize()` now also maps the home dir to `<HOME>` so out-of-repo config paths (`julia_path`/`julia_project`) stay deterministic.
- Snapshot entry count: **14 -> 17** (added gard, difFubar, hivtrace).

### Verification
- **Deterministic**: regenerated with `GOLDEN_UPDATE=1`, then ran WITHOUT the flag — matches byte-for-byte.
- **Mutation-caught**: flipping a GARD param default (model `JTT`->`MUTANT`) fails the snapshot with `gard slurm qsub_params drift`; reverted.
- **No SLURM job submitted during capture**: `squeue -u sweaver` empty throughout (difFubar/gard route to validateParameters; hivtrace spawn stubbed).
- factory-parity golden suite still green (28 passing).

Refs #410