### PR TITLE
Phase 4c: var -> const/let across app+lib (no-var/prefer-const) (#410)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,10 @@ module.exports = {
         "sourceType": "script"
     },
     "rules": {
+        // Phase 4c (#410): modern block-scoped declarations. no-var is a
+        // CI-blocking error; prefer-const nudges immutable bindings.
+        "no-var": "error",
+        "prefer-const": "error",
         "indent": [
             "error",
             2

--- a/app/absrel/descriptor.js
+++ b/app/absrel/descriptor.js
@@ -6,12 +6,12 @@
  * exactly (pinned by test/golden/qsub-params.snapshot.json).
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "absrel",
   dir: __dirname,
   script: "absrel.sh",
@@ -23,7 +23,7 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original absrel.js branches.
   fields: function (self, params, src, ctx) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
       self.multiple_hits = params.multiple_hits || "None";
@@ -112,7 +112,7 @@ var descriptor = {
   ]
 };
 
-var absrel = factory.makeAnalysis(descriptor);
+const absrel = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.absrel is the constructor.
 exports.absrel = absrel;

--- a/app/bgm/descriptor.js
+++ b/app/bgm/descriptor.js
@@ -6,20 +6,20 @@
  * (pinned by test/golden/qsub-params.snapshot.json).
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
-var code = require("../code").code;
-var model = require("../model").model;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
+const code = require("../code").code;
+const model = require("../model").model;
 
-var datatypes = {
+const datatypes = {
   "1": "nucleotide",
   "2": "amino-acid",
   "3": "codon"
 };
 
-var descriptor = {
+const descriptor = {
   type: "bgm",
   dir: __dirname,
   script: "bgm.sh",
@@ -31,7 +31,7 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original bgm.js branches.
   fields: function (self, params, src) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
 
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
@@ -45,7 +45,7 @@ var descriptor = {
       self.branches = params.branches || "All";
       self.nwk_tree = params.nwk_tree || params.tree || "";
     } else {
-      var analysisParams = self.params.analysis || self.params;
+      const analysisParams = self.params.analysis || self.params;
 
       if (self.params.msa) {
         self.genetic_code = self.params.msa[0]
@@ -92,7 +92,7 @@ var descriptor = {
     utilities.ensureDirectoryExists(self.output_dir);
 
     // Clean tree data and write to file.
-    var cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
+    const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
     logger.info("BGM job " + self.id + ": Writing cleaned tree file to " + self.tree_fn, {
       original_length: self.nwk_tree ? self.nwk_tree.length : 0,
       cleaned_length: cleanTree ? cleanTree.length : 0,
@@ -134,7 +134,7 @@ var descriptor = {
   ]
 };
 
-var bgm = factory.makeAnalysis(descriptor);
+const bgm = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.bgm is the constructor.
 exports.bgm = bgm;

--- a/app/bstill/descriptor.js
+++ b/app/bstill/descriptor.js
@@ -19,12 +19,12 @@
  * Standard export prefix with no mode asymmetry, so no prefixKeys/skipInSlurm.
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "bstill",
   dir: __dirname,
   script: "bstill.sh",
@@ -39,7 +39,7 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original bstill.js branches and its trailing advanced-options block.
   fields: function (self, params, src) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
     } else {
@@ -86,7 +86,7 @@ var descriptor = {
     utilities.ensureDirectoryExists(self.output_dir);
 
     // Clean tree data and write to file.
-    var cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
+    const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
     logger.info("B-STILL job " + self.id + ": Writing cleaned tree file to " + self.tree_fn, {
       original_length: self.nwk_tree ? self.nwk_tree.length : 0,
       cleaned_length: cleanTree ? cleanTree.length : 0,
@@ -125,7 +125,7 @@ var descriptor = {
   ]
 };
 
-var bstill = factory.makeAnalysis(descriptor);
+const bstill = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.bstill is the constructor.
 exports.bstill = bstill;

--- a/app/busted/descriptor.js
+++ b/app/busted/descriptor.js
@@ -10,19 +10,19 @@
  * exportKeys entry for analysis_type is therefore scoped to "local".
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
 // Original busted.js lookup tables + helper (verbatim).
-var synSubstitutionVar = {
+const synSubstitutionVar = {
   "1": "Yes",
   "2": "No",
   "3": "Branch-site"
 };
 
-var multihitVar = {
+const multihitVar = {
   Default: "None",
   Double: "Double",
   "Double+Triple": "Double+Triple"
@@ -34,7 +34,7 @@ function boolToYesNo(value) {
   return value; // Return as-is if already a string
 }
 
-var descriptor = {
+const descriptor = {
   type: "busted",
   dir: __dirname,
   script: "busted_submit.sh",
@@ -59,7 +59,7 @@ var descriptor = {
     self.starting_points = src.starting_points || 1;
     self.save_fit = src.save_fit || "/dev/null";
 
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
     } else {
@@ -134,7 +134,7 @@ var descriptor = {
   ]
 };
 
-var busted = factory.makeAnalysis(descriptor);
+const busted = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.busted is the constructor.
 exports.busted = busted;

--- a/app/contrast-fel/descriptor.js
+++ b/app/contrast-fel/descriptor.js
@@ -17,12 +17,12 @@
  * no prefixKeys / skipInSlurm needed.
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "cfel",
   dir: __dirname,
   script: "cfel.sh",
@@ -36,10 +36,10 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original cfel.js branches.
   fields: function (self, params, src) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
-      var rawBranchSets = params["branch-set"] || params.branch_sets || "";
+      const rawBranchSets = params["branch-set"] || params.branch_sets || "";
       self.branch_sets = Array.isArray(rawBranchSets) ? rawBranchSets.join(":") : rawBranchSets;
       self.rate_variation = params.srv || (params.ds_variation == 1 ? "Yes" : "No") || "Yes";
       self.permutations = params.permutations || "Yes";
@@ -61,7 +61,7 @@ var descriptor = {
           self.params.nwk_tree ||
           self.params.tree ||
           "";
-        var rawBranchSetsA =
+        const rawBranchSetsA =
           self.params.analysis["branch-set"] ||
           self.params.analysis.branch_sets ||
           src["branch-set"] ||
@@ -77,7 +77,7 @@ var descriptor = {
         self.q_value = src.q_value || src.qvalue || 0.2;
       } else {
         self.nwk_tree = self.params.nwk_tree || self.params.tree || "";
-        var rawBranchSetsB = self.params["branch-set"] || self.params.branch_sets || "";
+        const rawBranchSetsB = self.params["branch-set"] || self.params.branch_sets || "";
         self.branch_sets = Array.isArray(rawBranchSetsB)
           ? rawBranchSetsB.join(":")
           : rawBranchSetsB;
@@ -104,7 +104,7 @@ var descriptor = {
     utilities.ensureDirectoryExists(self.output_dir);
 
     // Clean tree data and write to file.
-    var cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
+    const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
     logger.info("Contrast-FEL job " + self.id + ": Writing cleaned tree file to " + self.tree_fn, {
       original_length: self.nwk_tree ? self.nwk_tree.length : 0,
       cleaned_length: cleanTree ? cleanTree.length : 0,
@@ -130,13 +130,13 @@ var descriptor = {
     // submit — the factory always calls self.init() after beforeInit, so we
     // suppress it here by replacing init with a no-op (mirrors the original
     // module's early return).
-    var _cfelSetCount = String(self.branch_sets == null ? "" : self.branch_sets)
+    const _cfelSetCount = String(self.branch_sets == null ? "" : self.branch_sets)
       .split(":")
       .filter(function (s) {
         return s.trim().length;
       }).length;
     if (_cfelSetCount < 2) {
-      var _cfelMsg =
+      const _cfelMsg =
         "Contrast-FEL requires at least two branch groups to compare, but " +
         _cfelSetCount +
         " were provided. Please tag a second group of branches in the tree and resubmit.";
@@ -168,7 +168,7 @@ var descriptor = {
   ]
 };
 
-var cfel = factory.makeAnalysis(descriptor);
+const cfel = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.cfel is the constructor.
 exports.cfel = cfel;

--- a/app/difFubar/difFubar.js
+++ b/app/difFubar/difFubar.js
@@ -1,4 +1,4 @@
-var config = require("../../lib/config"),
+const config = require("../../lib/config"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
   logger = require("../../lib/logger.js").logger,
   util = require("util"),
@@ -8,10 +8,10 @@ var config = require("../../lib/config"),
 // Shared redis v5 client (promise-native, camelCased commands). Reused across
 // onComplete calls instead of creating (and leaking) a client per job
 // (GH #400).
-var { client } = require("../../lib/redis-client");
+const { client } = require("../../lib/redis-client");
 
-var difFubar = function(socket, stream, params) {
-  var self = this;
+const difFubar = function(socket, stream, params) {
+  const self = this;
   self.socket = socket;
   self.stream = stream;
   self.params = params;
@@ -199,10 +199,10 @@ var difFubar = function(socket, stream, params) {
 };
 
 difFubar.prototype.sendPlotFiles = function(cb) {
-  var self = this;
+  const self = this;
   
   // Define the plot files to send
-  var plotFiles = [
+  const plotFiles = [
     { name: "overview.png", path: self.results_short_fn + "_overview.png", event: "difFubar overview png" },
     { name: "overview.svg", path: self.results_short_fn + "_overview.svg", event: "difFubar overview svg" },
     { name: "posteriors.png", path: self.results_short_fn + "_posteriors.png", event: "difFubar posteriors png" },
@@ -211,7 +211,7 @@ difFubar.prototype.sendPlotFiles = function(cb) {
     { name: "detections.svg", path: self.results_short_fn + "_detections.svg", event: "difFubar detections svg" }
   ];
   
-  var promises = plotFiles.map(file => {
+  const promises = plotFiles.map(file => {
     return new Promise((resolve, reject) => {
       fs.readFile(file.path, (err, data) => {
         if (err || !data) {
@@ -225,7 +225,7 @@ difFubar.prototype.sendPlotFiles = function(cb) {
   });
   
   Promise.all(promises).then(results => {
-    var sentFiles = results.filter(f => f !== null);
+    const sentFiles = results.filter(f => f !== null);
     self.log("sent plot files", sentFiles.join(", "));
     cb(null, "success");
   }).catch(err => {
@@ -234,7 +234,7 @@ difFubar.prototype.sendPlotFiles = function(cb) {
 };
 
 difFubar.prototype.onComplete = function() {
-  var self = this;
+  const self = this;
   
   logger.info(`[DEBUG] difFUBAR ${self.id}: onComplete() called!`);
   logger.info(`[DEBUG] difFUBAR ${self.id}: Socket connected: ${self.socket && self.socket.connected}`);
@@ -267,7 +267,7 @@ difFubar.prototype.onComplete = function() {
           self.socket.emit("difFubar results file", { buffer: data });
           
           // Send lightweight completion event via Redis
-          var redis_packet = { 
+          const redis_packet = { 
             results: JSON.stringify({
               message: "Results sent via direct file transmission",
               file_size: stats.size,
@@ -275,7 +275,7 @@ difFubar.prototype.onComplete = function() {
             })
           };
           redis_packet.type = "completed";
-          var str_redis_packet = JSON.stringify(redis_packet);
+          const str_redis_packet = JSON.stringify(redis_packet);
           
           self.log("complete", "success (direct file transmission)");
           

--- a/app/fade/descriptor.js
+++ b/app/fade/descriptor.js
@@ -16,21 +16,21 @@
  * mode asymmetry, so it needs no prefixKeys or skipInSlurm.
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
-var model = require("../model").model;
-var code = require("../code").code;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
+const model = require("../model").model;
+const code = require("../code").code;
 
 // Original fade.js lookup table (verbatim).
-var estimationMethod = {
+const estimationMethod = {
   "1": "Metropolis-Hastings",
   "2": "Collapsed-Gibbs",
   "3": "Variational-Bayes"
 };
 
-var descriptor = {
+const descriptor = {
   type: "fade",
   dir: __dirname,
   script: "fade.sh",
@@ -42,7 +42,7 @@ var descriptor = {
   // three-way branch (checkOnly / normal-with-analysis / normal-without-analysis)
   // verbatim.
   fields: function (self, params) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
 
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
@@ -71,7 +71,7 @@ var descriptor = {
         0.5;
       self.nwk_tree = params.nwk_tree || params.tree || "";
     } else {
-      var analysisParams = self.params.analysis || self.params;
+      const analysisParams = self.params.analysis || self.params;
 
       // parameter attributes with fallbacks
       if (self.params.msa) {
@@ -171,7 +171,7 @@ var descriptor = {
     utilities.ensureDirectoryExists(self.output_dir);
 
     // Clean tree data and write to file.
-    var cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
+    const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
     logger.info("FADE job " + self.id + ": Writing cleaned tree file to " + self.tree_fn, {
       original_length: self.nwk_tree ? self.nwk_tree.length : 0,
       cleaned_length: cleanTree ? cleanTree.length : 0,
@@ -214,7 +214,7 @@ var descriptor = {
   ]
 };
 
-var fade = factory.makeAnalysis(descriptor);
+const fade = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.fade is the constructor.
 exports.fade = fade;

--- a/app/fel/descriptor.js
+++ b/app/fel/descriptor.js
@@ -6,12 +6,12 @@
  * (pinned by test/golden/qsub-params.js).
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "fel",
   dir: __dirname,
   script: "fel.sh",
@@ -29,7 +29,7 @@ var descriptor = {
     self.bootstrap = src.bootstrap || false;
     self.resample = src.resample || 1;
 
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
       self.rate_variation = "No";
@@ -120,7 +120,7 @@ var descriptor = {
   ]
 };
 
-var fel = factory.makeAnalysis(descriptor);
+const fel = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.fel is the constructor.
 exports.fel = fel;

--- a/app/flea/flea.js
+++ b/app/flea/flea.js
@@ -1,17 +1,17 @@
-var spawn_job = require("./spawn_flea.js"),
+const spawn_job = require("./spawn_flea.js"),
   fs = require("fs"),
   path = require("path"),
   logger = require("../../lib/logger").logger;
 
 // Pass socket to flea job
-var flea = function(socket, stream, params) {
+const flea = function(socket, stream, params) {
 
-  var log = function(notification) {
+  const log = function(notification) {
     logger.info(["flea", JSON.stringify(notification)].join(" : "));
   };
 
   // Setup Analysis
-  var flea_analysis = new spawn_job.FleaRunner();
+  const flea_analysis = new spawn_job.FleaRunner();
 
   // On status updates, report to datamonkey-js
   flea_analysis.on("status update", function(status_update) {
@@ -48,7 +48,7 @@ var flea = function(socket, stream, params) {
     });
   });
 
-  var fn = path.join(__dirname, "/output/", params.analysis._id + ".tar");
+  const fn = path.join(__dirname, "/output/", params.analysis._id + ".tar");
   flea_analysis.start(fn, socket, params);
   socket.emit("status update", { phase: params.status_stack[0], msg: "" });
 

--- a/app/flea/spawn_flea.js
+++ b/app/flea/spawn_flea.js
@@ -1,4 +1,4 @@
-var spawn = require("child_process").spawn,
+const spawn = require("child_process").spawn,
   fs = require("fs"),
   tar = require("tar"),
   path = require("path"),
@@ -19,7 +19,7 @@ var spawn = require("child_process").spawn,
  * Date objects and full datetime strings pass straight through to new Date().
  */
 function formatVisitDate(visit_date) {
-  var d;
+  let d;
   if (typeof visit_date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(visit_date)) {
     d = new Date(visit_date + "T00:00:00");
   } else {
@@ -28,7 +28,7 @@ function formatVisitDate(visit_date) {
   return dateFns.format(d, "yyyyMMdd");
 }
 
-var FleaRunner = function() {};
+const FleaRunner = function() {};
 
 util.inherits(FleaRunner, EventEmitter);
 
@@ -39,7 +39,7 @@ util.inherits(FleaRunner, EventEmitter);
  */
 
 FleaRunner.prototype.start = function(fn, socket, flea_params) {
-  var self = this;
+  const self = this;
 
   self.filepath = fn;
   self.output_dir = path.dirname(self.filepath);
@@ -68,10 +68,10 @@ FleaRunner.prototype.start = function(fn, socket, flea_params) {
   self.session_zip_fn = path.join(self.analysis_dir, "session.zip");
 
   // flea_pipeline.py
-  var flea_pipeline_submit = function() {
+  const flea_pipeline_submit = function() {
     self.emit("status update", { phase: self.status_stack[2], msg: "" });
 
-    var flea_pipeline_parameters = [
+    const flea_pipeline_parameters = [
       "run",
       self.pipeline,
       "-c",
@@ -94,7 +94,7 @@ FleaRunner.prototype.start = function(fn, socket, flea_params) {
             flea_pipeline_parameters.join(" ")
         );
 
-        var flea_pipeline = spawn(self.nextflow, flea_pipeline_parameters, {
+        const flea_pipeline = spawn(self.nextflow, flea_pipeline_parameters, {
           cwd: self.filedir,
           env: Object.assign(process.env, {
             LD_LIBRARY_PATH:
@@ -109,14 +109,14 @@ FleaRunner.prototype.start = function(fn, socket, flea_params) {
         flea_pipeline.stdout.on("data", function(data) {
           self.stdout += String(data);
           logger.info(self.id + " : flea : " + self.stdout);
-          var status_update_packet = { phase: "running", msg: self.stdout };
+          const status_update_packet = { phase: "running", msg: self.stdout };
           self.emit("status update", status_update_packet);
         });
 
         flea_pipeline.stderr.on("data", function(data) {
           self.stderr += String(data);
           logger.info(self.id + " : flea : " + self.stderr);
-          var status_update_packet = { phase: "running", msg: self.stderr };
+          const status_update_packet = { phase: "running", msg: self.stderr };
           self.emit("status update", status_update_packet);
         });
 
@@ -136,7 +136,7 @@ FleaRunner.prototype.start = function(fn, socket, flea_params) {
 
   // Write the contents of the file in the parameters to a file on the
   // local filesystem, then spawn the job.
-  var do_flea = function(stream, flea_params) {
+  const do_flea = function(stream, flea_params) {
     self.emit("status update", { phase: self.status_stack[1], msg: "" });
 
     //Unpack the tar file
@@ -157,8 +157,8 @@ FleaRunner.prototype.start = function(fn, socket, flea_params) {
           // Append to file
           // Format : PC64_V00_small.fastq V00 20080301
           if (files.indexOf(msa._id + ".fastq") != -1) {
-            var formatted_visit_date = formatVisitDate(msa.visit_date);
-            var string_to_write = util.format(
+            const formatted_visit_date = formatVisitDate(msa.visit_date);
+            const string_to_write = util.format(
               "%s %s %s\n",
               self.filedir + "/" + msa._id + ".fastq",
               msa.visit_code,
@@ -175,7 +175,7 @@ FleaRunner.prototype.start = function(fn, socket, flea_params) {
       });
     }
 
-    var extractor = tar
+    const extractor = tar
       .Extract({ path: self.filedir })
       .on("error", onError)
       .on("end", onEnd);
@@ -187,7 +187,7 @@ FleaRunner.prototype.start = function(fn, socket, flea_params) {
 };
 
 FleaRunner.prototype.onComplete = function(fn, flea_params) {
-  var self = this;
+  const self = this;
   self.sendSessionJSONFile((err, success) => {
     self.sendSessionZipFile((err, success) => {
       self.emit("completed", { results: "success" });
@@ -196,7 +196,7 @@ FleaRunner.prototype.onComplete = function(fn, flea_params) {
 };
 
 FleaRunner.prototype.sendSessionJSONFile = function(cb) {
-  var self = this;
+  const self = this;
   fs.readFile(self.session_json_fn, function(err, results) {
     if (results) {
       self.socket.emit("flea session json file", { buffer: results });
@@ -208,7 +208,7 @@ FleaRunner.prototype.sendSessionJSONFile = function(cb) {
 };
 
 FleaRunner.prototype.sendSessionZipFile = function(cb) {
-  var self = this;
+  const self = this;
 
   fs.readFile(self.session_zip_fn, function(err, results) {
     if (results) {

--- a/app/fubar/descriptor.js
+++ b/app/fubar/descriptor.js
@@ -11,12 +11,12 @@
  * number_of_grid_points, concentration_of_dirichlet_prior, procs.
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "fubar",
   dir: __dirname,
   script: "fubar.sh",
@@ -28,7 +28,7 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original fubar.js branches.
   fields: function (self, params, src) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
       self.nwk_tree = params.nwk_tree || params.tree || "";
@@ -70,7 +70,7 @@ var descriptor = {
     utilities.ensureDirectoryExists(self.output_dir);
 
     // Clean tree data and write to file (like Contrast-FEL).
-    var cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
+    const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
     logger.info("FUBAR job " + self.id + ": Writing cleaned tree file to " + self.tree_fn, {
       original_length: self.nwk_tree ? self.nwk_tree.length : 0,
       cleaned_length: cleanTree ? cleanTree.length : 0,
@@ -105,7 +105,7 @@ var descriptor = {
   ]
 };
 
-var fubar = factory.makeAnalysis(descriptor);
+const fubar = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.fubar is the constructor.
 exports.fubar = fubar;

--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -11,14 +11,14 @@ const config = require("../../lib/config"),
 // Use the shared redis v5 client (promise-native, camelCased commands).
 const { client } = require("../../lib/redis-client");
 
-var gard = function(socket, stream, params) {
-  var self = this;
+const gard = function(socket, stream, params) {
+  const self = this;
   self.socket = socket;
   self.stream = stream;
   self.params = params;
   
   // Check if this is a check-only operation
-  var isCheckOnly = params.checkOnly || false;
+  const isCheckOnly = params.checkOnly || false;
   
   logger.info("GARD constructor called with:", {
     stream_type: typeof stream,
@@ -59,7 +59,7 @@ var gard = function(socket, stream, params) {
     self.finalout_results_fn = self.fn + ".best-gard";
   } else {
     // Normal operation with full parameters
-    var analysisParams = self.params.analysis || self.params;
+    const analysisParams = self.params.analysis || self.params;
     
     // parameter attributes with fallbacks
     if (self.params.msa) {
@@ -301,7 +301,7 @@ var gard = function(socket, stream, params) {
 util.inherits(gard, hyphyJob);
 
 gard.prototype.sendNexusFile = function(cb) {
-  var self = this;
+  const self = this;
 
   fs.readFile(self.finalout_results_fn, function(err, results) {
     if (results) {
@@ -314,9 +314,9 @@ gard.prototype.sendNexusFile = function(cb) {
 };
 
 gard.prototype.onComplete = function() {
-  var self = this;
+  const self = this;
 
-  var files = {
+  const files = {
     finalout: self.finalout_results_fn,
     json: self.results_fn
   };
@@ -335,12 +335,12 @@ gard.prototype.onComplete = function() {
           self.onError("unable to read results file. " + err);
         } else {
 
-          var stringified_results = String(data);
+          const stringified_results = String(data);
 
           // Prepare redis packet for delivery
-          var redis_packet = { results: stringified_results };
+          const redis_packet = { results: stringified_results };
           redis_packet.type = "completed";
-          var str_redis_packet = JSON.stringify(redis_packet);
+          const str_redis_packet = JSON.stringify(redis_packet);
 
           // Log that the job has been completed
           self.log("complete", "success");

--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -1,4 +1,4 @@
-var spawn = require("child_process").spawn,
+const spawn = require("child_process").spawn,
   cs = require("../../lib/clientsocket.js"),
   fs = require("fs"),
   config = require("../../lib/config"),
@@ -15,12 +15,12 @@ var spawn = require("child_process").spawn,
 // Use the shared redis v5 client (promise-native, camelCased commands) for
 // key-value + publish, and createSubscriber() for the dedicated pub/sub
 // connection (redis v5 requires a separate connection for subscriber mode).
-var { client, createSubscriber } = require("../../lib/redis-client");
+const { client, createSubscriber } = require("../../lib/redis-client");
 
 // Small replacement for underscore's _.once — returns a function that invokes
 // fn at most once and caches its result.
 function once(fn) {
-  var called = false,
+  let called = false,
     result;
   return function () {
     if (!called) {
@@ -32,10 +32,10 @@ function once(fn) {
 }
 
 // Promisified fs.readFile (replaces Q.nfcall(fs.readFile, ...)).
-var readFileAsync = util.promisify(fs.readFile);
+const readFileAsync = util.promisify(fs.readFile);
 
-var hivtrace = function(socket, stream, params) {
-  var self = this;
+const hivtrace = function(socket, stream, params) {
+  const self = this;
 
   self.status_states = {
     PENDING: 1,
@@ -43,7 +43,7 @@ var hivtrace = function(socket, stream, params) {
     COMPLETED: 3
   };
 
-  var cluster_output_suffix = "_user.trace.json",
+  const cluster_output_suffix = "_user.trace.json",
     tn93_json_suffix = "_user.tn93output.json",
     tn93_csv_suffix = "_user.tn93output.csv",
     custom_reference_suffix = "_custom_reference.fas",
@@ -103,7 +103,7 @@ var hivtrace = function(socket, stream, params) {
   self.aligned_fasta = self.filepath + output_fasta_suffix;
   self.hivtrace_log = self.filepath + hivtrace_log_suffix;
 
-  var initial_statuses = [];
+  const initial_statuses = [];
   (self.status_stack || []).forEach(function(d) {
     initial_statuses.push({ title: d, status: self.status_states.PENDING });
   });
@@ -182,7 +182,7 @@ var hivtrace = function(socket, stream, params) {
 util.inherits(hivtrace, hyphyJob);
 
 hivtrace.prototype.spawn = function() {
-  var self = this;
+  const self = this;
   self.send_aligned_fasta_once = once(self.sendAlignedFasta.bind(self));
   self.send_tn93_once = once(self.sendtn93.bind(self));
 
@@ -193,14 +193,14 @@ hivtrace.prototype.spawn = function() {
   );
 
   // Setup Analysis
-  var trace_runner = new HivTraceRunner(self.id, self.hivtrace_log);
+  const trace_runner = new HivTraceRunner(self.id, self.hivtrace_log);
   self.trace_runner = trace_runner;
   self.client_socket = new cs.ClientSocket(self.socket, self.id);
 
   // On status updates, report to datamonkey-js
   trace_runner.on("status update", function(status_update) {
-    var index = status_update.index;
-    var status = status_update.status;
+    const index = status_update.index;
+    const status = status_update.status;
 
     try {
       self.onStatusUpdate(status_update, status_update.index);
@@ -263,9 +263,9 @@ hivtrace.prototype.spawn = function() {
   // Choose the appropriate submission method based on config.submit_type
   if (self.submit_type === "local") {
     // For local submission, create job parameters as environment variables
-    var job_params = {};
+    const job_params = {};
     self.params_string.split(",").forEach(function(param) {
-      var parts = param.split("=");
+      const parts = param.split("=");
       if (parts.length === 2) {
         job_params[parts[0]] = parts[1];
       }
@@ -281,7 +281,7 @@ hivtrace.prototype.spawn = function() {
 };
 
 hivtrace.prototype.onStatusUpdate = function(data, index) {
-  var self = this;
+  const self = this;
 
   if (!data) {
     return;
@@ -301,7 +301,7 @@ hivtrace.prototype.onStatusUpdate = function(data, index) {
       //  'msg'    : msg
       //}
 
-      var new_status = JSON.parse(entire_status);
+      const new_status = JSON.parse(entire_status);
 
       // validate new_status and index
       if (new_status === undefined) {
@@ -324,7 +324,7 @@ hivtrace.prototype.onStatusUpdate = function(data, index) {
 
       new_status[data.index].msg = data.msg ? data.msg : "";
 
-      var status_update = {
+      const status_update = {
         msg: new_status,
         torque_id: self.torque_id
       };
@@ -332,9 +332,9 @@ hivtrace.prototype.onStatusUpdate = function(data, index) {
       // Prepare redis packet for delivery
       client.hSet(self.id, "status update", JSON.stringify(data));
 
-      var redis_packet = status_update;
+      const redis_packet = status_update;
       redis_packet.type = "status update";
-      var str_redis_packet = JSON.stringify(status_update);
+      const str_redis_packet = JSON.stringify(status_update);
 
       // Store packet in redis and publish to channel
       client.hSet(self.id, "complete phase status", JSON.stringify(new_status));
@@ -351,19 +351,19 @@ hivtrace.prototype.onStatusUpdate = function(data, index) {
 };
 
 hivtrace.prototype.onComplete = function() {
-  var self = this;
+  const self = this;
   client.hSet(self.id, "status", "completed");
 
-  var results_promise = readFileAsync(self.output_cluster_output, "utf-8");
-  var promises = [results_promise];
+  const results_promise = readFileAsync(self.output_cluster_output, "utf-8");
+  const promises = [results_promise];
 
   // Native Promise.allSettled result shape is {status, value/reason}
   // (q's allSettled used {state, value/reason}).
   Promise.allSettled(promises).then(function(results) {
     if (results[0].status == "fulfilled" && results[0].value) {
-      var results_data = JSON.parse(results[0].value);
-      var redis_packet = { type: "completed" };
-      var str_redis_packet = JSON.stringify(redis_packet);
+      const results_data = JSON.parse(results[0].value);
+      const redis_packet = { type: "completed" };
+      const str_redis_packet = JSON.stringify(redis_packet);
 
       // Log that the job has been completed
       self.log("complete", "success");
@@ -385,7 +385,7 @@ hivtrace.prototype.onComplete = function() {
 };
 
 hivtrace.prototype.onJobCreated = function(torque_id) {
-  var self = this;
+  const self = this;
 
   self.push_active_job = function(id) {
     client.rPush("active_jobs", self.id);
@@ -393,9 +393,9 @@ hivtrace.prototype.onJobCreated = function(torque_id) {
 
   self.push_job_once = once(self.push_active_job);
   self.setTorqueParameters(torque_id);
-  var redis_packet = torque_id;
+  const redis_packet = torque_id;
   redis_packet.type = "job created";
-  var str_redis_packet = JSON.stringify(torque_id);
+  const str_redis_packet = JSON.stringify(torque_id);
   self.log("job created", str_redis_packet);
   client.hSet(self.id, "torque_id", str_redis_packet);
   client.publish(self.id, str_redis_packet);
@@ -405,10 +405,10 @@ hivtrace.prototype.onJobCreated = function(torque_id) {
 };
 
 hivtrace.prototype.sendAlignedFasta = function() {
-  var self = this;
+  const self = this;
 
-  var aligned_promise = readFileAsync(self.aligned_fasta);
-  var promises = [aligned_promise];
+  const aligned_promise = readFileAsync(self.aligned_fasta);
+  const promises = [aligned_promise];
 
   Promise.allSettled(promises).then(function(results) {
     if (results[0].status == "fulfilled" && results[0].value) {
@@ -423,9 +423,9 @@ hivtrace.prototype.sendAlignedFasta = function() {
 };
 
 hivtrace.prototype.sendtn93 = function() {
-  var self = this;
-  var tn93_promise = readFileAsync(self.tn93_results);
-  var promises = [tn93_promise];
+  const self = this;
+  const tn93_promise = readFileAsync(self.tn93_results);
+  const promises = [tn93_promise];
 
   Promise.allSettled(promises).then(function(results) {
     if (results[0].status == "fulfilled" && results[0].value) {
@@ -439,8 +439,8 @@ hivtrace.prototype.sendtn93 = function() {
 };
 
 // An object that manages the job submission process
-var HivTraceRunner = function(id, hivtrace_log) {
-  var self = this;
+const HivTraceRunner = function(id, hivtrace_log) {
+  const self = this;
   self.python_redis_channel = "python_" + id;
   self.hivtrace_log = hivtrace_log;
   self.last_status_update = "";
@@ -471,7 +471,7 @@ var HivTraceRunner = function(id, hivtrace_log) {
       }
 
       return subscriber.subscribe(self.python_redis_channel, function(message) {
-        var redis_packet = JSON.parse(message);
+        const redis_packet = JSON.parse(message);
         logger.info(redis_packet);
 
         if (message != self.last_status_update) {
@@ -495,7 +495,7 @@ util.inherits(HivTraceRunner, EventEmitter);
  * See issue #397.
  */
 HivTraceRunner.prototype.close = function() {
-  var self = this;
+  const self = this;
   if (self._closed) return;
   self._closed = true;
 
@@ -519,7 +519,7 @@ HivTraceRunner.prototype.close = function() {
   // Wait for that to settle so we never leak a subscriber that finished
   // connecting after close() ran, then unsubscribe + quit. The _closed flag
   // set above also makes the connect() handler self-quit if it wins the race.
-  var teardown = self.subscriber_ready
+  const teardown = self.subscriber_ready
     ? Promise.resolve(self.subscriber_ready)
     : Promise.resolve();
 
@@ -547,7 +547,7 @@ HivTraceRunner.prototype.close = function() {
 };
 
 HivTraceRunner.prototype.log_publisher = function() {
-  var self = this;
+  const self = this;
 
   // read log file (stored on self so close() can stop watching it; GH #400)
   self.tail = new Tail(self.hivtrace_log);
@@ -556,11 +556,13 @@ HivTraceRunner.prototype.log_publisher = function() {
     logger.debug(data);
 
     if (data.indexOf("INFO:") != -1) {
-      var msg = "";
+      let msg = "";
+      // declared outside the try so the catch handler can reference it
+      let info;
 
       // try parsing the message
       try {
-        var info = data.split("INFO:")[1].split("root:")[1];
+        info = data.split("INFO:")[1].split("root:")[1];
         msg = JSON.parse(info);
       } catch (e) {
         logger.warn("error" + e + " for " + info);
@@ -577,17 +579,17 @@ HivTraceRunner.prototype.log_publisher = function() {
  * sends updates to.
  */
 HivTraceRunner.prototype.status_watcher = function() {
-  var self = this;
+  const self = this;
   
   // For local jobs, no status watcher is needed
   if (self.submit_type === "local") {
     return;
   }
 
-  var job_status = new JobStatus(self.torque_id);
+  const job_status = new JobStatus(self.torque_id);
 
   self.metronome_id = job_status.watch(function(error, status) {
-    var new_status = status.status;
+    const new_status = status.status;
 
     if (new_status == "completed" || new_status == "exiting") {
       // check exit code
@@ -606,10 +608,10 @@ HivTraceRunner.prototype.status_watcher = function() {
  * Emit events that are being listened for by the calling class
  */
 HivTraceRunner.prototype.submit = function(qsub_params, cwd) {
-  var self = this;
+  const self = this;
 
-  var qsub_submit = function() {
-    var qsub = spawn("qsub", qsub_params, { cwd: cwd });
+  const qsub_submit = function() {
+    const qsub = spawn("qsub", qsub_params, { cwd: cwd });
 
     qsub.stderr.on("data", function(data) {
       // error when starting job
@@ -640,12 +642,12 @@ HivTraceRunner.prototype.submit = function(qsub_params, cwd) {
  * Emit events that are being listened for by the calling class
  */
 HivTraceRunner.prototype.submit_slurm = function(slurm_params, cwd) {
-  var self = this;
+  const self = this;
   
   logger.info("Submitting job to SLURM", slurm_params);
 
-  var sbatch_submit = function() {
-    var sbatch = spawn("sbatch", slurm_params, { cwd: cwd });
+  const sbatch_submit = function() {
+    const sbatch = spawn("sbatch", slurm_params, { cwd: cwd });
 
     sbatch.stderr.on("data", function(data) {
       // error when starting job
@@ -680,12 +682,12 @@ HivTraceRunner.prototype.submit_slurm = function(slurm_params, cwd) {
  * Emit events that are being listened for by the calling class
  */
 HivTraceRunner.prototype.submit_local = function(script, params, cwd) {
-  var self = this;
+  const self = this;
   
   logger.info("Submitting job locally", script, params);
 
-  var local_submit = function() {
-    var proc = spawn(script, { cwd: cwd, env: params });
+  const local_submit = function() {
+    const proc = spawn(script, { cwd: cwd, env: params });
     
     // Use process id as job identifier
     self.torque_id = "local_" + process.pid;

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -8,18 +8,18 @@ const cs = require("../lib/clientsocket.js"),
   JobStatus = require(__dirname + "/../lib/jobstatus.js").JobStatus,
   config = require("../lib/config");
 
-var jobRegistry = require("../lib/jobregistry.js");
+const jobRegistry = require("../lib/jobregistry.js");
 
 // Use the shared redis@5 client factory (see lib/redis-client.js). redis@5 is
 // promise-native and camelCases commands (hset -> hSet, hget -> hGet,
 // rpush -> rPush, lrem -> lRem, llen -> lLen).
-var client = require("../lib/redis-client").client;
+const client = require("../lib/redis-client").client;
 
 // Native replacement for underscore's _.once: returns a function that invokes
 // `fn` at most once, caching and returning that first result thereafter.
 function once(fn) {
-  var called = false;
-  var result;
+  let called = false;
+  let result;
   return function() {
     if (!called) {
       called = true;
@@ -30,7 +30,7 @@ function once(fn) {
 }
 
 // Promisified fs.readFile for the q -> native Promise migration in onError().
-var readFileAsync = util.promisify(fs.readFile);
+const readFileAsync = util.promisify(fs.readFile);
 
 // Prepend a scheduler --comment flag carrying the submission source so SLURM
 // accounting (sacct/scontrol) records which path submitted the job. Grafana
@@ -43,10 +43,10 @@ function injectSubmissionSource(qsub_params, source, submit_type) {
   return ["--comment=source=" + source].concat(qsub_params);
 }
 
-var hyphyJob = function() {};
+const hyphyJob = function() {};
 
 hyphyJob.prototype.log = function(notification, complementary_info) {
-  var self = this;
+  const self = this;
 
   if (complementary_info) {
     logger.info(
@@ -58,7 +58,7 @@ hyphyJob.prototype.log = function(notification, complementary_info) {
 };
 
 hyphyJob.prototype.warn = function(notification, complementary_info) {
-  var self = this;
+  const self = this;
   if (complementary_info) {
     logger.warn(
       [self.type, self.id, notification, complementary_info].join(" : ")
@@ -70,14 +70,14 @@ hyphyJob.prototype.warn = function(notification, complementary_info) {
 
 // Attach socket to redis channel
 hyphyJob.prototype.attachSocket = function() {
-  var self = this;
+  const self = this;
   logger.info(`[DEBUG REDIS] Attaching socket to job ${self.id}`);
   self.client_socket = new cs.ClientSocket(self.socket, self.id);
 };
 
 // Can either initialize a new job or check on previous one
 hyphyJob.prototype.init = function() {
-  var self = this;
+  const self = this;
 
   // store parameters in redis
   logger.info(`Job ${self.id}: Storing parameters in redis`);
@@ -98,11 +98,11 @@ hyphyJob.prototype.init = function() {
 };
 
 hyphyJob.prototype.spawn = function() {
-  var self = this;
+  const self = this;
 
   self.log("spawning");
 
-  var source = (self.params && self.params.submission_source)
+  const source = (self.params && self.params.submission_source)
             || (self.params && self.params.analysis && self.params.analysis.submission_source)
             || "unknown";
   self.qsub_params = injectSubmissionSource(self.qsub_params, source, config.submit_type);
@@ -113,7 +113,7 @@ hyphyJob.prototype.spawn = function() {
   logger.info(`[JOB START] Parameters: ${JSON.stringify(self.qsub_params)}`);
   logger.info(`[JOB START] Results file: ${self.results_fn}`);
   logger.info(`[DEBUG HYPHY] Job ${self.id}: About to create jobRunner instance`);
-  var hyphy_job_runner = new job.jobRunner(self.qsub_params, self.results_fn);
+  const hyphy_job_runner = new job.jobRunner(self.qsub_params, self.results_fn);
   logger.info(`[DEBUG HYPHY] Job ${self.id}: jobRunner instance created successfully`);
 
   // On status updates, report to datamonkey-js
@@ -233,7 +233,7 @@ hyphyJob.prototype.spawn = function() {
 };
 
 hyphyJob.prototype.onJobCreated = function(torque_id) {
-  var self = this;
+  const self = this;
 
   self.push_active_job = function() {
     client.rPush("active_jobs", self.id);
@@ -263,7 +263,7 @@ hyphyJob.prototype.onJobCreated = function(torque_id) {
     status_update.raw_status = torque_id.raw_status;
   }
   
-  var str_redis_packet = JSON.stringify(status_update);
+  const str_redis_packet = JSON.stringify(status_update);
 
   self.log("job created", str_redis_packet);
 
@@ -297,7 +297,7 @@ hyphyJob.prototype.onJobCreated = function(torque_id) {
 };
 
 hyphyJob.prototype.onComplete = function() {
-  var self = this;
+  const self = this;
 
   fs.readFile(self.results_fn, "utf8", function(err, data) {
     if (err) {
@@ -306,10 +306,10 @@ hyphyJob.prototype.onComplete = function() {
     } else {
       if (data && data.length > 0) {
         // Prepare redis packet for delivery
-        var redis_packet = { results: data };
+        const redis_packet = { results: data };
         redis_packet.type = "completed";
 
-        var str_redis_packet = JSON.stringify(redis_packet);
+        const str_redis_packet = JSON.stringify(redis_packet);
 
         // Log that the job has been completed
         self.log("complete", "success");
@@ -353,7 +353,7 @@ hyphyJob.prototype.onComplete = function() {
 };
 
 hyphyJob.prototype.onStatusUpdate = function(data) {
-  var self = this;
+  const self = this;
   
   // If data is an object, extract the message
   let statusMessage = data;
@@ -371,7 +371,7 @@ hyphyJob.prototype.onStatusUpdate = function(data) {
   self.current_status = statusMessage;
 
   // Create enhanced status update with scheduler info
-  var status_update = {
+  const status_update = {
     msg: self.current_status,
     torque_id: self.torque_id,
     id: self.id,
@@ -395,10 +395,10 @@ hyphyJob.prototype.onStatusUpdate = function(data) {
   }
 
   // Prepare redis packet for delivery
-  var redis_packet = status_update;
+  const redis_packet = status_update;
   redis_packet.type = "status update";
 
-  var str_redis_packet = JSON.stringify(redis_packet);
+  const str_redis_packet = JSON.stringify(redis_packet);
 
   // Store packet in redis and publish to channel
   logger.info(`[DEBUG REDIS] Publishing status update to channel: ${self.id}`);
@@ -415,7 +415,7 @@ hyphyJob.prototype.onStatusUpdate = function(data) {
 };
 
 hyphyJob.prototype.onJobMetadata = function(data) {
-  var self = this;
+  const self = this;
   self.stime = data.stime;
   self.ctime = data.ctime;
   
@@ -438,7 +438,7 @@ hyphyJob.prototype.onJobMetadata = function(data) {
       metadata_update.raw_status = data.raw_status;
     }
     
-    var str_redis_packet = JSON.stringify(metadata_update);
+    const str_redis_packet = JSON.stringify(metadata_update);
     
     self.log("job metadata", str_redis_packet);
     
@@ -453,10 +453,10 @@ hyphyJob.prototype.onJobMetadata = function(data) {
 
 // If a job is cancelled early or the result contents cannot be read
 hyphyJob.prototype.onError = function(error) {
-  var self = this;
+  const self = this;
 
   // The packet that will delivered to datamonkey via the publish command
-  var redis_packet = { error: error };
+  const redis_packet = { error: error };
   redis_packet.type = "script error";
 
   // Read error path contents. q's Q.nfcall + Q.allSettled are replaced with
@@ -465,11 +465,11 @@ hyphyJob.prototype.onError = function(error) {
   // {status:'fulfilled'|'rejected', value/reason}. A rejected read therefore
   // has no `.value`, so the `|| "No ... content"` fallbacks below cover the
   // missing-file case exactly as before.
-  var std_err_promise = readFileAsync(self.std_err, "utf-8");
-  var progress_fn_promise = readFileAsync(self.progress_fn, "utf-8");
-  var std_out_promise = readFileAsync(self.std_out, "utf-8");
+  const std_err_promise = readFileAsync(self.std_err, "utf-8");
+  const progress_fn_promise = readFileAsync(self.progress_fn, "utf-8");
+  const std_out_promise = readFileAsync(self.std_out, "utf-8");
 
-  var promises = [std_err_promise, progress_fn_promise, std_out_promise];
+  const promises = [std_err_promise, progress_fn_promise, std_out_promise];
 
   Promise.allSettled(promises).then(function(results) {
     // Prepare redis packet for delivery
@@ -477,7 +477,7 @@ hyphyJob.prototype.onError = function(error) {
     redis_packet.progress = results[1].value || "No progress content";
     redis_packet.stdout = results[2].value || "No stdout content";
 
-    var str_redis_packet = JSON.stringify(redis_packet);
+    const str_redis_packet = JSON.stringify(redis_packet);
 
     // Enhanced logging for script errors
     logger.error(`[SCRIPT ERROR] Job ${self.id} failed`);
@@ -517,7 +517,7 @@ hyphyJob.prototype.onError = function(error) {
 // Called when a job is first created
 // Set id and output file names
 hyphyJob.prototype.setTorqueParameters = function(torque_id) {
-  var self = this;
+  const self = this;
   
   // Extract the ID, considering both object and string formats
   if (typeof torque_id === "object" && torque_id.torque_id) {
@@ -553,9 +553,9 @@ hyphyJob.prototype.setTorqueParameters = function(torque_id) {
 
 // Cancel the job and report an error
 hyphyJob.prototype.cancel = function() {
-  var self = this;
+  const self = this;
 
-  var cb = function() {
+  const cb = function() {
     self.onError("job cancelled");
   };
 
@@ -567,11 +567,11 @@ hyphyJob.prototype.cancel = function() {
 
 // Validate parameters for check-only mode
 hyphyJob.prototype.validateParameters = function() {
-  var self = this;
+  const self = this;
   
   // Basic validation - can be overridden by specific analysis types
-  var errors = [];
-  var valid = true;
+  const errors = [];
+  let valid = true;
   
   // Check required parameters based on analysis type
   if (!self.params.analysis_type) {
@@ -596,13 +596,13 @@ hyphyJob.prototype.validateParameters = function() {
 
 // Return whether job has completed, still running, or aborted
 hyphyJob.prototype.checkJob = function() {
-  var self = this;
+  const self = this;
 
   // Get results file stats
   fs.stat(self.results_fn, (err, res) => {
     if (err || !res) {
       // Get status of job
-      var jobStatus = new JobStatus(self.torque_id);
+      const jobStatus = new JobStatus(self.torque_id);
       jobStatus.returnJobStatus(self.torque_id, function(err, status) {
         if (err) {
           // If job has no status returned and there are no results, return aborted

--- a/app/job.js
+++ b/app/job.js
@@ -1,4 +1,4 @@
-var spawn = require("child_process").spawn,
+const spawn = require("child_process").spawn,
   fs = require("fs"),
   util = require("util"),
   cs = require("../lib/clientsocket.js"),
@@ -10,12 +10,12 @@ var spawn = require("child_process").spawn,
 
 // Use the shared redis@5 client factory (see lib/redis-client.js). redis@5 is
 // promise-native and camelCases commands (hgetall -> hGetAll, hset -> hSet).
-var client = require("../lib/redis-client").client;
+const client = require("../lib/redis-client").client;
 
 // resubscribes a socket to an existing pending job,
 // otherwise reports contents from redis
-var resubscribe = function(socket, id) {
-  var self = this;
+const resubscribe = function(socket, id) {
+  const self = this;
   self.id = id;
 
   // redis@5 commands return promises; hGetAll resolves to the hash (an empty
@@ -29,7 +29,7 @@ var resubscribe = function(socket, id) {
     }
 
     // check job status
-    var current_status = obj.status;
+    const current_status = obj.status;
     logger.info(self.id + " : job : current status : " + obj.status);
     if (current_status != "completed" && current_status != "exiting") {
       // if job is still pending, resubscribe
@@ -42,7 +42,7 @@ var resubscribe = function(socket, id) {
     } else if (current_status == "completed") {
       // if job completed, emit results
       logger.info(self.id + " : job : resubscribe : job completed");
-      var json_results = JSON.parse(obj.results);
+      const json_results = JSON.parse(obj.results);
       socket.emit("completed", json_results);
       socket.disconnect();
     } else {
@@ -55,8 +55,8 @@ var resubscribe = function(socket, id) {
   });
 };
 
-var cancel = function(socket, id) {
-  var self = this;
+const cancel = function(socket, id) {
+  const self = this;
   self.id = id;
 
   client.hGetAll(self.id).then(function(obj) {
@@ -67,8 +67,8 @@ var cancel = function(socket, id) {
     }
 
     // check job status
-    var current_status = obj.status,
-      torque_id = "";
+    const current_status = obj.status;
+    let torque_id = "";
 
     try {
       torque_id = JSON.parse(obj.torque_id).torque_id;
@@ -108,8 +108,8 @@ var cancel = function(socket, id) {
   });
 };
 
-var jobRunner = function(params, results_fn) {
-  var self = this;
+const jobRunner = function(params, results_fn) {
+  const self = this;
   self.torque_id = "";
   self.error_count = 0;
   self.QSTAT_ERROR_LIMIT = 500;
@@ -158,7 +158,7 @@ function get_slurm_id_from_data(data) {
 // Submits a job to the scheduler (TORQUE, SLURM, or local) by spawning a submission script.
 // Emit events
 jobRunner.prototype.submit = function(params, cwd) {
-  var self = this;
+  const self = this;
   self.qsub_params = params;
 
   // Handle local execution
@@ -179,9 +179,12 @@ jobRunner.prototype.submit = function(params, cwd) {
   logger.info(`[${scheduler.toUpperCase()} JOB] Job submission using ${scheduler} with params: ${JSON.stringify(params)}`);
   logger.info(`[${scheduler.toUpperCase()} JOB] Working directory: ${cwd}`);
   
+  // declared outside the try so the spawned process is visible to the
+  // event-handler wiring below (the catch returns on failure)
+  let qsub;
   try {
     console.log(`EXECUTING: ${fullCommand}`);
-    var qsub = spawn(scheduler, params, { cwd: cwd });
+    qsub = spawn(scheduler, params, { cwd: cwd });
     logger.info(`${scheduler} process spawned successfully with pid: ${qsub.pid}`);
   } catch (error) {
     logger.error(`Error spawning ${scheduler} process: ${error.message}`);
@@ -205,7 +208,7 @@ jobRunner.prototype.submit = function(params, cwd) {
     console.log(`${scheduler} STDOUT: ${output}`);
     
     try {
-      var torque_id = self.submit_type === "qsub" 
+      const torque_id = self.submit_type === "qsub" 
         ? get_torque_id_from_data(data) 
         : get_slurm_id_from_data(data);
       
@@ -239,7 +242,7 @@ jobRunner.prototype.submit = function(params, cwd) {
 
 // Local job submission - used when submit_type is 'local'
 jobRunner.prototype.submit_local = function(script, params, cwd) {
-  var self = this;
+  const self = this;
   
   logger.info("[LOCAL JOB] Starting local job submission");
   logger.info(`[LOCAL JOB] Script: ${script}`);
@@ -260,7 +263,7 @@ jobRunner.prototype.submit_local = function(script, params, cwd) {
   
   try {
     // For local execution, pass params as command line arguments
-    var proc = spawn(script, params, { cwd: cwd });
+    const proc = spawn(script, params, { cwd: cwd });
     
     // Store process reference for cancellation
     self.local_process = proc;
@@ -316,18 +319,18 @@ jobRunner.prototype.submit_local = function(script, params, cwd) {
 
 // SLURM job submission with specific parameters
 jobRunner.prototype.submit_slurm = function(script, cwd, slurm_params) {
-  var self = this;
+  const self = this;
   
   logger.info("SLURM job submission", script, slurm_params);
   
-  var sbatch = spawn("sbatch", slurm_params, { cwd: cwd });
+  const sbatch = spawn("sbatch", slurm_params, { cwd: cwd });
   
   sbatch.stderr.on("data", function(data) {
     logger.info("SLURM stderr: " + data.toString("utf8"));
   });
   
   sbatch.stdout.on("data", function(data) {
-    var job_id = get_slurm_id_from_data(data);
+    const job_id = get_slurm_id_from_data(data);
     self.torque_id = job_id;
     self.emit("job created", { torque_id: job_id });
   });
@@ -340,7 +343,7 @@ jobRunner.prototype.submit_slurm = function(script, cwd, slurm_params) {
 // Once the job has been scheduled, we need to watch the files that it
 // sends updates to.
 jobRunner.prototype.status_watcher = function() {
-  var self = this;
+  const self = this;
   
   // Don't create a job status watcher for local jobs
   if (self.submit_type === "local") {
@@ -348,7 +351,7 @@ jobRunner.prototype.status_watcher = function() {
   }
   
   logger.info(`Starting job status watcher for job ID: ${self.torque_id}`);
-  var job_status = new JobStatus(self.torque_id);
+  const job_status = new JobStatus(self.torque_id);
 
   self.metronome_id = job_status.watch(function(error, status_packet) {
     // Log status updates for debugging

--- a/app/meme/descriptor.js
+++ b/app/meme/descriptor.js
@@ -6,12 +6,12 @@
  * (pinned by test/golden/qsub-params.snapshot.json).
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "meme",
   dir: __dirname,
   script: "meme.sh",
@@ -31,7 +31,7 @@ var descriptor = {
     self.bootstrap = src.bootstrap || false;
     self.resample = src.resample || 0;
 
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
     } else {
@@ -60,7 +60,7 @@ var descriptor = {
       self.params.analysis.msa &&
       typeof self.params.analysis.msa === "object"
     ) {
-      var msa = self.params.analysis.msa[0];
+      const msa = self.params.analysis.msa[0];
 
       if (msa.usertree && msa.usertree.trim()) {
         // Use the usertree if it is populated.
@@ -134,7 +134,7 @@ var descriptor = {
   ]
 };
 
-var meme = factory.makeAnalysis(descriptor);
+const meme = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.meme is the constructor.
 exports.meme = meme;

--- a/app/multihit/descriptor.js
+++ b/app/multihit/descriptor.js
@@ -10,12 +10,12 @@
  * fields are the multiple/triple hit rate params (rate_classes, triple_islands).
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "multihit",
   dir: __dirname,
   script: "multihit.sh",
@@ -30,7 +30,7 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original multihit.js branches.
   fields: function (self, params, src) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
       self.rate_classes = params.rate_classes || params.rates || 1;
@@ -81,7 +81,7 @@ var descriptor = {
     utilities.ensureDirectoryExists(self.output_dir);
 
     // Clean tree data and write to file.
-    var cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
+    const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
     logger.info("MultiHit job " + self.id + ": Writing cleaned tree file to " + self.tree_fn, {
       original_length: self.nwk_tree ? self.nwk_tree.length : 0,
       cleaned_length: cleanTree ? cleanTree.length : 0,
@@ -118,7 +118,7 @@ var descriptor = {
   ]
 };
 
-var multihit = factory.makeAnalysis(descriptor);
+const multihit = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.multihit is the constructor.
 exports.multihit = multihit;

--- a/app/nrm/descriptor.js
+++ b/app/nrm/descriptor.js
@@ -12,12 +12,12 @@
  * fn/tree_fn/sfn/pfn/rfn/treemode order while pointing rfn at results_fn.
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "nrm",
   dir: __dirname,
   script: "nrm.sh",
@@ -33,7 +33,7 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original nrm.js branches.
   fields: function (self, params, src) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
       self.branches = params.branches || "All";
@@ -75,7 +75,7 @@ var descriptor = {
     utilities.ensureDirectoryExists(self.output_dir);
 
     // Clean tree data and write to file.
-    var cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
+    const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
     logger.info("NRM job " + self.id + ": Writing cleaned tree file to " + self.tree_fn, {
       original_length: self.nwk_tree ? self.nwk_tree.length : 0,
       cleaned_length: cleanTree ? cleanTree.length : 0,
@@ -114,7 +114,7 @@ var descriptor = {
   ]
 };
 
-var nrm = factory.makeAnalysis(descriptor);
+const nrm = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.nrm is the constructor.
 exports.nrm = nrm;

--- a/app/prime/descriptor.js
+++ b/app/prime/descriptor.js
@@ -9,12 +9,12 @@
  * descriptor sets prefixKeys (no treemode).
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "prime",
   dir: __dirname,
   script: "prime.sh",
@@ -35,7 +35,7 @@ var descriptor = {
     self.impute_states = src.impute_states || src["impute-states"] || "No";
     self.branches = src.branches || "All";
 
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
     } else {
@@ -64,7 +64,7 @@ var descriptor = {
       self.params.analysis.msa &&
       typeof self.params.analysis.msa === "object"
     ) {
-      var msa = self.params.analysis.msa[0];
+      const msa = self.params.analysis.msa[0];
 
       if (msa.usertree && msa.usertree.trim()) {
         self.selectedTree = msa.usertree;
@@ -130,7 +130,7 @@ var descriptor = {
   ]
 };
 
-var prime = factory.makeAnalysis(descriptor);
+const prime = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.prime is the constructor.
 exports.prime = prime;

--- a/app/relax/descriptor.js
+++ b/app/relax/descriptor.js
@@ -10,12 +10,12 @@
  * uppercase "RELAX" suffix (self.fn + ".RELAX.progress" / ".RELAX.json").
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "relax",
   dir: __dirname,
   script: "relax.sh",
@@ -31,7 +31,7 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original relax.js branches.
   fields: function (self, params, src) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || "Universal";
       self.mode = params.mode || "Classic mode";
@@ -128,7 +128,7 @@ var descriptor = {
   ]
 };
 
-var relax = factory.makeAnalysis(descriptor);
+const relax = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.relax is the constructor.
 exports.relax = relax;

--- a/app/slac/descriptor.js
+++ b/app/slac/descriptor.js
@@ -6,12 +6,12 @@
  * (pinned by test/golden/qsub-params.js).
  */
 
-var factory = require("../../lib/analysis-factory.js");
-var fs = require("fs");
-var utilities = require("../../lib/utilities");
-var logger = require("../../lib/logger").logger;
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
 
-var descriptor = {
+const descriptor = {
   type: "slac",
   dir: __dirname,
   script: "slac.sh",
@@ -23,7 +23,7 @@ var descriptor = {
   // raw params; in normal mode it is params.analysis (or params). This mirrors
   // the original slac.js branches.
   fields: function (self, params, src, ctx) {
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     if (isCheckOnly) {
       self.genetic_code = params.genetic_code || params.code || "Universal";
       self.branches = params.branches || "All";
@@ -59,7 +59,7 @@ var descriptor = {
       self.params.analysis.msa &&
       typeof self.params.analysis.msa === "object"
     ) {
-      var msa = self.params.analysis.msa[0];
+      const msa = self.params.analysis.msa[0];
 
       if (msa && msa.usertree && msa.usertree.trim()) {
         self.selectedTree = msa.usertree;
@@ -115,7 +115,7 @@ var descriptor = {
   ]
 };
 
-var slac = factory.makeAnalysis(descriptor);
+const slac = factory.makeAnalysis(descriptor);
 
 // Preserve the original module's export shape: exports.slac is the constructor.
 exports.slac = slac;

--- a/lib/analysis-factory.js
+++ b/lib/analysis-factory.js
@@ -55,23 +55,23 @@
  * }
  */
 
-var path = require("path");
-var util = require("util");
-var config = require("./config");
-var logger = require("./logger").logger;
-var hyphyJob = require("../app/hyphyjob.js").hyphyJob;
-var code = require("../app/code").code;
-var model = require("../app/model").model;
+const path = require("path");
+const util = require("util");
+const config = require("./config");
+const logger = require("./logger").logger;
+const hyphyJob = require("../app/hyphyjob.js").hyphyJob;
+const code = require("../app/code").code;
+const model = require("../app/model").model;
 
 // Convert a PBS walltime (D:HH:MM:SS or HH:MM:SS) to SLURM format, matching the
 // per-analysis inline logic exactly.
 function toSlurmTime(walltime) {
-  var slurmTime = "72:00:00";
+  let slurmTime = "72:00:00";
   if (walltime) {
-    var parts = walltime.split(":");
+    const parts = walltime.split(":");
     if (parts.length === 4) {
-      var days = parseInt(parts[0]);
-      var hours = parseInt(parts[1]) + days * 24;
+      const days = parseInt(parts[0]);
+      const hours = parseInt(parts[1]) + days * 24;
       slurmTime = hours + ":" + parts[2] + ":" + parts[3];
     } else if (parts.length === 3) {
       slurmTime = walltime;
@@ -86,20 +86,20 @@ function toSlurmTime(walltime) {
  * hand-written module.
  */
 function makeAnalysis(descriptor) {
-  var ctx = { code: code, model: model };
+  const ctx = { code: code, model: model };
 
   function Analysis(socket, stream, params) {
-    var self = this;
+    const self = this;
     self.socket = socket;
     self.stream = stream;
     self.params = params;
 
-    var isCheckOnly = params.checkOnly || false;
+    const isCheckOnly = params.checkOnly || false;
     self.type = descriptor.type;
 
     // --- resolve analysis-specific fields (checkOnly reads params; normal reads
     // analysisParams). The descriptor decides which; we pass both. ---
-    var analysisParams = isCheckOnly ? params : (self.params.analysis || self.params);
+    const analysisParams = isCheckOnly ? params : (self.params.analysis || self.params);
     descriptor.fields(self, params, analysisParams, ctx);
 
     // --- id / msaid / genetic_code / tree (the common fallback dance) ---
@@ -161,8 +161,8 @@ function makeAnalysis(descriptor) {
 // The common file-path key=value pairs that lead every analysis's param block.
 // Most analyses use the full set, but a few omit one (relax has no rfn; prime
 // has no treemode), so descriptor.prefixKeys can override the default order.
-var DEFAULT_PREFIX = ["fn", "tree_fn", "sfn", "pfn", "rfn", "treemode"];
-var PREFIX_VALUES = {
+const DEFAULT_PREFIX = ["fn", "tree_fn", "sfn", "pfn", "rfn", "treemode"];
+const PREFIX_VALUES = {
   fn: function (self) { return self.fn; },
   tree_fn: function (self) { return self.tree_fn; },
   sfn: function (self) { return self.status_fn; },
@@ -172,7 +172,7 @@ var PREFIX_VALUES = {
 };
 
 function commonPrefixPairs(self, descriptor) {
-  var order = descriptor.prefixKeys || DEFAULT_PREFIX;
+  const order = descriptor.prefixKeys || DEFAULT_PREFIX;
   return order.map(function (k) {
     return k + "=" + PREFIX_VALUES[k](self);
   });
@@ -181,14 +181,14 @@ function commonPrefixPairs(self, descriptor) {
 // Assemble the export="ALL,..." key=value string from the descriptor's ordered
 // list, preceded by the common prefix and using each entry's value fn.
 function buildExport(self, descriptor) {
-  var procs = config[descriptor.procsKey];
-  var pairs = ["slurm_mpi_type=" + (config.slurm_mpi_type || "pmix")].concat(
+  const procs = config[descriptor.procsKey];
+  const pairs = ["slurm_mpi_type=" + (config.slurm_mpi_type || "pmix")].concat(
     commonPrefixPairs(self, descriptor)
   );
   descriptor.exportKeys.forEach(function (entry) {
-    var key = entry[0];
-    var valFn = entry[1];
-    var opts = entry[2] || {};
+    const key = entry[0];
+    const valFn = entry[1];
+    const opts = entry[2] || {};
     // A few analyses' SLURM export differs from local (e.g. busted omits
     // analysis_type in slurm but includes it in local). Honor skipInSlurm.
     if (opts.skipInSlurm) return;
@@ -198,9 +198,9 @@ function buildExport(self, descriptor) {
 }
 
 function buildQsubParams(self, descriptor) {
-  var procs = config[descriptor.procsKey] || 4;
+  const procs = config[descriptor.procsKey] || 4;
   if (config.submit_type === "slurm") {
-    var slurmTime = toSlurmTime(config[descriptor.walltimeKey]);
+    const slurmTime = toSlurmTime(config[descriptor.walltimeKey]);
     logger.info(
       "Converted walltime from " + config[descriptor.walltimeKey] + " to SLURM format: " + slurmTime
     );
@@ -217,9 +217,9 @@ function buildQsubParams(self, descriptor) {
     ];
   }
   // local (and any non-slurm) path: script first, then bare key=val pairs.
-  var params = [self.qsub_script];
-  var procsLocal = config[descriptor.procsKey];
-  var pairs = commonPrefixPairs(self, descriptor);
+  const params = [self.qsub_script];
+  const procsLocal = config[descriptor.procsKey];
+  const pairs = commonPrefixPairs(self, descriptor);
   descriptor.exportKeys.forEach(function (entry) {
     pairs.push(entry[0] + "=" + entry[1](self, config, procsLocal));
   });

--- a/lib/clientsocket.js
+++ b/lib/clientsocket.js
@@ -33,11 +33,11 @@ function ClientSocket(socket, job_id) {
 
 ClientSocket.prototype.initializeServer = function() {
   // We need to attach to events emitted by the worker job
-  var self = this;
+  const self = this;
 
   logger.info(`[DEBUG REDIS] Client subscribing to Redis channel: ${self.channel_id}`);
 
-  var readyPromise = createSubscriber()
+  const readyPromise = createSubscriber()
     .then(function(subscriber) {
       self.subscriber = subscriber;
 
@@ -53,7 +53,7 @@ ClientSocket.prototype.initializeServer = function() {
         logger.info(`[DEBUG REDIS] Message length: ${message.length} bytes`);
 
         try {
-          var redis_packet = JSON.parse(message);
+          const redis_packet = JSON.parse(message);
           logger.info(`[DEBUG REDIS] Message type: ${redis_packet.type}`);
           logger.info("emitting " + message);
 
@@ -97,12 +97,12 @@ ClientSocket.prototype.close = function() {
   if (this._closed) return;
   this._closed = true;
 
-  var self = this;
+  const self = this;
   logger.info(`[REDIS] Closing subscriber for channel ${this.channel_id}`);
 
   // Wait for the (possibly still in-flight) subscribe to settle, then tear the
   // subscriber down. If the subscriber never connected, _teardown is a no-op.
-  var readyPromise = this._ready || Promise.resolve();
+  const readyPromise = this._ready || Promise.resolve();
   readyPromise.then(function() {
     return self._teardown();
   }).catch(function(err) {
@@ -117,8 +117,8 @@ ClientSocket.prototype.close = function() {
 */
 
 ClientSocket.prototype._teardown = function() {
-  var self = this;
-  var subscriber = this.subscriber;
+  const self = this;
+  const subscriber = this.subscriber;
   if (!subscriber) return Promise.resolve();
   this.subscriber = null;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,11 +19,11 @@
  * DM_SUBMIT_TYPE, DM_PORT, DM_MCP_PORT. Others can be added as needed.
  */
 
-var path = require("path");
-var { z } = require("zod");
+const path = require("path");
+const { z } = require("zod");
 
 // Load the raw config.json (same file every module used to require directly).
-var raw;
+let raw;
 try {
   raw = require(path.join(__dirname, "..", "config.json"));
 } catch (e) {
@@ -33,7 +33,7 @@ try {
 
 // Apply environment-variable overrides for deploy-critical keys.
 function applyEnvOverrides(cfg) {
-  var out = Object.assign({}, cfg);
+  const out = Object.assign({}, cfg);
   if (process.env.DM_REDIS_HOST) out.redis_host = process.env.DM_REDIS_HOST;
   if (process.env.DM_REDIS_PORT) out.redis_port = parseInt(process.env.DM_REDIS_PORT, 10);
   if (process.env.DM_REDIS_PASSWORD) out.redis_password = process.env.DM_REDIS_PASSWORD;
@@ -48,7 +48,7 @@ function applyEnvOverrides(cfg) {
 // are allowed through via .passthrough() rather than enumerated — validating
 // them all strictly would risk rejecting valid production configs, and they are
 // read defensively (with `|| default`) at their call sites anyway.
-var schema = z
+const schema = z
   .object({
     port: z.number({ invalid_type_error: "port must be a number" }),
     redis_host: z.string().min(1, "redis_host is required"),
@@ -68,11 +68,11 @@ var schema = z
   })
   .passthrough();
 
-var merged = applyEnvOverrides(raw);
+const merged = applyEnvOverrides(raw);
 
-var result = schema.safeParse(merged);
+const result = schema.safeParse(merged);
 if (!result.success) {
-  var issues = result.error.issues
+  const issues = result.error.issues
     .map(function (i) {
       return "  - " + (i.path.join(".") || "(root)") + ": " + i.message;
     })

--- a/lib/jobdel.js
+++ b/lib/jobdel.js
@@ -1,4 +1,4 @@
-var spawn = require("child_process").spawn,
+const spawn = require("child_process").spawn,
   client = require("./redis-client").client,
   logger = require("./logger").logger,
   config = require("./config");
@@ -11,7 +11,7 @@ function validateTorqueId(torque_id) {
 // Delete job handler for TORQUE (qsub)
 function qsubJobDelete(torque_id, cb) {
   logger.info("job delete (qsub): " + torque_id);
-  var qdel = {};
+  let qdel = {};
 
   // verify torque_id
   if (validateTorqueId(torque_id)) {
@@ -46,7 +46,7 @@ function qsubJobDelete(torque_id, cb) {
 // Delete job handler for SLURM (sbatch)
 function slurmJobDelete(torque_id, cb) {
   logger.info("job delete (slurm): " + torque_id);
-  var scancel = {};
+  let scancel = {};
 
   // verify torque_id
   if (validateTorqueId(torque_id)) {
@@ -140,7 +140,7 @@ function localJobDelete(torque_id, cb) {
 }
 
 // Choose the appropriate job delete function based on config.submit_type
-var jobDelete;
+let jobDelete;
 if (config.submit_type === "qsub") {
   jobDelete = qsubJobDelete;
 } else if (config.submit_type === "local") {

--- a/lib/jobqueue.js
+++ b/lib/jobqueue.js
@@ -50,9 +50,9 @@ function returnQsubJobInfo(job_id, callback) {
     return;
   }
   
-  var qstat = spawn("qstat", ["-f", "-1", job_id]);
+  const qstat = spawn("qstat", ["-f", "-1", job_id]);
 
-  var status = {
+  const status = {
     C: "Completed",
     E: "Exiting",
     H: "Held",
@@ -66,8 +66,8 @@ function returnQsubJobInfo(job_id, callback) {
   // Extract job status, creation time, and running time from qstat's output.
   try {
     qstat.stdout.on("data", function(data) {
-      var job_data = data.toString(),
-        job_state = null,
+      const job_data = data.toString();
+      let job_state = null,
         job_ctime = null,
         job_stime = null,
         type = null,
@@ -141,9 +141,9 @@ function QsubJobQueue(callback) {
       return;
     }
 
-    var data = stdout;
-    var job_data = data.toString().split("\n");
-    var jobs = [];
+    const data = stdout;
+    const job_data = data.toString().split("\n");
+    const jobs = [];
 
     if (job_data.length <= 2) {
       // No jobs in the queue
@@ -151,8 +151,8 @@ function QsubJobQueue(callback) {
       return;
     }
 
-    for (var i = 2; i < job_data.length - 1; i++) {
-      var job_id = job_data[i].split(" ")[0];
+    for (let i = 2; i < job_data.length - 1; i++) {
+      const job_id = job_data[i].split(" ")[0];
       returnQsubJobInfo(job_id, function(data) {
         if (Object.keys(data).length > 0) {
           jobs.push(data);
@@ -177,9 +177,9 @@ function returnSlurmJobInfo(job_id, callback) {
     return;
   }
   
-  var sacct = spawn("sacct", ["-j", job_id, "-o", "JobID,Submit,Start,State", "-P"]);
+  const sacct = spawn("sacct", ["-j", job_id, "-o", "JobID,Submit,Start,State", "-P"]);
   
-  var slurmStatus = {
+  const slurmStatus = {
     "BOOT_FAIL": "Failed",
     "CANCELLED": "Cancelled",
     "COMPLETED": "Completed",
@@ -199,7 +199,7 @@ function returnSlurmJobInfo(job_id, callback) {
   
   try {
     sacct.stdout.on("data", function(data) {
-      var lines = data.toString().split("\n").filter(line => line.trim() !== "");
+      const lines = data.toString().split("\n").filter(line => line.trim() !== "");
       
       if (lines.length < 2) {
         logger.warn("Invalid sacct output format for job " + job_id);
@@ -208,7 +208,7 @@ function returnSlurmJobInfo(job_id, callback) {
       }
       
       // Skip the header line and get the job data line
-      var job_fields = lines[1].split("|");
+      const job_fields = lines[1].split("|");
       
       if (job_fields.length < 4) {
         logger.warn("Invalid sacct output field count for job " + job_id);
@@ -216,12 +216,12 @@ function returnSlurmJobInfo(job_id, callback) {
         return;
       }
       
-      var job_state = job_fields[3];
-      var job_ctime = job_fields[1] ? formatSacctTime(job_fields[1]) : null;
-      var job_stime = job_fields[2] ? formatSacctTime(job_fields[2]) : null;
+      const job_state = job_fields[3];
+      const job_ctime = job_fields[1] ? formatSacctTime(job_fields[1]) : null;
+      const job_stime = job_fields[2] ? formatSacctTime(job_fields[2]) : null;
 
       client.hGetAll(job_id).then(function(obj) {
-        var type = null, sites = null, sequences = null;
+        let type = null, sites = null, sequences = null;
 
         if (obj && Object.keys(obj).length) {
           type = obj.type;
@@ -275,8 +275,8 @@ function SlurmJobQueue(callback) {
       return;
     }
     
-    var job_data = stdout.toString().split("\n").filter(line => line.trim() !== "");
-    var jobs = [];
+    const job_data = stdout.toString().split("\n").filter(line => line.trim() !== "");
+    const jobs = [];
     
     if (job_data.length === 0) {
       // No jobs in the queue
@@ -284,10 +284,10 @@ function SlurmJobQueue(callback) {
       return;
     }
     
-    var completed_count = 0;
+    let completed_count = 0;
     
-    for (var i = 0; i < job_data.length; i++) {
-      var job_id = job_data[i].trim().split(/\s+/)[0];
+    for (let i = 0; i < job_data.length; i++) {
+      const job_id = job_data[i].trim().split(/\s+/)[0];
       
       returnSlurmJobInfo(job_id, function(data) {
         completed_count++;

--- a/lib/jobregistry.js
+++ b/lib/jobregistry.js
@@ -4,8 +4,8 @@
 
 // Wrap a function so it runs at most once (native replacement for _.once).
 function once(fn) {
-  var called = false;
-  var result;
+  let called = false;
+  let result;
   return function () {
     if (!called) {
       called = true;
@@ -15,7 +15,7 @@ function once(fn) {
   };
 }
 
-var activeJobs = new Map(); // id -> job instance
+const activeJobs = new Map(); // id -> job instance
 
 function register(job) {
   if (job && job.id) activeJobs.set(job.id, job);

--- a/lib/jobstatus.js
+++ b/lib/jobstatus.js
@@ -31,8 +31,8 @@ function validateJobId(job_id) {
 /**
  * QsubJobStatus class for Torque job scheduler
  */
-var QsubJobStatus = function(job_id) {
-  var self = this;
+const QsubJobStatus = function(job_id) {
+  const self = this;
 
   self.metronome = 0;
   self.job_id = job_id;
@@ -52,7 +52,7 @@ var QsubJobStatus = function(job_id) {
 
 // Define the status-returning function for Torque jobs
 QsubJobStatus.prototype.returnJobStatus = function(job_id, callback) {
-  var self = this;
+  const self = this;
   self.callback = callback;
   self.job_id = job_id;
   self.status = "";
@@ -60,7 +60,7 @@ QsubJobStatus.prototype.returnJobStatus = function(job_id, callback) {
 
   logger.info(`Checking Torque job status for job ID: ${job_id}`);
   
-  var qstat = {};
+  let qstat = {};
 
   if (validateJobId(job_id)) {
     logger.info(`Job ID ${job_id} is valid, spawning qstat -f command`);
@@ -72,7 +72,7 @@ QsubJobStatus.prototype.returnJobStatus = function(job_id, callback) {
     return;
   }
 
-  var status = {
+  const status = {
     C: "completed",
     E: "exiting",
     H: "held",
@@ -89,9 +89,9 @@ QsubJobStatus.prototype.returnJobStatus = function(job_id, callback) {
   });
 
   qstat.stdout.on("data", function(data) {
-    var job_status = null;
-    var job_ctime = null;
-    var job_stime = null;
+    let job_status = null;
+    let job_ctime = null;
+    let job_stime = null;
 
     data = String(data);
 
@@ -132,7 +132,7 @@ QsubJobStatus.prototype.returnJobStatus = function(job_id, callback) {
   qstat.stderr.on("data", function(data) {
     logger.info(self.job_id + " " + data);
 
-    var doesnt_exist =
+    const doesnt_exist =
       data.toString().slice(0, 27) == "qstat: Unknown Job Id Error";
 
     if (doesnt_exist) {
@@ -146,17 +146,17 @@ QsubJobStatus.prototype.returnJobStatus = function(job_id, callback) {
 };
 
 QsubJobStatus.prototype.fullJobInfo = function(callback) {
-  var self = this;
+  const self = this;
 
   self.callback = callback;
 
-  var translateQstat = function(d) {
-    var job = {};
+  const translateQstat = function(d) {
+    const job = {};
 
     // iterate over each line
-    var job_arr = d.toString().split("\n");
+    const job_arr = d.toString().split("\n");
     job_arr.forEach(function(item) {
-      var item_split = item.split("=");
+      const item_split = item.split("=");
       if (item_split.length == 2) {
         job[item_split[0].trim()] = item_split[1].trim();
       }
@@ -165,7 +165,7 @@ QsubJobStatus.prototype.fullJobInfo = function(callback) {
     return job;
   };
 
-  var qstat = {};
+  let qstat = {};
   
   if (validateJobId(self.job_id)) {
     qstat = spawn("qstat", ["-f", self.job_id]);
@@ -181,7 +181,7 @@ QsubJobStatus.prototype.fullJobInfo = function(callback) {
   });
 
   qstat.stdout.on("data", function(data) {
-    var job_status = translateQstat(data.toString());
+    const job_status = translateQstat(data.toString());
     self.callback(self.error, job_status);
   });
 
@@ -193,9 +193,9 @@ QsubJobStatus.prototype.fullJobInfo = function(callback) {
 };
 
 QsubJobStatus.prototype.watch = function(callback) {
-  var self = this;
+  const self = this;
 
-  var metronome = new setInterval(
+  const metronome = new setInterval(
     self.returnJobStatus,
     5000,
     self.job_id,
@@ -208,8 +208,8 @@ QsubJobStatus.prototype.watch = function(callback) {
 /**
  * SlurmJobStatus class for Slurm job scheduler
  */
-var SlurmJobStatus = function(job_id) {
-  var self = this;
+const SlurmJobStatus = function(job_id) {
+  const self = this;
 
   self.metronome = 0;
   self.job_id = job_id;
@@ -236,7 +236,7 @@ var SlurmJobStatus = function(job_id) {
 
 // Define the status-returning function for Slurm jobs
 SlurmJobStatus.prototype.returnJobStatus = function(job_id, callback) {
-  var self = this;
+  const self = this;
   self.callback = callback;
   self.job_id = job_id;
   self.status = "";
@@ -513,7 +513,7 @@ SlurmJobStatus.prototype.returnJobStatus = function(job_id, callback) {
 };
 
 SlurmJobStatus.prototype.fullJobInfo = function(callback) {
-  var self = this;
+  const self = this;
   self.callback = callback;
 
   // First try scontrol for running and pending jobs
@@ -714,9 +714,9 @@ SlurmJobStatus.prototype.fullJobInfo = function(callback) {
 };
 
 SlurmJobStatus.prototype.watch = function(callback) {
-  var self = this;
+  const self = this;
 
-  var metronome = new setInterval(
+  const metronome = new setInterval(
     self.returnJobStatus,
     5000,
     self.job_id,
@@ -729,8 +729,8 @@ SlurmJobStatus.prototype.watch = function(callback) {
 /**
  * LocalJobStatus class for local job execution
  */
-var LocalJobStatus = function(job_id) {
-  var self = this;
+const LocalJobStatus = function(job_id) {
+  const self = this;
   
   self.metronome = 0;
   self.job_id = job_id;
@@ -741,7 +741,7 @@ var LocalJobStatus = function(job_id) {
 };
 
 LocalJobStatus.prototype.returnJobStatus = function(job_id, callback) {
-  var self = this;
+  const self = this;
   
   // For local jobs, we just return a running status
   // The actual completion is handled by the job runner itself
@@ -784,11 +784,11 @@ LocalJobStatus.prototype.returnJobStatus = function(job_id, callback) {
 };
 
 LocalJobStatus.prototype.watch = function(callback) {
-  var self = this;
+  const self = this;
   
   // For local jobs, we can check less frequently since
   // completion is handled by direct events
-  var metronome = new setInterval(
+  const metronome = new setInterval(
     self.returnJobStatus,
     10000, // Check every 10 seconds instead of 5
     self.job_id,
@@ -801,7 +801,7 @@ LocalJobStatus.prototype.watch = function(callback) {
 // Choose the appropriate JobStatus class based on config.submit_type
 logger.info(`Current submit_type is: ${config.submit_type}`);
 
-var JobStatus;
+let JobStatus;
 if (config.submit_type === "qsub") {
   JobStatus = QsubJobStatus;
   logger.info("Using QsubJobStatus class");

--- a/lib/mcp/index.js
+++ b/lib/mcp/index.js
@@ -1,16 +1,16 @@
-var express = require("express"),
+const express = require("express"),
   crypto = require("crypto"),
   rateLimit = require("express-rate-limit"),
   logger = require("../logger.js").logger;
 
-var path = require("path");
-var McpServer = require("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
-var StreamableHTTPServerTransport = require("@modelcontextprotocol/sdk/server/streamableHttp.js").StreamableHTTPServerTransport;
-var registerTools = require("./tools").registerTools;
-var TOOL_NAMES = require("./tools").TOOL_NAMES;
-var registerPrompts = require("./prompts").registerPrompts;
-var registerResources = require("./resources").registerResources;
-var pkg = require(path.join(__dirname, "../../package.json"));
+const path = require("path");
+const McpServer = require("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
+const StreamableHTTPServerTransport = require("@modelcontextprotocol/sdk/server/streamableHttp.js").StreamableHTTPServerTransport;
+const registerTools = require("./tools").registerTools;
+const TOOL_NAMES = require("./tools").TOOL_NAMES;
+const registerPrompts = require("./prompts").registerPrompts;
+const registerResources = require("./resources").registerResources;
+const pkg = require(path.join(__dirname, "../../package.json"));
 
 /**
  * Start the MCP server on a separate Express instance.
@@ -19,7 +19,7 @@ var pkg = require(path.join(__dirname, "../../package.json"));
  * @param {import("redis").RedisClient} redisClient
  */
 function startMcpServer(config, redisClient) {
-  var app = express();
+  const app = express();
 
   // Log every incoming request so we can see what's actually hitting the server
   app.use(function (req, res, next) {
@@ -32,17 +32,17 @@ function startMcpServer(config, redisClient) {
 
   app.use(express.json());
 
-  var issuer = config.mcp_issuer || ("http://localhost:" + (config.mcp_port || 7016));
+  const issuer = config.mcp_issuer || ("http://localhost:" + (config.mcp_port || 7016));
 
   // --- Origin header validation (MCP spec MUST for DNS rebinding prevention) ---
-  var ALLOWED_ORIGINS = [
+  const ALLOWED_ORIGINS = [
     issuer,
     "https://mcp.datamonkey.org",
     "http://localhost:" + (config.mcp_port || 7016)
   ];
 
   app.use(function (req, res, next) {
-    var origin = req.headers["origin"];
+    const origin = req.headers["origin"];
     // Only reject when Origin IS present and NOT in the allowed list.
     // Missing Origin (curl, direct API calls) is permitted.
     if (origin && ALLOWED_ORIGINS.indexOf(origin) === -1) {
@@ -57,7 +57,7 @@ function startMcpServer(config, redisClient) {
   });
 
   // --- Rate limiting on /mcp (MCP spec: servers MUST rate limit tool invocations) ---
-  var mcpLimiter = rateLimit({
+  const mcpLimiter = rateLimit({
     windowMs: 60 * 1000,    // 1 minute window
     max: 120,               // 120 requests per minute per IP
     standardHeaders: true,
@@ -72,7 +72,7 @@ function startMcpServer(config, redisClient) {
 
   // Factory: create a new McpServer per session (SDK requires one transport per instance)
   function createMcpServer() {
-    var server = new McpServer(
+    const server = new McpServer(
       { name: "datamonkey", version: "1.0.0" },
       { capabilities: { tools: {}, prompts: {}, resources: {} } }
     );
@@ -83,9 +83,9 @@ function startMcpServer(config, redisClient) {
   }
 
   // In-memory stores for minimal OAuth ceremony
-  var clients = {};
-  var authCodes = {};
-  var tokens = {};
+  const clients = {};
+  const authCodes = {};
+  const tokens = {};
 
   // OAuth Discovery — server metadata
   app.get("/.well-known/oauth-authorization-server", function (req, res) {
@@ -108,8 +108,8 @@ function startMcpServer(config, redisClient) {
   // /mcp endpoint, not the bare issuer. Claude Code's MCP client validates
   // this match before continuing the OAuth flow, so a missing /mcp suffix
   // causes the client to silently abort discovery.
-  var mcpResourceUrl = issuer.replace(/\/$/, "") + "/mcp";
-  var protectedResourceMetadata = {
+  const mcpResourceUrl = issuer.replace(/\/$/, "") + "/mcp";
+  const protectedResourceMetadata = {
     resource: mcpResourceUrl,
     authorization_servers: [issuer],
     bearer_methods_supported: ["header"],
@@ -140,9 +140,9 @@ function startMcpServer(config, redisClient) {
 
   // Dynamic Client Registration
   app.post("/register", function (req, res) {
-    var clientId = crypto.randomUUID();
-    var clientSecret = crypto.randomUUID();
-    var redirectUris = req.body.redirect_uris || [];
+    const clientId = crypto.randomUUID();
+    const clientSecret = crypto.randomUUID();
+    const redirectUris = req.body.redirect_uris || [];
 
     logger.info("MCP OAuth register: clientId=" + clientId + " redirect_uris=" + JSON.stringify(redirectUris));
 
@@ -167,7 +167,7 @@ function startMcpServer(config, redisClient) {
   // for headless clients (SSH boxes where http://localhost callbacks aren't
   // reachable from the user's browser): the code is rendered as HTML for the
   // user to copy-paste back into their client, instead of 302-redirected.
-  var OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
+  const OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
 
   function escapeHtml(s) {
     return String(s)
@@ -179,7 +179,7 @@ function startMcpServer(config, redisClient) {
   }
 
   function renderOobPage(code) {
-    var safeCode = escapeHtml(code);
+    const safeCode = escapeHtml(code);
     return "<!doctype html>\n" +
       "<html lang=\"en\"><head><meta charset=\"utf-8\">" +
       "<title>Datamonkey MCP — authorization code</title>" +
@@ -200,9 +200,9 @@ function startMcpServer(config, redisClient) {
   }
 
   app.get("/authorize", function (req, res) {
-    var redirectUri = req.query.redirect_uri;
-    var state = req.query.state || "";
-    var clientId = req.query.client_id;
+    const redirectUri = req.query.redirect_uri;
+    const state = req.query.state || "";
+    const clientId = req.query.client_id;
 
     logger.info("MCP OAuth authorize: clientId=" + clientId + " redirect_uri=" + redirectUri);
 
@@ -212,7 +212,7 @@ function startMcpServer(config, redisClient) {
       return;
     }
 
-    var code = crypto.randomUUID();
+    const code = crypto.randomUUID();
     authCodes[code] = {
       client_id: clientId,
       redirect_uri: redirectUri,
@@ -229,18 +229,18 @@ function startMcpServer(config, redisClient) {
     }
 
     logger.info("MCP OAuth authorize: issued code, redirecting");
-    var sep = redirectUri.indexOf("?") === -1 ? "?" : "&";
+    const sep = redirectUri.indexOf("?") === -1 ? "?" : "&";
     res.redirect(redirectUri + sep + "code=" + encodeURIComponent(code) + "&state=" + encodeURIComponent(state));
   });
 
   // Token Endpoint
   app.post("/token", express.urlencoded({ extended: false }), function (req, res) {
-    var grantType = req.body.grant_type;
+    const grantType = req.body.grant_type;
     logger.info("MCP OAuth token: grant_type=" + grantType);
 
     if (grantType === "authorization_code") {
-      var code = req.body.code;
-      var stored = authCodes[code];
+      const code = req.body.code;
+      const stored = authCodes[code];
 
       if (!stored || stored.expires < Date.now()) {
         logger.warn("MCP OAuth token: invalid or expired auth code");
@@ -250,13 +250,13 @@ function startMcpServer(config, redisClient) {
 
       // PKCE verification (MCP spec: clients MUST implement PKCE, servers should verify)
       if (stored.code_challenge) {
-        var verifier = req.body.code_verifier;
+        const verifier = req.body.code_verifier;
         if (!verifier) {
           logger.warn("MCP OAuth token: code_verifier required but missing");
           res.status(400).json({ error: "invalid_grant", error_description: "code_verifier required" });
           return;
         }
-        var expectedChallenge = crypto.createHash("sha256").update(verifier).digest("base64url");
+        const expectedChallenge = crypto.createHash("sha256").update(verifier).digest("base64url");
         if (expectedChallenge !== stored.code_challenge) {
           logger.warn("MCP OAuth token: code_verifier mismatch");
           res.status(400).json({ error: "invalid_grant", error_description: "code_verifier mismatch" });
@@ -269,10 +269,10 @@ function startMcpServer(config, redisClient) {
 
       // RFC 8707: token request may also carry a resource parameter; prefer
       // the one bound at authorize-time, fall back to the token-request value.
-      var tokenResource = stored.resource || req.body.resource;
+      const tokenResource = stored.resource || req.body.resource;
 
-      var accessToken = crypto.randomUUID();
-      var refreshToken = crypto.randomUUID();
+      const accessToken = crypto.randomUUID();
+      const refreshToken = crypto.randomUUID();
       tokens[accessToken] = { type: "access", client_id: stored.client_id, resource: tokenResource };
       tokens[refreshToken] = { type: "refresh", client_id: stored.client_id, resource: tokenResource };
 
@@ -284,7 +284,7 @@ function startMcpServer(config, redisClient) {
         refresh_token: refreshToken
       });
     } else if (grantType === "refresh_token") {
-      var rt = req.body.refresh_token;
+      const rt = req.body.refresh_token;
 
       if (!tokens[rt] || tokens[rt].type !== "refresh") {
         logger.warn("MCP OAuth token: invalid refresh_token");
@@ -292,7 +292,7 @@ function startMcpServer(config, redisClient) {
         return;
       }
 
-      var newAccessToken = crypto.randomUUID();
+      const newAccessToken = crypto.randomUUID();
       tokens[newAccessToken] = { type: "access", client_id: tokens[rt].client_id, resource: tokens[rt].resource };
 
       logger.info("MCP OAuth token: refreshed access_token for clientId=" + tokens[rt].client_id);
@@ -310,7 +310,7 @@ function startMcpServer(config, redisClient) {
 
   // Token Revocation
   app.post("/revoke", express.urlencoded({ extended: false }), function (req, res) {
-    var token = req.body.token;
+    const token = req.body.token;
     logger.info("MCP OAuth revoke: token=" + (token ? token.substring(0, 8) + "..." : "none"));
     if (token && tokens[token]) {
       delete tokens[token];
@@ -320,7 +320,7 @@ function startMcpServer(config, redisClient) {
 
   // --- Bearer token validation on /mcp (MCP spec: validate auth tokens) ---
   app.use("/mcp", function (req, res, next) {
-    var authHeader = req.headers["authorization"];
+    const authHeader = req.headers["authorization"];
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
       res.set("WWW-Authenticate", 'Bearer resource_metadata="' + issuer + '/.well-known/oauth-protected-resource/mcp"');
       return res.status(401).json({
@@ -330,8 +330,8 @@ function startMcpServer(config, redisClient) {
       });
     }
 
-    var token = authHeader.substring(7);
-    var tokenRecord = tokens[token];
+    const token = authHeader.substring(7);
+    const tokenRecord = tokens[token];
     if (!tokenRecord || tokenRecord.type !== "access") {
       res.set("WWW-Authenticate", 'Bearer resource_metadata="' + issuer + '/.well-known/oauth-protected-resource/mcp"');
       return res.status(401).json({
@@ -357,16 +357,16 @@ function startMcpServer(config, redisClient) {
   });
 
   // Track transports by session ID for stateful connections
-  var transports = {};
+  const transports = {};
 
   // POST /mcp — JSON-RPC requests (initialize, tool calls, etc.)
   app.post("/mcp", async function (req, res) {
     try {
-      var sessionId = req.headers["mcp-session-id"];
-      var method = req.body && req.body.method ? req.body.method : "unknown";
-      var rpcId = req.body && req.body.id !== undefined ? req.body.id : "none";
-      var activeSessionIds = Object.keys(transports);
-      var activeSessions = activeSessionIds.length;
+      const sessionId = req.headers["mcp-session-id"];
+      const method = req.body && req.body.method ? req.body.method : "unknown";
+      const rpcId = req.body && req.body.id !== undefined ? req.body.id : "none";
+      const activeSessionIds = Object.keys(transports);
+      const activeSessions = activeSessionIds.length;
 
       logger.info("MCP POST: method=" + method + " rpcId=" + rpcId +
         " sessionId=" + (sessionId || "none") + " activeSessions=" + activeSessions);
@@ -381,7 +381,7 @@ function startMcpServer(config, redisClient) {
 
       if (sessionId && transports[sessionId]) {
         // Existing session — reuse transport
-        var existingTransport = transports[sessionId];
+        const existingTransport = transports[sessionId];
         logger.info("MCP POST: reusing existing session " + sessionId +
           " transportSessionId=" + existingTransport.sessionId);
         await existingTransport.handleRequest(req, res, req.body);
@@ -479,8 +479,8 @@ function startMcpServer(config, redisClient) {
 
   // GET /mcp — SSE stream for server-initiated notifications
   app.get("/mcp", async function (req, res) {
-    var sessionId = req.headers["mcp-session-id"];
-    var activeSessionIds = Object.keys(transports);
+    const sessionId = req.headers["mcp-session-id"];
+    const activeSessionIds = Object.keys(transports);
     logger.info("MCP GET (SSE): sessionId=" + (sessionId || "none") +
       " known=" + (sessionId ? !!transports[sessionId] : false) +
       " activeSessions=" + activeSessionIds.length);
@@ -520,8 +520,8 @@ function startMcpServer(config, redisClient) {
 
   // DELETE /mcp — Session cleanup
   app.delete("/mcp", async function (req, res) {
-    var sessionId = req.headers["mcp-session-id"];
-    var activeSessionIds = Object.keys(transports);
+    const sessionId = req.headers["mcp-session-id"];
+    const activeSessionIds = Object.keys(transports);
     logger.info("MCP DELETE: sessionId=" + (sessionId || "none") +
       " known=" + (sessionId ? !!transports[sessionId] : false) +
       " activeSessions=" + activeSessionIds.length);
@@ -555,7 +555,7 @@ function startMcpServer(config, redisClient) {
     }
   });
 
-  var port = config.mcp_port || 7016;
+  const port = config.mcp_port || 7016;
   app.listen(port, function () {
     logger.info("MCP server listening on port " + port);
   });

--- a/lib/mcp/prompts.js
+++ b/lib/mcp/prompts.js
@@ -2,9 +2,9 @@
  * MCP Prompt templates for guided analysis experience.
  */
 
-var z = require("zod");
+const z = require("zod");
 
-var ANALYSIS_TYPES = [
+const ANALYSIS_TYPES = [
   "absrel", "fel", "busted", "relax", "meme", "slac", "fubar",
   "gard", "cfel", "multihit", "nrm", "fade", "bgm", "bstill",
   "difFubar", "prime", "hivtrace", "flea"
@@ -21,7 +21,7 @@ function registerPrompts(mcpServer) {
     "Decision matrix: maps biological questions to appropriate HyPhy analysis methods",
     { question: z.string().optional().describe("Your biological question (optional)") },
     function (args) {
-      var intro = args.question
+      const intro = args.question
         ? "Based on your question: \"" + args.question + "\"\n\n"
         : "";
 
@@ -73,7 +73,7 @@ function registerPrompts(mcpServer) {
       )
     },
     function (args) {
-      var branchGuidance;
+      let branchGuidance;
       if (args.has_foreground_branches === "yes") {
         branchGuidance =
           "Your tree has foreground branches labeled. BUSTED will test those specific " +
@@ -189,7 +189,7 @@ function registerPrompts(mcpServer) {
       method: z.enum(ANALYSIS_TYPES).describe("The analysis method to interpret results for")
     },
     function (args) {
-      var guidance = getInterpretationGuidance(args.method);
+      const guidance = getInterpretationGuidance(args.method);
       return {
         messages: [{
           role: "user",
@@ -206,7 +206,7 @@ guidance.text
 }
 
 function getInterpretationGuidance(method) {
-  var guides = {
+  const guides = {
     absrel: {
       name: "aBSREL",
       text:

--- a/lib/mcp/resources.js
+++ b/lib/mcp/resources.js
@@ -2,15 +2,15 @@
  * MCP Resources — static and template resources for method documentation.
  */
 
-var ResourceTemplate = require("@modelcontextprotocol/sdk/server/mcp.js").ResourceTemplate;
+const ResourceTemplate = require("@modelcontextprotocol/sdk/server/mcp.js").ResourceTemplate;
 
-var METHOD_KEYS = [
+const METHOD_KEYS = [
   "absrel", "bgm", "busted", "difFubar", "fel", "cfel", "flea",
   "fubar", "bstill", "fade", "gard", "hivtrace", "meme", "multihit",
   "nrm", "prime", "relax", "slac"
 ];
 
-var METHOD_REQUIREMENTS = {
+const METHOD_REQUIREMENTS = {
   absrel: {
     name: "aBSREL", requires_tree: true, requires_codon_alignment: true,
     requires_branch_labels: false, branch_label_convention: "{FG} for foreground (optional)",
@@ -104,7 +104,7 @@ var METHOD_REQUIREMENTS = {
 };
 
 // Per-method detailed guides
-var METHOD_GUIDES = {
+const METHOD_GUIDES = {
   absrel:
 "# aBSREL — Adaptive Branch-Site REL\n\n" +
 "## Purpose\nTests each branch in a phylogeny for episodic diversifying selection. " +
@@ -276,7 +276,7 @@ var METHOD_GUIDES = {
 };
 
 // Static comparison table
-var COMPARISON_TABLE =
+const COMPARISON_TABLE =
 "# HyPhy Method Comparison\n\n" +
 "| Method | Question Answered | Branch Labels | Codon Required | Key Output |\n" +
 "|--------|------------------|---------------|----------------|------------|\n" +
@@ -342,8 +342,8 @@ function registerResources(mcpServer) {
     new ResourceTemplate("datamonkey://methods/{method_name}/guide", { list: undefined }),
     { description: "Detailed per-method guide: purpose, inputs, parameters, interpretation, example" },
     function (uri, params) {
-      var methodName = params.method_name;
-      var guide = METHOD_GUIDES[methodName];
+      const methodName = params.method_name;
+      const guide = METHOD_GUIDES[methodName];
 
       if (!guide) {
         return {

--- a/lib/mcp/spawn-helpers.js
+++ b/lib/mcp/spawn-helpers.js
@@ -1,4 +1,4 @@
-var EventEmitter = require("events").EventEmitter,
+const EventEmitter = require("events").EventEmitter,
   crypto = require("crypto"),
   absrel = require("../../app/absrel/absrel.js"),
   bgm = require("../../app/bgm/bgm.js"),
@@ -21,7 +21,7 @@ var EventEmitter = require("events").EventEmitter,
   logger = require("../logger.js").logger;
 
 // Map of analysis type to constructor
-var analysisMap = {
+const analysisMap = {
   absrel:    absrel.absrel,
   bgm:       bgm.bgm,
   busted:    busted.busted,
@@ -43,7 +43,7 @@ var analysisMap = {
 };
 
 // Analysis metadata for list_analyses
-var analysisInfo = {
+const analysisInfo = {
   absrel: {
     name: "aBSREL",
     description: "Adaptive Branch-Site REL test for episodic diversification",
@@ -230,7 +230,7 @@ var analysisInfo = {
  * writes to Redis normally.
  */
 function createStubSocket() {
-  var stub = new EventEmitter();
+  const stub = new EventEmitter();
   stub.id = "mcp-" + crypto.randomBytes(8).toString("hex");
   stub.emit = function(event) {
     // Allow internal EventEmitter events, but log socket.io style emits
@@ -256,13 +256,13 @@ function createStubSocket() {
  * @returns {string} job_id
  */
 function spawnAnalysis(type, alignment, tree, analysisParams) {
-  var Constructor = analysisMap[type];
+  const Constructor = analysisMap[type];
   if (!Constructor) {
     throw new Error("Unknown analysis type: " + type);
   }
 
-  var socket = createStubSocket();
-  var jobId = crypto.randomBytes(12).toString("hex");
+  const socket = createStubSocket();
+  const jobId = crypto.randomBytes(12).toString("hex");
 
   // Build the params object matching what the server.js routing provides.
   // Most analyses expect: { analysis: { _id, msa: [...], ...opts }, msa: [{gencodeid, nj, usertree}], tree }
@@ -280,12 +280,12 @@ function spawnAnalysis(type, alignment, tree, analysisParams) {
   } else {
     // If no tree provided, try to extract from NEXUS TREES block
     if (!tree && alignment && alignment.indexOf("#NEXUS") !== -1) {
-      var treeMatch = alignment.match(/TREE\s+\w+\s*=\s*(.+);/i);
+      const treeMatch = alignment.match(/TREE\s+\w+\s*=\s*(.+);/i);
       if (treeMatch) {
         tree = treeMatch[1].trim();
       }
     }
-    var msaEntry = {
+    const msaEntry = {
       gencodeid: (analysisParams && analysisParams.gencodeid) || 0,
       nj: tree || "",
       usertree: tree || ""

--- a/lib/mcp/stdio.js
+++ b/lib/mcp/stdio.js
@@ -8,17 +8,17 @@
  * Config: claude mcp add datamonkey -- node lib/mcp/stdio.js
  */
 
-var McpServer = require("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
-var StdioServerTransport = require("@modelcontextprotocol/sdk/server/stdio.js").StdioServerTransport;
-var registerTools = require("./tools").registerTools;
-var registerPrompts = require("./prompts").registerPrompts;
-var registerResources = require("./resources").registerResources;
+const McpServer = require("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
+const StdioServerTransport = require("@modelcontextprotocol/sdk/server/stdio.js").StdioServerTransport;
+const registerTools = require("./tools").registerTools;
+const registerPrompts = require("./prompts").registerPrompts;
+const registerResources = require("./resources").registerResources;
 
 // Shared redis v5 client factory (connects on require). The factory already
 // attaches an "error" handler that logs, so we do not add another here.
-var client = require("../redis-client").client;
+const client = require("../redis-client").client;
 
-var mcpServer = new McpServer(
+const mcpServer = new McpServer(
   { name: "datamonkey", version: "1.0.0" },
   { capabilities: { tools: {}, prompts: {}, resources: {} } }
 );
@@ -27,7 +27,7 @@ registerTools(mcpServer, client);
 registerPrompts(mcpServer);
 registerResources(mcpServer);
 
-var transport = new StdioServerTransport();
+const transport = new StdioServerTransport();
 mcpServer.connect(transport).then(function () {
   process.stderr.write("Datamonkey MCP server running on stdio\n");
 });

--- a/lib/mcp/tools.js
+++ b/lib/mcp/tools.js
@@ -1,4 +1,4 @@
-var z = require("zod"),
+const z = require("zod"),
   logger = require("../logger.js").logger,
   spawnHelpers = require("./spawn-helpers"),
   jobdel = require("../jobdel.js"),
@@ -20,7 +20,7 @@ function registerTools(mcpServer, redisClient) {
     async function () {
       try {
         logger.info("MCP tool call: list_analyses");
-        var types = Object.keys(spawnHelpers.analysisInfo).map(function (key) {
+        const types = Object.keys(spawnHelpers.analysisInfo).map(function (key) {
           return Object.assign({ type: key }, spawnHelpers.analysisInfo[key]);
         });
         logger.info("MCP list_analyses: returning " + types.length + " analyses");
@@ -55,14 +55,14 @@ function registerTools(mcpServer, redisClient) {
         logger.info("MCP tool call: validate_alignment" +
           (args.analysis_type ? " analysis_type=" + args.analysis_type : "") +
           " alignment_length=" + (args.alignment ? args.alignment.length : 0) + " chars");
-        var alignResult = validation.validateAlignment(args.alignment);
-        var allErrors = alignResult.errors.slice();
-        var allWarnings = alignResult.warnings.slice();
+        const alignResult = validation.validateAlignment(args.alignment);
+        let allErrors = alignResult.errors.slice();
+        let allWarnings = alignResult.warnings.slice();
 
         // If analysis type requires codons and alignment is not in codon frame, promote warnings to errors
         if (args.analysis_type && validation.CODON_METHODS.indexOf(args.analysis_type) !== -1) {
-          var sequences = validation.parseFasta(args.alignment);
-          var frameCheck = validation.checkCodonFrame(sequences);
+          const sequences = validation.parseFasta(args.alignment);
+          const frameCheck = validation.checkCodonFrame(sequences);
           if (!frameCheck.valid) {
             allErrors = allErrors.concat(frameCheck.errors.map(function (w) {
               return w + " (required for " + args.analysis_type + ")";
@@ -76,7 +76,7 @@ function registerTools(mcpServer, redisClient) {
 
         // Validate analysis-specific params
         if (args.analysis_type) {
-          var paramResult = validation.validateAnalysisParams(
+          const paramResult = validation.validateAnalysisParams(
             args.analysis_type,
             args.tree || null,
             {}
@@ -85,9 +85,9 @@ function registerTools(mcpServer, redisClient) {
           allWarnings = allWarnings.concat(paramResult.warnings);
         }
 
-        var valid = alignResult.valid && allErrors.length === 0;
+        const valid = alignResult.valid && allErrors.length === 0;
 
-        var response = {
+        const response = {
           valid: valid,
           sequence_count: alignResult.sequence_count,
           alignment_length: alignResult.alignment_length,
@@ -133,10 +133,10 @@ function registerTools(mcpServer, redisClient) {
           " has_tree=" + !!args.tree + " has_params=" + !!(args.params && Object.keys(args.params).length));
 
         // Pre-flight validation
-        var warnings = [];
+        let warnings = [];
 
         // Validate alignment
-        var alignResult = validation.validateAlignment(args.alignment);
+        const alignResult = validation.validateAlignment(args.alignment);
         if (!alignResult.valid) {
           return {
             content: [{
@@ -154,8 +154,8 @@ function registerTools(mcpServer, redisClient) {
 
         // Check codon frame for methods that require it
         if (validation.CODON_METHODS.indexOf(args.analysis_type) !== -1) {
-          var sequences = validation.parseFasta(args.alignment);
-          var frameCheck = validation.checkCodonFrame(sequences);
+          const sequences = validation.parseFasta(args.alignment);
+          const frameCheck = validation.checkCodonFrame(sequences);
           if (!frameCheck.valid) {
             return {
               content: [{
@@ -172,7 +172,7 @@ function registerTools(mcpServer, redisClient) {
         }
 
         // Validate analysis-specific params
-        var paramResult = validation.validateAnalysisParams(
+        const paramResult = validation.validateAnalysisParams(
           args.analysis_type,
           args.tree || null,
           args.params || {}
@@ -192,7 +192,7 @@ function registerTools(mcpServer, redisClient) {
         }
         warnings = warnings.concat(paramResult.warnings);
 
-        var jobId = spawnHelpers.spawnAnalysis(
+        const jobId = spawnHelpers.spawnAnalysis(
           args.analysis_type,
           args.alignment,
           args.tree || null,
@@ -201,7 +201,7 @@ function registerTools(mcpServer, redisClient) {
 
         logger.info("MCP spawn_analysis: spawned job_id=" + jobId + " type=" + args.analysis_type);
 
-        var response = { job_id: jobId, analysis_type: args.analysis_type };
+        const response = { job_id: jobId, analysis_type: args.analysis_type };
         if (warnings.length > 0) {
           response.warnings = warnings;
           logger.info("MCP spawn_analysis: warnings=" + JSON.stringify(warnings));
@@ -233,7 +233,7 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: get_job_status job_id=" + args.job_id);
-        var jobData = await redisClient.hGetAll(args.job_id);
+        const jobData = await redisClient.hGetAll(args.job_id);
 
         if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP get_job_status: job_id=" + args.job_id + " not found");
@@ -244,7 +244,7 @@ function registerTools(mcpServer, redisClient) {
 
         logger.info("MCP get_job_status: job_id=" + args.job_id + " status=" + (jobData.status || "unknown"));
 
-        var response = {
+        const response = {
           status: jobData.status || "unknown",
           job_id: args.job_id
         };
@@ -298,7 +298,7 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: get_job_results job_id=" + args.job_id);
-        var jobData = await redisClient.hGetAll(args.job_id);
+        const jobData = await redisClient.hGetAll(args.job_id);
 
         if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP get_job_results: job_id=" + args.job_id + " not found");
@@ -332,9 +332,9 @@ function registerTools(mcpServer, redisClient) {
 
         // Results are stored double-nested: JSON.stringify({ results: JSON.stringify(data), type: "completed" })
         // Same unwrapping logic as server.js job:status handler
-        var results;
+        let results;
         try {
-          var parsedResults = JSON.parse(jobData.results);
+          const parsedResults = JSON.parse(jobData.results);
           if (parsedResults.results && typeof parsedResults.results === "string") {
             results = JSON.parse(parsedResults.results);
           } else {
@@ -344,7 +344,7 @@ function registerTools(mcpServer, redisClient) {
           results = jobData.results;
         }
 
-        var resultStr = JSON.stringify(results);
+        const resultStr = JSON.stringify(results);
         logger.info("MCP get_job_results: job_id=" + args.job_id + " returning " + resultStr.length + " chars");
         return {
           content: [{ type: "text", text: resultStr }]
@@ -369,7 +369,7 @@ function registerTools(mcpServer, redisClient) {
     async function (args) {
       try {
         logger.info("MCP tool call: cancel_job job_id=" + args.job_id);
-        var jobData = await redisClient.hGetAll(args.job_id);
+        const jobData = await redisClient.hGetAll(args.job_id);
 
         if (!jobData || Object.keys(jobData).length === 0) {
           logger.info("MCP cancel_job: job_id=" + args.job_id + " not found");
@@ -400,7 +400,7 @@ function registerTools(mcpServer, redisClient) {
         }
 
         // Extract torque_id and cancel
-        var torqueId = "";
+        let torqueId = "";
         try {
           torqueId = JSON.parse(jobData.torque_id).torque_id;
         } catch (e) {
@@ -442,7 +442,7 @@ function registerTools(mcpServer, redisClient) {
 }
 
 // Tool names exported for the /.well-known/mcp.json manifest
-var TOOL_NAMES = [
+const TOOL_NAMES = [
   "list_analyses",
   "validate_alignment",
   "spawn_analysis",

--- a/lib/mcp/validation.js
+++ b/lib/mcp/validation.js
@@ -3,7 +3,7 @@
  * Pure functions — no Redis or analysis constructor dependencies.
  */
 
-var STOP_CODONS = ["TAA", "TAG", "TGA"];
+const STOP_CODONS = ["TAA", "TAG", "TGA"];
 
 /**
  * Parse FASTA (or simple NEXUS) text into [{name, seq}].
@@ -12,12 +12,12 @@ var STOP_CODONS = ["TAA", "TAG", "TGA"];
 function parseFasta(text) {
   if (!text || typeof text !== "string") return [];
 
-  var lines = text.split(/\r?\n/);
-  var sequences = [];
-  var current = null;
+  const lines = text.split(/\r?\n/);
+  const sequences = [];
+  let current = null;
 
-  for (var i = 0; i < lines.length; i++) {
-    var line = lines[i].trim();
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
     if (!line) continue;
 
     if (line.charAt(0) === ">") {
@@ -38,8 +38,8 @@ function parseFasta(text) {
  * Returns {valid, errors}
  */
 function checkCodonFrame(sequences) {
-  var errors = [];
-  for (var i = 0; i < sequences.length; i++) {
+  const errors = [];
+  for (let i = 0; i < sequences.length; i++) {
     if (sequences[i].seq.length % 3 !== 0) {
       errors.push(
         "Sequence \"" + sequences[i].name + "\" length " +
@@ -56,15 +56,15 @@ function checkCodonFrame(sequences) {
  * Returns {warnings}
  */
 function checkStopCodons(sequences) {
-  var warnings = [];
+  const warnings = [];
 
-  for (var i = 0; i < sequences.length; i++) {
-    var seq = sequences[i].seq.toUpperCase();
+  for (let i = 0; i < sequences.length; i++) {
+    const seq = sequences[i].seq.toUpperCase();
     if (seq.length < 6) continue; // Need at least 2 codons
 
-    var internalLen = seq.length - 3; // Exclude last codon
-    for (var j = 0; j < internalLen; j += 3) {
-      var codon = seq.substring(j, j + 3);
+    const internalLen = seq.length - 3; // Exclude last codon
+    for (let j = 0; j < internalLen; j += 3) {
+      const codon = seq.substring(j, j + 3);
       if (STOP_CODONS.indexOf(codon) !== -1) {
         warnings.push(
           "Sequence \"" + sequences[i].name + "\" has internal stop codon " +
@@ -83,7 +83,7 @@ function checkStopCodons(sequences) {
  * Returns {valid, errors[], warnings[], sequence_count, alignment_length}
  */
 function validateAlignment(alignment) {
-  var result = {
+  const result = {
     valid: true,
     errors: [],
     warnings: [],
@@ -97,7 +97,7 @@ function validateAlignment(alignment) {
     return result;
   }
 
-  var sequences = parseFasta(alignment);
+  const sequences = parseFasta(alignment);
   if (sequences.length === 0) {
     result.valid = false;
     result.errors.push("Could not parse any sequences from the alignment");
@@ -113,7 +113,7 @@ function validateAlignment(alignment) {
   }
 
   // Check that sequences are non-empty
-  for (var i = 0; i < sequences.length; i++) {
+  for (let i = 0; i < sequences.length; i++) {
     if (sequences[i].seq.length === 0) {
       result.valid = false;
       result.errors.push("Sequence \"" + sequences[i].name + "\" is empty");
@@ -126,7 +126,7 @@ function validateAlignment(alignment) {
   result.alignment_length = sequences[0].seq.length;
 
   // Check codon frame
-  var frameCheck = checkCodonFrame(sequences);
+  const frameCheck = checkCodonFrame(sequences);
   if (!frameCheck.valid) {
     // This is a warning for general validation; becomes error for codon-requiring analyses
     result.warnings = result.warnings.concat(frameCheck.errors);
@@ -134,7 +134,7 @@ function validateAlignment(alignment) {
 
   // Check stop codons (only if in codon frame)
   if (frameCheck.valid) {
-    var stopCheck = checkStopCodons(sequences);
+    const stopCheck = checkStopCodons(sequences);
     result.warnings = result.warnings.concat(stopCheck.warnings);
   }
 
@@ -142,14 +142,14 @@ function validateAlignment(alignment) {
 }
 
 // Methods that require codon-aligned input
-var CODON_METHODS = [
+const CODON_METHODS = [
   "absrel", "busted", "fel", "cfel", "fubar", "meme", "slac",
   "relax", "multihit", "fade", "bgm", "prime", "difFubar",
   "gard", "nrm", "bstill"
 ];
 
 // Methods that require a tree
-var TREE_METHODS = [
+const TREE_METHODS = [
   "absrel", "busted", "fel", "cfel", "fubar", "meme", "slac",
   "relax", "multihit", "fade", "bgm", "prime", "difFubar",
   "gard", "nrm", "bstill", "flea"
@@ -161,10 +161,10 @@ var TREE_METHODS = [
  */
 function extractBranchLabels(tree) {
   if (!tree) return [];
-  var matches = tree.match(/\{([^}]+)\}/g);
+  const matches = tree.match(/\{([^}]+)\}/g);
   if (!matches) return [];
-  var labels = {};
-  for (var i = 0; i < matches.length; i++) {
+  const labels = {};
+  for (let i = 0; i < matches.length; i++) {
     labels[matches[i].slice(1, -1)] = true;
   }
   return Object.keys(labels);
@@ -175,7 +175,7 @@ function extractBranchLabels(tree) {
  * Returns {valid, errors[], warnings[]}
  */
 function validateAnalysisParams(type, tree, params) {
-  var result = { valid: true, errors: [], warnings: [] };
+  const result = { valid: true, errors: [], warnings: [] };
 
   if (!type) {
     result.valid = false;
@@ -183,12 +183,12 @@ function validateAnalysisParams(type, tree, params) {
     return result;
   }
 
-  var labels = extractBranchLabels(tree);
+  const labels = extractBranchLabels(tree);
 
   // RELAX requires {TEST} and {REFERENCE} branch labels
   if (type === "relax") {
-    var hasTest = labels.indexOf("TEST") !== -1 || labels.indexOf("test") !== -1;
-    var hasRef = labels.indexOf("REFERENCE") !== -1 || labels.indexOf("reference") !== -1;
+    const hasTest = labels.indexOf("TEST") !== -1 || labels.indexOf("test") !== -1;
+    const hasRef = labels.indexOf("REFERENCE") !== -1 || labels.indexOf("reference") !== -1;
     if (!hasTest || !hasRef) {
       result.valid = false;
       result.errors.push(

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,7 +1,7 @@
 const logger = require("./logger").logger;
 
-var io = function(socket) {
-  var self = this;
+const io = function(socket) {
+  const self = this;
   self.socket = socket;
   
   logger.info("New socket connection established: " + socket.id);
@@ -15,12 +15,12 @@ var io = function(socket) {
 
 io.prototype.route = function(route, next) {
 
-  var initRoutes = function(socket, routes) {
+  const initRoutes = function(socket, routes) {
     Object.keys(routes).forEach(function(i) {
-      var x = routes[i];
+      const x = routes[i];
       // Check if key uses a stream
-      var key = i;
-      var callback = x;
+      const key = i;
+      const callback = x;
 
       if (key.indexOf("spawn") != -1) {
         socket.on(key, function(stream, data) {
@@ -87,14 +87,14 @@ io.prototype.route = function(route, next) {
   };
 
   // Set functions up for routing
-  var self = this;
-  var routes = {};
+  const self = this;
+  const routes = {};
 
-  var c = 0;
-  var next_length = Object.keys(next).length;
+  let c = 0;
+  const next_length = Object.keys(next).length;
 
   Object.keys(next).forEach(function(i) {
-    var key = route + ":" + i;
+    const key = route + ":" + i;
     routes[key] = next[i];
     if (++c == next_length) {
       initRoutes(self.socket, routes);

--- a/lib/routes/analysis-routes.js
+++ b/lib/routes/analysis-routes.js
@@ -14,13 +14,13 @@
  *   - resubscribe / cancel: delegate to job.resubscribe / job.cancel.
  */
 
-var job = require("../../app/job.js");
-var logger = require("../logger.js").logger;
+const job = require("../../app/job.js");
+const logger = require("../logger.js").logger;
 
 // The analysis route table. Each entry: [routeName, constructor, options].
 // options.mergeTree (default true) — whether spawn merges params.tree into the
 // job params (bgm and difFubar pass params.job directly, no tree merge).
-var ANALYSES = [
+const ANALYSES = [
   ["absrel", require("../../app/absrel/absrel.js").absrel],
   ["bgm", require("../../app/bgm/bgm.js").bgm, { mergeTree: false }],
   ["bstill", require("../../app/bstill/bstill.js").bstill],
@@ -42,7 +42,7 @@ var ANALYSES = [
 // Build the standard {spawn, check, resubscribe, cancel} handler set for one
 // analysis, closed over the connection socket.
 function standardHandlers(socket, name, Ctor, options) {
-  var mergeTree = !(options && options.mergeTree === false);
+  const mergeTree = !(options && options.mergeTree === false);
   return {
     spawn: function (stream, params) {
       if (!params || !params.job) {
@@ -50,7 +50,7 @@ function standardHandlers(socket, name, Ctor, options) {
         socket.emit("script error", { error: "Invalid job parameters" });
         return;
       }
-      var jobParams = params.job;
+      let jobParams = params.job;
       if (mergeTree) {
         jobParams = Object.assign({}, params.job);
         if (params.tree) {
@@ -84,9 +84,9 @@ function standardHandlers(socket, name, Ctor, options) {
  */
 function registerAnalysisRoutes(r, socket, deps) {
   ANALYSES.forEach(function (entry) {
-    var name = entry[0];
-    var Ctor = entry[1];
-    var options = entry[2];
+    const name = entry[0];
+    const Ctor = entry[1];
+    const options = entry[2];
     r.route(name, standardHandlers(socket, name, Ctor, options));
   });
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,4 +1,4 @@
-var logger = require("./logger").logger,
+const logger = require("./logger").logger,
   fs = require("fs"),
   client = require("./redis-client").client;
 

--- a/server.js
+++ b/server.js
@@ -20,14 +20,14 @@ program
 
 
 //Assigns port number to variable, if none then refer to config.json
-var ioOptions = { 
+const ioOptions = { 
   "maxHttpBufferSize" : 1e8,
   cors: {
     origin: ["http://localhost:5173", "http://localhost:3000"],
     methods: ["GET", "POST"]
   }
 };
-var ioPort = config.port;
+let ioPort = config.port;
 
 if (program.port) {
   ioPort = program.port;
@@ -38,7 +38,7 @@ const io = require("socket.io")(ioPort, ioOptions);
 // Use the shared redis@5 client factory (see lib/redis-client.js). redis@5 is
 // promise-native, so commands return promises and are camelCased
 // (del stays del, hgetall -> hGetAll).
-var client = require("./lib/redis-client").client;
+const client = require("./lib/redis-client").client;
 
 // clear active_jobs list
 // TODO: we should do more than just clear the active_jobs list
@@ -71,7 +71,7 @@ io.sockets.on("connection", function(socket) {
         return;
       }
 
-      var response = {
+      const response = {
         status: jobData.status || "unknown",
         torque_id: jobData.torque_id
       };
@@ -80,7 +80,7 @@ io.sockets.on("connection", function(socket) {
         // Results are stored as: {"results":"{ stringified JSON }","type":"completed"}
         // We need to unwrap and parse the inner results string
         try {
-          var parsedResults = JSON.parse(jobData.results);
+          const parsedResults = JSON.parse(jobData.results);
           if (parsedResults.results && typeof parsedResults.results === "string") {
             response.results = JSON.parse(parsedResults.results);
           } else {
@@ -103,7 +103,7 @@ io.sockets.on("connection", function(socket) {
     });
   });
 
-  var r = new router.io(socket);
+  const r = new router.io(socket);
 
   // Analysis routes are data-driven — see lib/routes/analysis-routes.js.
   // It reproduces the 16 standard spawn/check/resubscribe/cancel blocks plus
@@ -118,7 +118,7 @@ io.sockets.on("connection", function(socket) {
 
 
 // Start MCP server on separate port
-var mcp = require("./lib/mcp");
+const mcp = require("./lib/mcp");
 mcp.startMcpServer(config, client);
 
 process.setMaxListeners(20); // bounded; GH #400 removed per-job cancelJob listeners


### PR DESCRIPTION
## Phase 4c (#410): var -> const/let modernization

Behavior-preserving, mechanical block-scoped-declaration modernization across `app/`, `lib/`, and `server.js`.

### What changed
- Enabled `no-var: error` and `prefer-const: error` in `.eslintrc.js`.
- Ran `eslint app lib server.js --fix` (safe, mechanical var->const/let).
- Manually resolved the 5 cases the autofixer refused (all genuine hoisting/scope hazards), each fixed in a behavior-preserving way:
  - **app/hivtrace/hivtrace.js**: `var info` declared inside a `try` but referenced from the `catch` handler -> declared `let info;` before the try so the catch still sees it (block-scoping would have broken the error log). `var HivTraceRunner = function(){}` -> `const` (function expression only invoked at runtime, after module load; the line-196 usage runs inside a prototype method).
  - **app/job.js**: `var qsub = spawn(...)` inside a `try` but wired to `.stderr/.stdout/.on("close")` handlers *after* the block -> `let qsub;` before the try (the catch `return`s on failure, so it's always assigned by use). Split a combined `let current_status, torque_id` so the never-reassigned `current_status` becomes `const`.
  - **lib/jobqueue.js**: split a combined declaration so the never-reassigned `job_data` becomes `const`.

### Loop-closure audit
The task's key hazard is `var`-in-loop closures changing capture semantics when they become `let`. The only loops with async callbacks are `returnQsubJobInfo`/`returnSlurmJobInfo` in `lib/jobqueue.js`; both capture the per-iteration `const job_id` and outer accumulators, **never the loop counter `i`**, so `var i` -> `let i` is behavior-identical. All other loops (validation, jobstatus) are synchronous.

### Coordination hazard respected
`lib/analysis-factory.js:157` `util.inherits(Analysis, hyphyJob)` and `app/hyphyjob.js`'s constructor shape are **untouched** (only local var->const/let inside those files). The dynamic-constructor inheritance is deferred to Phase 4d.

### Verification
- `node -c` clean on all 39 changed files
- `npm run test:ci`: 125 passing (unchanged)
- MCP (`mocha --exit test/mcp/mcp.test.js`): 58 passing (unchanged)
- golden (`mocha --exit test/golden/*.js`): 30 passing (unchanged)
- `npm run lint`: 0 errors (31 pre-existing unused-var warnings unchanged)

### Paradigm counts (declaration `var` -> 0)
- Before: 549 var / 95 const / 12 let (raw grep)
- After: 0 `var` declarations (eslint no-var confirms 0); 2 remaining "var" matches are inside comments in `lib/redis-client.js`