### PR TITLE
Phase 4b: test hygiene — leak-free cleanup + bespoke golden coverage (#410)

### DIFF
--- a/test/golden/qsub-params.js
+++ b/test/golden/qsub-params.js
@@ -28,6 +28,7 @@ var fs = require("fs"),
   config = require(__dirname + "/../../lib/config");
 
 var ABS_ROOT = path.resolve(__dirname, "../..");
+var HOME = require("os").homedir();
 var SNAPSHOT = path.join(__dirname, "qsub-params.snapshot.json");
 
 // The 14 declarative-candidate analyses: [label, module path, export key].
@@ -72,6 +73,7 @@ function normalize(arr) {
   return (arr || []).map(function (entry) {
     return String(entry)
       .split(ABS_ROOT).join("<ROOT>")
+      .split(HOME).join("<HOME>")
       .replace(/check-\d+/g, "check-<TS>");
   });
 }
@@ -88,11 +90,141 @@ function capture(modPath, exportKey, submitType) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Bespoke analyses (gard, difFubar, hivtrace).
+//
+// These are NOT part of the 14-analysis factory family and each is captured
+// specially:
+//   - gard      : supports checkOnly, so it routes through hyphyJob.init() ->
+//                 validateParameters() and never submits (like the factory
+//                 analyses). It exposes self.qsub_params.
+//   - difFubar  : has NO checkOnly branch of its own, but its constructor ends
+//                 in self.init() (inherited from hyphyJob), which DOES honour
+//                 params.checkOnly and routes to validateParameters() instead
+//                 of spawn(). So passing checkOnly:true captures qsub_params
+//                 without submitting a SLURM job. It exposes self.qsub_params.
+//   - hivtrace  : does NOT honour checkOnly at all — its constructor
+//                 unconditionally calls self.spawn(), which submits via sbatch.
+//                 We therefore STUB hivtrace.prototype.spawn to a no-op so the
+//                 constructor builds params but nothing is submitted. hivtrace
+//                 builds BOTH self.qsub_params (torque) AND self.slurm_params
+//                 (SLURM); for slurm mode we snapshot self.slurm_params (the
+//                 field its sbatch path actually submits).
+// ---------------------------------------------------------------------------
+
+var GARD_PATH = "../../app/gard/gard.js";
+var DIFFUBAR_PATH = "../../app/difFubar/difFubar.js";
+var HIVTRACE_PATH = "../../app/hivtrace/hivtrace.js";
+
+function captureGard(submitType) {
+  config.submit_type = submitType;
+  var Ctor = require(GARD_PATH).gard;
+  // checkOnly:true -> init() -> validateParameters(), never submits.
+  // We pass ONLY genetic_code + tree so GARD's own defaults (rate_classes,
+  // run_mode, datatype, max_breakpoints, model, site_to_site_variation) are
+  // exercised — that is what makes the mutation-check meaningful: flipping any
+  // GARD param default drifts this snapshot.
+  var job = new Ctor(fakeSocket(), ">A\nACGT\n", {
+    checkOnly: true,
+    genetic_code: "Universal",
+    nwk_tree: "(A,B);"
+  });
+  return {
+    type: job.type,
+    resultsSuffix: job.results_fn
+      ? path.basename(job.results_fn).replace(/^check-\d+\.?/, "")
+      : null,
+    field: "qsub_params",
+    qsub_params: normalize(job.qsub_params)
+  };
+}
+
+function captureDifFubar(submitType) {
+  config.submit_type = submitType;
+  var Ctor = require(DIFFUBAR_PATH).difFubar;
+  // difFubar has no checkOnly of its own, but the inherited init() honours it:
+  // checkOnly:true routes to validateParameters() and NEVER submits. A stable
+  // _id avoids any volatile timestamp in the snapshot.
+  var job = new Ctor(fakeSocket(), ">A\nACGT\n", {
+    checkOnly: true,
+    analysis: {
+      _id: "GOLDEN-ID",
+      number_of_grid_points: 20,
+      concentration_of_dirichlet_prior: 0.5,
+      mcmc_iterations: 2500,
+      burnin_samples: 500,
+      pos_threshold: 0.95
+    },
+    msa: [{ _id: "MSA-ID", nj: "(A,B);" }]
+  });
+  return {
+    type: job.type,
+    resultsSuffix: job.results_fn ? path.basename(job.results_fn) : null,
+    field: "qsub_params",
+    qsub_params: normalize(job.qsub_params)
+  };
+}
+
+function captureHivtrace(submitType) {
+  config.submit_type = submitType;
+  var mod = require(HIVTRACE_PATH);
+  var Ctor = mod.hivtrace;
+  // hivtrace does NOT honour checkOnly; its constructor unconditionally calls
+  // self.spawn() which submits via sbatch. STUB spawn so nothing is submitted
+  // while the constructor still builds qsub_params + slurm_params.
+  var origSpawn = Ctor.prototype.spawn;
+  Ctor.prototype.spawn = function () {};
+  var job;
+  try {
+    job = new Ctor(fakeSocket(), new EventEmitter(), {
+      _id: "GOLDEN-ID",
+      distance_threshold: 0.015,
+      ambiguity_handling: "Resolve",
+      fraction: 0.05,
+      reference: "HXB2_prrt",
+      filter_edges: "no",
+      reference_strip: "no",
+      min_overlap: 500,
+      status_stack: [],
+      lanl_compare: "no",
+      prealigned: "no",
+      strip_drams: "no"
+    });
+  } finally {
+    Ctor.prototype.spawn = origSpawn;
+  }
+  // hivtrace builds self.slurm_params for its sbatch path and self.qsub_params
+  // for torque. For slurm mode we snapshot the field it actually submits.
+  var field = submitType === "slurm" ? "slurm_params" : "qsub_params";
+  return {
+    type: job.type,
+    resultsSuffix: null,
+    field: field,
+    qsub_params: normalize(job[field])
+  };
+}
+
 describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
   this.timeout(20000);
 
+  // Bespoke analyses, keyed by label -> capture function. difFubar's
+  // constructor synchronously opens its progress file, so its output dir must
+  // exist before construction; ensure the output dirs for all three.
+  var utilities = require("../../lib/utilities");
+  var BESPOKE = {
+    gard: captureGard,
+    difFubar: captureDifFubar,
+    hivtrace: captureHivtrace
+  };
+  var BESPOKE_LABELS = Object.keys(BESPOKE);
+  var ALL_LABELS = ANALYSES.map(function (a) { return a[0]; }).concat(BESPOKE_LABELS);
+
   var current = {};
   before(function () {
+    utilities.ensureDirectoryExists(path.join(ABS_ROOT, "app/gard/output"));
+    utilities.ensureDirectoryExists(path.join(ABS_ROOT, "app/difFubar/output"));
+    utilities.ensureDirectoryExists(path.join(ABS_ROOT, "app/hivtrace/output"));
+
     ANALYSES.forEach(function (a) {
       var label = a[0], modPath = a[1], key = a[2];
       current[label] = {
@@ -100,15 +232,22 @@ describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
         local: capture(modPath, key, "local")
       };
     });
+    BESPOKE_LABELS.forEach(function (label) {
+      var fn = BESPOKE[label];
+      current[label] = {
+        slurm: fn("slurm"),
+        local: fn("local")
+      };
+    });
     // restore a sane default so later suites aren't affected
     config.submit_type = "slurm";
   });
 
-  it("captures all 14 analyses for slurm and local", function () {
-    Object.keys(current).length.should.equal(14);
-    ANALYSES.forEach(function (a) {
-      current[a[0]].slurm.qsub_params.length.should.be.above(0);
-      current[a[0]].local.qsub_params.length.should.be.above(0);
+  it("captures all 14 factory + 3 bespoke analyses for slurm and local", function () {
+    Object.keys(current).length.should.equal(17);
+    ALL_LABELS.forEach(function (label) {
+      current[label].slurm.qsub_params.length.should.be.above(0);
+      current[label].local.qsub_params.length.should.be.above(0);
     });
   });
 
@@ -117,13 +256,12 @@ describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
       fs.writeFileSync(SNAPSHOT, JSON.stringify(current, null, 2) + "\n");
       // Sanity: file is valid + non-trivial.
       var written = JSON.parse(fs.readFileSync(SNAPSHOT, "utf8"));
-      Object.keys(written).length.should.equal(14);
+      Object.keys(written).length.should.equal(17);
     });
   } else {
     it("matches the committed golden snapshot (byte-for-byte per analysis)", function () {
       var golden = JSON.parse(fs.readFileSync(SNAPSHOT, "utf8"));
-      ANALYSES.forEach(function (a) {
-        var label = a[0];
+      ALL_LABELS.forEach(function (label) {
         should.exist(golden[label], "missing golden entry for " + label);
         current[label].slurm.qsub_params.should.eql(
           golden[label].slurm.qsub_params, label + " slurm qsub_params drift");

--- a/test/golden/qsub-params.snapshot.json
+++ b/test/golden/qsub-params.snapshot.json
@@ -558,5 +558,118 @@
         "procs=32"
       ]
     }
+  },
+  "gard": {
+    "slurm": {
+      "type": "gard",
+      "resultsSuffix": "GARD.json",
+      "field": "qsub_params",
+      "qsub_params": [
+        "--ntasks=48",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/gard/output/check-<TS>,tree_fn=<ROOT>/app/gard/output/check-<TS>.tre,sfn=<ROOT>/app/gard/output/check-<TS>.status,pfn=<ROOT>/app/gard/output/check-<TS>.GARD.progress,rfn=<ROOT>/app/gard/output/check-<TS>.GARD.json,treemode=0,genetic_code=Universal,rate_var=None,rate_classes=2,datatype=codon,run_mode=Normal,max_breakpoints=10000,model=JTT,analysis_type=gard,cwd=<ROOT>/app/gard,msaid=check,procs=48",
+        "--output=<ROOT>/app/gard/output/gard_check-<TS>_%j.out",
+        "--error=<ROOT>/app/gard/output/gard_check-<TS>_%j.err",
+        "<ROOT>/app/gard/gard.sh"
+      ]
+    },
+    "local": {
+      "type": "gard",
+      "resultsSuffix": "GARD.json",
+      "field": "qsub_params",
+      "qsub_params": [
+        "<ROOT>/app/gard/gard.sh",
+        "fn=<ROOT>/app/gard/output/check-<TS>",
+        "tree_fn=<ROOT>/app/gard/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/gard/output/check-<TS>.status",
+        "pfn=<ROOT>/app/gard/output/check-<TS>.GARD.progress",
+        "rfn=<ROOT>/app/gard/output/check-<TS>.GARD.json",
+        "treemode=0",
+        "genetic_code=Universal",
+        "rate_var=None",
+        "rate_classes=2",
+        "datatype=codon",
+        "run_mode=Normal",
+        "max_breakpoints=10000",
+        "model=JTT",
+        "analysis_type=gard",
+        "cwd=<ROOT>/app/gard",
+        "msaid=check",
+        "procs=48"
+      ]
+    }
+  },
+  "difFubar": {
+    "slurm": {
+      "type": "difFubar",
+      "resultsSuffix": "GOLDEN-ID.difFubar.json",
+      "field": "qsub_params",
+      "qsub_params": [
+        "--ntasks=8",
+        "--cpus-per-task=1",
+        "--time=24:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--mem=32GB",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/difFubar/output/GOLDEN-ID,tree_fn=<ROOT>/app/difFubar/output/GOLDEN-ID.tre,pfn=<ROOT>/app/difFubar/output/GOLDEN-ID.difFubar.progress,rfn=<ROOT>/app/difFubar/output/GOLDEN-ID.difFubar,treemode=nj,analysis_type=difFubar,cwd=<ROOT>/app/difFubar,msaid=MSA-ID,number_of_grid_points=20,concentration_of_dirichlet_prior=0.5,mcmc_iterations=2500,burnin_samples=500,pos_threshold=0.95,julia_path=<HOME>/.juliaup/bin/julia,julia_project=<HOME>/programming/datamonkey-js-server/.julia_env/",
+        "--output=<ROOT>/app/difFubar/output/difFubar_GOLDEN-ID_%j.out",
+        "--error=<ROOT>/app/difFubar/output/difFubar_GOLDEN-ID_%j.err",
+        "<ROOT>/app/difFubar/difFubar.sh"
+      ]
+    },
+    "local": {
+      "type": "difFubar",
+      "resultsSuffix": "GOLDEN-ID.difFubar.json",
+      "field": "qsub_params",
+      "qsub_params": [
+        "<ROOT>/app/difFubar/difFubar.sh",
+        "<ROOT>/app/difFubar/output/GOLDEN-ID",
+        "<ROOT>/app/difFubar/output/GOLDEN-ID.tre",
+        "<ROOT>/app/difFubar/output/GOLDEN-ID.difFubar",
+        "<ROOT>/app/difFubar/output/GOLDEN-ID.difFubar.progress",
+        "0.95",
+        "2500",
+        "500",
+        "0.5",
+        "<HOME>/.juliaup/bin/julia",
+        "<HOME>/programming/datamonkey-js-server/.julia_env/"
+      ]
+    }
+  },
+  "hivtrace": {
+    "slurm": {
+      "type": "hivtrace",
+      "resultsSuffix": null,
+      "field": "slurm_params",
+      "qsub_params": [
+        "--ntasks=1",
+        "--cpus-per-task=16",
+        "--time=3:00:00:00",
+        "--output=<ROOT>/app/hivtrace/output/hivtrace_GOLDEN-ID_%j.out",
+        "--error=<ROOT>/app/hivtrace/output/hivtrace_GOLDEN-ID_%j.err",
+        "--export=fn=<ROOT>/app/hivtrace/output/GOLDEN-ID,python=<ROOT>/.python/env/bin/python,hivtrace=<ROOT>/.python/env/bin/hivtrace,dt=0.015,ambiguity_handling=Resolve,fraction=0.05,reference=HXB2_prrt,mo=500,filter=no,comparelanl=no,reference_strip=no,strip_drams=false,prealigned=no,output=<ROOT>/app/hivtrace/output/GOLDEN-ID_user.trace.json,hivtrace_log=<ROOT>/app/hivtrace/output/GOLDEN-ID.hivtrace.log,custom_reference_fn=",
+        "<ROOT>/app/hivtrace/hivtrace_submit.sh"
+      ]
+    },
+    "local": {
+      "type": "hivtrace",
+      "resultsSuffix": null,
+      "field": "qsub_params",
+      "qsub_params": [
+        "-l walltime=3:00:00:00,nodes=1:ppn=16",
+        "-q",
+        "datamonkey",
+        "-v",
+        "fn=<ROOT>/app/hivtrace/output/GOLDEN-ID,python=<ROOT>/.python/env/bin/python,hivtrace=<ROOT>/.python/env/bin/hivtrace,dt=0.015,ambiguity_handling=Resolve,fraction=0.05,reference=HXB2_prrt,mo=500,filter=no,comparelanl=no,reference_strip=no,strip_drams=false,prealigned=no,output=<ROOT>/app/hivtrace/output/GOLDEN-ID_user.trace.json,hivtrace_log=<ROOT>/app/hivtrace/output/GOLDEN-ID.hivtrace.log,custom_reference_fn=",
+        "-o",
+        "<ROOT>/app/hivtrace/output/hivtrace_GOLDEN-ID.o",
+        "-e",
+        "<ROOT>/app/hivtrace/output/hivtrace_GOLDEN-ID.e",
+        "<ROOT>/app/hivtrace/hivtrace_submit.sh"
+      ]
+    }
   }
 }

--- a/test/helpers/slurm-cleanup.js
+++ b/test/helpers/slurm-cleanup.js
@@ -1,0 +1,87 @@
+/**
+ * slurm-cleanup.js — SLURM-leak backstop for the real-scheduler test suites.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS EXISTS
+ * ---------------------------------------------------------------------------
+ * test/jobqueue.js and test/jobstatus.js submit real jobs to the live
+ * `datamonkey` SLURM partition (multi-day walltimes). Their per-suite cleanup
+ * used a fire-and-forget `spawn('scancel', ids)` in an `after`/`afterEach`
+ * hook. Under `mocha --exit`, mocha force-kills the process the instant the
+ * last test's callback returns — before the detached `scancel` child has a
+ * chance to run — so the submitted jobs SURVIVE on the partition. A crashing
+ * test (throw before its own cleanup) leaks the same way.
+ *
+ * This module provides two things:
+ *
+ *   1. `track(id)` — register a slurm job id the moment it is known, so it can
+ *      be cleaned up even if the test that created it never reaches its own
+ *      afterEach/after (e.g. it throws or times out).
+ *
+ *   2. A mocha ROOT-LEVEL `after` hook (registered on require) that runs a
+ *      single BLOCKING `execSync('scancel <tracked ids>')` after ALL suites in
+ *      the process finish. Because it is synchronous, it completes before
+ *      `--exit` tears the process down. It is intentionally conservative: it
+ *      only cancels the specific ids this suite tracked (never `scancel -u`,
+ *      never other users' jobs).
+ *
+ * The per-suite hooks in jobqueue.js / jobstatus.js ALSO switch to a blocking
+ * `execSync` scancel; this root hook is a backstop for ids that slipped past
+ * those hooks (crashes, untracked-but-registered ids).
+ */
+var execSync = require("child_process").execSync;
+
+// Set of slurm job ids (as strings) that this test process has submitted and
+// is responsible for cancelling.
+var tracked = new Set();
+
+/**
+ * Register a slurm job id for backstop cleanup. Ids are normalized to strings
+ * so lookups line up regardless of numeric/string origin.
+ * @param {string|number} id
+ */
+function track(id) {
+  if (id === null || id === undefined) return;
+  tracked.add(String(id));
+}
+
+/**
+ * Forget an id once the owning test has already cancelled it (keeps the
+ * backstop's scancel list minimal). Safe to call with an unknown id.
+ * @param {string|number} id
+ */
+function untrack(id) {
+  if (id === null || id === undefined) return;
+  tracked.delete(String(id));
+}
+
+/**
+ * Blocking cancel of the supplied ids (defaults to everything tracked). Wrapped
+ * so a scancel failure (e.g. job already gone) never fails the suite. Returns
+ * the list of ids it attempted to cancel.
+ * @param {Array<string|number>} [ids]
+ * @returns {string[]}
+ */
+function cancel(ids) {
+  var list = (ids || Array.from(tracked)).map(String).filter(Boolean);
+  if (!list.length) return [];
+  try {
+    // Blocking so it finishes before mocha's `--exit` kills the process.
+    execSync("scancel " + list.join(" "), { stdio: "ignore" });
+  } catch (e) {
+    // Best-effort: job may already be gone / cancelled. Do not fail cleanup.
+  }
+  list.forEach(untrack);
+  return list;
+}
+
+// Mocha root-level backstop. Registering a top-level `after` (outside any
+// describe) attaches it to the root suite, so it runs once after every suite
+// in the process — even if an individual test crashed before its own cleanup.
+if (typeof after === "function") {
+  after(function slurmCleanupBackstop() {
+    cancel();
+  });
+}
+
+module.exports = { track: track, untrack: untrack, cancel: cancel };

--- a/test/jobqueue.js
+++ b/test/jobqueue.js
@@ -1,9 +1,11 @@
 var fs = require('fs'),
     spawn = require('child_process').spawn,
+    execSync = require('child_process').execSync,
     should = require('should'),
     path = require('path'),
     redisClient = require('../lib/redis-client.js'),
-    config = require('../lib/config');
+    config = require('../lib/config'),
+    slurmCleanup = require('./helpers/slurm-cleanup');
 
 // redis@5 migration: reuse the shared connected client from lib/redis-client.js
 // (was `redis.createClient({host,port})`); commands are camelCased and
@@ -43,6 +45,9 @@ describe('job queue', function() {
         if (match) {
           var slurm_id = match[1];
           submitted_ids.push(slurm_id);
+          // Register with the root-hook backstop the instant the id is known,
+          // so a crash before `after()` still gets this job cancelled.
+          slurmCleanup.track(slurm_id);
           // redis@5: hset->hSet, promise-returning; swallow errors for this
           // best-effort seed (v5 buffers until the shared socket connects).
           client.hSet(slurm_id, 'type', 'test').catch(function () {});
@@ -55,19 +60,37 @@ describe('job queue', function() {
 
   after(function() {
     if (submitted_ids.length) {
-      spawn('scancel', submitted_ids);
+      // BLOCKING cancel: the previous fire-and-forget `spawn('scancel', ids)`
+      // was force-killed by `mocha --exit` before it ran, leaking jobs onto the
+      // live partition. execSync completes before the process exits.
+      try {
+        execSync('scancel ' + submitted_ids.join(' '), { stdio: 'ignore' });
+      } catch (e) {
+        // Best-effort: jobs may already be gone; do not fail the suite.
+      }
+      submitted_ids.forEach(function (id) { slurmCleanup.untrack(id); });
     }
   });
 
   it('return the job queue', function(done) {
     JobQueue(function(jobs) {
-      jobs[0].should.have.property('id');
-      jobs[0].should.have.property('status');
-      jobs[0].should.have.property('creation_time');
-      jobs[0].should.have.property('start_time');
-      jobs[0].should.have.property('type');
-      jobs[0].should.have.property('sites');
-      jobs[0].should.have.property('sequences');
+      // The live SLURM queue is unfiltered and may contain jobs from other
+      // users / other tests, so asserting on jobs[0] is racy. Instead find
+      // THIS suite's own submitted job and assert on it. returnSlurmJobInfo
+      // sets `id` to squeue's %i (the sbatch-printed slurm id), so match on it.
+      var mine = jobs.find(function (j) {
+        return submitted_ids.indexOf(j.id) !== -1 ||
+               submitted_ids.indexOf(String(j.id)) !== -1;
+      });
+      should.exist(mine, 'none of this suite\'s submitted jobs appeared in the queue: ' +
+        JSON.stringify(submitted_ids));
+      mine.should.have.property('id');
+      mine.should.have.property('status');
+      mine.should.have.property('creation_time');
+      mine.should.have.property('start_time');
+      mine.should.have.property('type');
+      mine.should.have.property('sites');
+      mine.should.have.property('sequences');
       done();
     });
   });

--- a/test/jobstatus.js
+++ b/test/jobstatus.js
@@ -1,18 +1,27 @@
-var spawn   = require('child_process').spawn,
-    winston = require('winston'),
-    should  = require('should');
+var spawn    = require('child_process').spawn,
+    execSync = require('child_process').execSync,
+    winston  = require('winston'),
+    should   = require('should');
 
 var JobStatus = require(__dirname + '/../lib/jobstatus.js').JobStatus;
+var slurmCleanup = require('./helpers/slurm-cleanup');
 
 describe('job status', function() {
 
   var jobId = null;
 
   // Ensure any submitted SLURM job is cancelled so it does not occupy the
-  // datamonkey partition (jobs have a multi-day walltime).
+  // datamonkey partition (jobs have a multi-day walltime). BLOCKING execSync:
+  // the previous fire-and-forget `spawn('scancel', [jobId])` was force-killed
+  // by `mocha --exit` before it ran, leaking the job onto the live partition.
   afterEach(function() {
     if (jobId) {
-      spawn('scancel', [jobId]);
+      try {
+        execSync('scancel ' + jobId, { stdio: 'ignore' });
+      } catch (e) {
+        // Best-effort: job may already be gone; do not fail the suite.
+      }
+      slurmCleanup.untrack(jobId);
       jobId = null;
     }
   });
@@ -40,6 +49,9 @@ describe('job status', function() {
       should.exist(match, 'could not parse job id from: ' + out);
       var id = match[1];
       jobId = id;
+      // Register with the root-hook backstop the instant the id is known, so a
+      // crash/timeout before afterEach still gets this job cancelled.
+      slurmCleanup.track(id);
       winston.info('submitted SLURM job ' + id);
 
       var job_status = new JobStatus(id);


### PR DESCRIPTION
## Phase 4b — test hygiene only (no production-code changes)

Part of the v4 modernization (#410). Merges two conflict-free units off \`feature/v4-modernization\` and targets the integration branch (not master).

### Unit 1 — leak-free SLURM cleanup (`v4/phase4b-leak-fix`)
- `test/jobqueue.js` / `test/jobstatus.js` previously used fire-and-forget `spawn('scancel', ids)` in their `after`/`afterEach` hooks. Under `mocha --exit`, mocha force-kills the process the instant the last callback returns — before the detached scancel runs — so submitted sbatch jobs (multi-day walltimes) SURVIVED on the live `datamonkey` partition.
- Switched both to **blocking** `execSync('scancel …')` so cancellation completes before `--exit` tears the process down.
- Added `test/helpers/slurm-cleanup.js`: a `track(id)` registry (ids registered the instant sbatch prints them) plus a mocha **root-level `after` backstop** that runs a single blocking `execSync` scancel — catching ids leaked by a test that crashes/times out before its own cleanup. Conservative: only cancels ids this suite tracked, never `scancel -u`.
- Fixed the racy `jobqueue` assertion: it asserted on `jobs[0]` of the UNFILTERED live-scheduler queue (which contains other users'/other tests' jobs). Now it finds this suite's OWN submitted job id and asserts on that.

### Unit 2 — bespoke golden coverage (`v4/phase4b-bespoke-golden`)
- The golden `qsub_params` snapshot covered the 14 factory analyses but MISSED the bespoke ones. Added coverage for **gard, difFubar, hivtrace** (flea excluded — Nextflow, no sbatch qsub_params).
  - gard / difFubar: captured via `checkOnly:true` → `init()` → `validateParameters()`, never submits.
  - hivtrace: does not honour checkOnly; its constructor unconditionally submits, so `hivtrace.prototype.spawn` is stubbed to a no-op while params are built. Snapshots `slurm_params` (the field its sbatch path submits) in slurm mode.
- Snapshot now has 17 labels; the bespoke entries are **matched byte-for-byte, not regenerated**. Added `$HOME`→`<HOME>` normalization for path stability.

### Verification (combined `v4/phase4b`)
- `test/jobqueue.js` + `test/jobstatus.js` run 3×: 2 passing each; `squeue -u sweaver` settles to **0** active jobs after every run.
- `npm run test:ci`: **125 passing, 1 pending, 0 failing**.
- Golden suite (qsub-params + factory-parity): **30 passing**, including the byte-for-byte bespoke snapshot match; no SLURM jobs submitted.
- `npm run lint`: **0 errors** (31 pre-existing warnings, none in phase4b files).
- No leftover jobs on the partition.