### PR TITLE
Phase 4c: convert leaf EventEmitter runners to ES classes (#410)

### DIFF
--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -439,278 +439,279 @@ hivtrace.prototype.sendtn93 = function() {
 };
 
 // An object that manages the job submission process
-var HivTraceRunner = function(id, hivtrace_log) {
-  var self = this;
-  self.python_redis_channel = "python_" + id;
-  self.hivtrace_log = hivtrace_log;
-  self.last_status_update = "";
-  self.submit_type = config.submit_type || "qsub";
-  self.subscriber = null;
+class HivTraceRunner extends EventEmitter {
+  constructor(id, hivtrace_log) {
+    super();
+    var self = this;
+    self.python_redis_channel = "python_" + id;
+    self.hivtrace_log = hivtrace_log;
+    self.last_status_update = "";
+    self.submit_type = config.submit_type || "qsub";
+    self.subscriber = null;
 
-  // redis v5 pub/sub requires a dedicated (duplicated) connection, and both
-  // connect() and subscribe() are async. We kick off the connection here and
-  // wire the message listener once connected. The listener is passed directly
-  // to subscribe() (there is no more .on("message", ...)). We stash the promise
-  // so close() can await teardown after connect, avoiding a leaked subscriber
-  // if the job ends before the socket is up (see #397/#400).
-  self.subscriber_ready = createSubscriber()
-    .then(function(subscriber) {
-      self.subscriber = subscriber;
+    // redis v5 pub/sub requires a dedicated (duplicated) connection, and both
+    // connect() and subscribe() are async. We kick off the connection here and
+    // wire the message listener once connected. The listener is passed directly
+    // to subscribe() (there is no more .on("message", ...)). We stash the promise
+    // so close() can await teardown after connect, avoiding a leaked subscriber
+    // if the job ends before the socket is up (see #397/#400).
+    self.subscriber_ready = createSubscriber()
+      .then(function(subscriber) {
+        self.subscriber = subscriber;
 
-      // If close() ran before the subscriber finished connecting, tear it down
-      // immediately instead of leaking it.
-      if (self._closed) {
-        try {
-          subscriber.quit();
-        } catch (e) {
+        // If close() ran before the subscriber finished connecting, tear it down
+        // immediately instead of leaking it.
+        if (self._closed) {
           try {
-            subscriber.destroy();
-          } catch (e2) {}
+            subscriber.quit();
+          } catch (e) {
+            try {
+              subscriber.destroy();
+            } catch (e2) {}
+          }
+          return;
         }
-        return;
-      }
 
-      return subscriber.subscribe(self.python_redis_channel, function(message) {
-        var redis_packet = JSON.parse(message);
-        logger.info(redis_packet);
+        return subscriber.subscribe(self.python_redis_channel, function(message) {
+          var redis_packet = JSON.parse(message);
+          logger.info(redis_packet);
 
-        if (message != self.last_status_update) {
-          self.emit(redis_packet.type, redis_packet);
-          self.last_status_update = message;
-        }
-      });
-    })
-    .catch(function(err) {
-      logger.error(
-        "Error setting up HivTrace Redis subscriber: " + err.message
-      );
-    });
-};
-
-util.inherits(HivTraceRunner, EventEmitter);
-
-/**
- * Tears down the dedicated python_<id> Redis subscriber and the status-watcher
- * timer. Idempotent — safe to call from terminal events and socket disconnect.
- * See issue #397.
- */
-HivTraceRunner.prototype.close = function() {
-  var self = this;
-  if (self._closed) return;
-  self._closed = true;
-
-  if (self.metronome_id) clearInterval(self.metronome_id);
-
-  // Stop watching the hivtrace log file (node-tail exposes unwatch()). See #400.
-  if (self.tail) {
-    try {
-      self.tail.unwatch();
-    } catch (e) {
-      logger.warn("error unwatching hivtrace log tail: " + e);
-    }
-    self.tail = null;
-  }
-
-  logger.info(
-    "[REDIS] Closing subscriber for channel " + self.python_redis_channel
-  );
-
-  // The subscriber connects asynchronously (redis v5 duplicate + connect).
-  // Wait for that to settle so we never leak a subscriber that finished
-  // connecting after close() ran, then unsubscribe + quit. The _closed flag
-  // set above also makes the connect() handler self-quit if it wins the race.
-  var teardown = self.subscriber_ready
-    ? Promise.resolve(self.subscriber_ready)
-    : Promise.resolve();
-
-  teardown.then(function() {
-    if (!self.subscriber) return;
-    // In redis v5 the listener was passed to subscribe(); unsubscribe drops it.
-    return self.subscriber
-      .unsubscribe(self.python_redis_channel)
-      .then(function() {
-        return self.subscriber.quit();
+          if (message != self.last_status_update) {
+            self.emit(redis_packet.type, redis_packet);
+            self.last_status_update = message;
+          }
+        });
       })
       .catch(function(err) {
         logger.error(
-          "Error closing HivTrace Redis subscriber: " + err.message
+          "Error setting up HivTrace Redis subscriber: " + err.message
         );
-        try {
-          self.subscriber.destroy();
-        } catch (e) {
-          logger.error(
-            "Error force-ending HivTrace Redis subscriber: " + e.message
-          );
-        }
       });
-  });
-};
-
-HivTraceRunner.prototype.log_publisher = function() {
-  var self = this;
-
-  // read log file (stored on self so close() can stop watching it; GH #400)
-  self.tail = new Tail(self.hivtrace_log);
-
-  self.tail.on("line", function(data) {
-    logger.debug(data);
-
-    if (data.indexOf("INFO:") != -1) {
-      var msg = "";
-
-      // try parsing the message
-      try {
-        var info = data.split("INFO:")[1].split("root:")[1];
-        msg = JSON.parse(info);
-      } catch (e) {
-        logger.warn("error" + e + " for " + info);
-      }
-
-      // publish to redis
-      client.publish(self.python_redis_channel, JSON.stringify(msg));
-    }
-  });
-};
-
-/**
- * Once the job has been scheduled, we need to watch the files that it
- * sends updates to.
- */
-HivTraceRunner.prototype.status_watcher = function() {
-  var self = this;
-  
-  // For local jobs, no status watcher is needed
-  if (self.submit_type === "local") {
-    return;
   }
 
-  var job_status = new JobStatus(self.torque_id);
+  /**
+   * Tears down the dedicated python_<id> Redis subscriber and the status-watcher
+   * timer. Idempotent — safe to call from terminal events and socket disconnect.
+   * See issue #397.
+   */
+  close() {
+    var self = this;
+    if (self._closed) return;
+    self._closed = true;
 
-  self.metronome_id = job_status.watch(function(error, status) {
-    var new_status = status.status;
+    if (self.metronome_id) clearInterval(self.metronome_id);
 
-    if (new_status == "completed" || new_status == "exiting") {
-      // check exit code
-      clearInterval(self.metronome_id);
-      self.emit("completed", "");
+    // Stop watching the hivtrace log file (node-tail exposes unwatch()). See #400.
+    if (self.tail) {
+      try {
+        self.tail.unwatch();
+      } catch (e) {
+        logger.warn("error unwatching hivtrace log tail: " + e);
+      }
+      self.tail = null;
     }
-  });
+
+    logger.info(
+      "[REDIS] Closing subscriber for channel " + self.python_redis_channel
+    );
+
+    // The subscriber connects asynchronously (redis v5 duplicate + connect).
+    // Wait for that to settle so we never leak a subscriber that finished
+    // connecting after close() ran, then unsubscribe + quit. The _closed flag
+    // set above also makes the connect() handler self-quit if it wins the race.
+    var teardown = self.subscriber_ready
+      ? Promise.resolve(self.subscriber_ready)
+      : Promise.resolve();
+
+    teardown.then(function() {
+      if (!self.subscriber) return;
+      // In redis v5 the listener was passed to subscribe(); unsubscribe drops it.
+      return self.subscriber
+        .unsubscribe(self.python_redis_channel)
+        .then(function() {
+          return self.subscriber.quit();
+        })
+        .catch(function(err) {
+          logger.error(
+            "Error closing HivTrace Redis subscriber: " + err.message
+          );
+          try {
+            self.subscriber.destroy();
+          } catch (e) {
+            logger.error(
+              "Error force-ending HivTrace Redis subscriber: " + e.message
+            );
+          }
+        });
+    });
+  }
+
+  log_publisher() {
+    var self = this;
+
+    // read log file (stored on self so close() can stop watching it; GH #400)
+    self.tail = new Tail(self.hivtrace_log);
+
+    self.tail.on("line", function(data) {
+      logger.debug(data);
+
+      if (data.indexOf("INFO:") != -1) {
+        var msg = "";
+
+        // try parsing the message
+        try {
+          var info = data.split("INFO:")[1].split("root:")[1];
+          msg = JSON.parse(info);
+        } catch (e) {
+          logger.warn("error" + e + " for " + info);
+        }
+
+        // publish to redis
+        client.publish(self.python_redis_channel, JSON.stringify(msg));
+      }
+    });
+  }
+
+  /**
+   * Once the job has been scheduled, we need to watch the files that it
+   * sends updates to.
+   */
+  status_watcher() {
+    var self = this;
+  
+    // For local jobs, no status watcher is needed
+    if (self.submit_type === "local") {
+      return;
+    }
+
+    var job_status = new JobStatus(self.torque_id);
+
+    self.metronome_id = job_status.watch(function(error, status) {
+      var new_status = status.status;
+
+      if (new_status == "completed" || new_status == "exiting") {
+      // check exit code
+        clearInterval(self.metronome_id);
+        self.emit("completed", "");
+      }
+    });
 
   // The python_<id> subscriber message listener is wired at subscribe() time
   // in the constructor (redis v5 passes the listener to subscribe()); there is
   // no more .on("message", ...) here.
-};
+  }
 
-/**
- * Submits a job to TORQUE using qsub command
- * Emit events that are being listened for by the calling class
- */
-HivTraceRunner.prototype.submit = function(qsub_params, cwd) {
-  var self = this;
+  /**
+   * Submits a job to TORQUE using qsub command
+   * Emit events that are being listened for by the calling class
+   */
+  submit(qsub_params, cwd) {
+    var self = this;
 
-  var qsub_submit = function() {
-    var qsub = spawn("qsub", qsub_params, { cwd: cwd });
+    var qsub_submit = function() {
+      var qsub = spawn("qsub", qsub_params, { cwd: cwd });
 
-    qsub.stderr.on("data", function(data) {
+      qsub.stderr.on("data", function(data) {
       // error when starting job
-      self.emit("script error", { error: "" + data });
-    });
+        self.emit("script error", { error: "" + data });
+      });
 
-    qsub.stdout.on("data", function(data) {
-      self.torque_id = String(data).replace(/\n$/, "");
-      self.emit("job created", { torque_id: self.torque_id });
-      logger.info(self.torque_id);
-    });
+      qsub.stdout.on("data", function(data) {
+        self.torque_id = String(data).replace(/\n$/, "");
+        self.emit("job created", { torque_id: self.torque_id });
+        logger.info(self.torque_id);
+      });
 
-    qsub.on("close", function(code) {
-      self.status_watcher();
-    });
-  };
+      qsub.on("close", function(code) {
+        self.status_watcher();
+      });
+    };
 
-  // Ensure log directory exists
-  utilities.ensureDirectoryExists(path.dirname(self.hivtrace_log));
+    // Ensure log directory exists
+    utilities.ensureDirectoryExists(path.dirname(self.hivtrace_log));
   
-  fs.closeSync(fs.openSync(self.hivtrace_log, "w"));
-  qsub_submit();
-  self.log_publisher();
-};
+    fs.closeSync(fs.openSync(self.hivtrace_log, "w"));
+    qsub_submit();
+    self.log_publisher();
+  }
 
-/**
- * Submits a job to SLURM using sbatch command
- * Emit events that are being listened for by the calling class
- */
-HivTraceRunner.prototype.submit_slurm = function(slurm_params, cwd) {
-  var self = this;
+  /**
+   * Submits a job to SLURM using sbatch command
+   * Emit events that are being listened for by the calling class
+   */
+  submit_slurm(slurm_params, cwd) {
+    var self = this;
   
-  logger.info("Submitting job to SLURM", slurm_params);
+    logger.info("Submitting job to SLURM", slurm_params);
 
-  var sbatch_submit = function() {
-    var sbatch = spawn("sbatch", slurm_params, { cwd: cwd });
+    var sbatch_submit = function() {
+      var sbatch = spawn("sbatch", slurm_params, { cwd: cwd });
 
-    sbatch.stderr.on("data", function(data) {
+      sbatch.stderr.on("data", function(data) {
       // error when starting job
-      logger.error("SLURM stderr: " + data.toString("utf8"));
-      self.emit("script error", { error: "" + data });
-    });
+        logger.error("SLURM stderr: " + data.toString("utf8"));
+        self.emit("script error", { error: "" + data });
+      });
 
-    sbatch.stdout.on("data", function(data) {
-      logger.info("SLURM stdout: " + data.toString("utf8"));
-      // Extract job ID from SLURM output (format: "Submitted batch job 123456")
-      self.torque_id = String(data).replace(/\n$/, "").split(" ").pop();
-      self.emit("job created", { torque_id: self.torque_id });
-      logger.info("SLURM job ID: " + self.torque_id);
-    });
+      sbatch.stdout.on("data", function(data) {
+        logger.info("SLURM stdout: " + data.toString("utf8"));
+        // Extract job ID from SLURM output (format: "Submitted batch job 123456")
+        self.torque_id = String(data).replace(/\n$/, "").split(" ").pop();
+        self.emit("job created", { torque_id: self.torque_id });
+        logger.info("SLURM job ID: " + self.torque_id);
+      });
 
-    sbatch.on("close", function(code) {
-      logger.info("SLURM sbatch process closed with code: " + code);
-      self.status_watcher();
-    });
-  };
+      sbatch.on("close", function(code) {
+        logger.info("SLURM sbatch process closed with code: " + code);
+        self.status_watcher();
+      });
+    };
 
-  // Ensure log directory exists
-  utilities.ensureDirectoryExists(path.dirname(self.hivtrace_log));
+    // Ensure log directory exists
+    utilities.ensureDirectoryExists(path.dirname(self.hivtrace_log));
   
-  fs.closeSync(fs.openSync(self.hivtrace_log, "w"));
-  sbatch_submit();
-  self.log_publisher();
-};
+    fs.closeSync(fs.openSync(self.hivtrace_log, "w"));
+    sbatch_submit();
+    self.log_publisher();
+  }
 
-/**
- * Submits a job locally without using a job scheduler
- * Emit events that are being listened for by the calling class
- */
-HivTraceRunner.prototype.submit_local = function(script, params, cwd) {
-  var self = this;
+  /**
+   * Submits a job locally without using a job scheduler
+   * Emit events that are being listened for by the calling class
+   */
+  submit_local(script, params, cwd) {
+    var self = this;
   
-  logger.info("Submitting job locally", script, params);
+    logger.info("Submitting job locally", script, params);
 
-  var local_submit = function() {
-    var proc = spawn(script, { cwd: cwd, env: params });
+    var local_submit = function() {
+      var proc = spawn(script, { cwd: cwd, env: params });
     
-    // Use process id as job identifier
-    self.torque_id = "local_" + process.pid;
-    self.emit("job created", { torque_id: self.torque_id });
+      // Use process id as job identifier
+      self.torque_id = "local_" + process.pid;
+      self.emit("job created", { torque_id: self.torque_id });
 
-    proc.stderr.on("data", function(data) {
-      logger.info("Local job stderr: " + data.toString("utf8"));
-    });
+      proc.stderr.on("data", function(data) {
+        logger.info("Local job stderr: " + data.toString("utf8"));
+      });
 
-    proc.stdout.on("data", function(data) {
-      logger.info("Local job stdout: " + data.toString("utf8"));
-    });
+      proc.stdout.on("data", function(data) {
+        logger.info("Local job stdout: " + data.toString("utf8"));
+      });
 
-    proc.on("close", function(code) {
-      logger.info("Local job completed with code: " + code);
-      self.emit("completed", "");
-    });
-  };
+      proc.on("close", function(code) {
+        logger.info("Local job completed with code: " + code);
+        self.emit("completed", "");
+      });
+    };
 
-  // Ensure log directory exists
-  utilities.ensureDirectoryExists(path.dirname(self.hivtrace_log));
+    // Ensure log directory exists
+    utilities.ensureDirectoryExists(path.dirname(self.hivtrace_log));
   
-  fs.closeSync(fs.openSync(self.hivtrace_log, "w"));
-  local_submit();
-  self.log_publisher();
-};
+    fs.closeSync(fs.openSync(self.hivtrace_log, "w"));
+    local_submit();
+    self.log_publisher();
+  }
+}
 
 exports.hivtrace = hivtrace;

--- a/app/job.js
+++ b/app/job.js
@@ -1,6 +1,5 @@
 var spawn = require("child_process").spawn,
   fs = require("fs"),
-  util = require("util"),
   cs = require("../lib/clientsocket.js"),
   logger = require("../lib/logger.js").logger,
   jobdel = require("../lib/jobdel.js"),
@@ -108,29 +107,6 @@ var cancel = function(socket, id) {
   });
 };
 
-var jobRunner = function(params, results_fn) {
-  var self = this;
-  self.torque_id = "";
-  self.error_count = 0;
-  self.QSTAT_ERROR_LIMIT = 500;
-  self.results_fn = results_fn || "";
-  self.qsub_params = params;
-  self.submit_type = config.submit_type || "qsub";
-
-  self.states = {
-    completed: "completed",
-    exiting: "exiting",
-    held: "held",
-    queued: "queued",
-    running: "running",
-    transit: "transit",
-    waiting: "waiting",
-    suspended: "suspended"
-  };
-};
-
-util.inherits(jobRunner, EventEmitter);
-
 // Extracts the TORQUE job ID from the command output.
 function get_torque_id_from_data(data) {
   return String(data).replace(/\n$/, "");
@@ -140,309 +116,333 @@ function get_torque_id_from_data(data) {
 function get_slurm_id_from_data(data) {
   const output = String(data).replace(/\n$/, "");
   console.log(`Parsing SLURM job ID from output: "${output}"`);
-  
+
   // Standard format is "Submitted batch job 123456"
   const match = output.match(/Submitted batch job (\d+)/i);
-  
+
   if (match && match[1]) {
     console.log(`Found SLURM job ID: ${match[1]}`);
     return match[1];
   }
-  
+
   // Fallback to the old method
   const splitOutput = output.split(" ");
   console.log(`Falling back to split method with ${splitOutput.length} parts: ${JSON.stringify(splitOutput)}`);
   return splitOutput[3];
 }
 
-// Submits a job to the scheduler (TORQUE, SLURM, or local) by spawning a submission script.
-// Emit events
-jobRunner.prototype.submit = function(params, cwd) {
-  var self = this;
-  self.qsub_params = params;
+class jobRunner extends EventEmitter {
+  constructor(params, results_fn) {
+    super();
+    var self = this;
+    self.torque_id = "";
+    self.error_count = 0;
+    self.QSTAT_ERROR_LIMIT = 500;
+    self.results_fn = results_fn || "";
+    self.qsub_params = params;
+    self.submit_type = config.submit_type || "qsub";
 
-  // Handle local execution
-  if (self.submit_type === "local") {
+    self.states = {
+      completed: "completed",
+      exiting: "exiting",
+      held: "held",
+      queued: "queued",
+      running: "running",
+      transit: "transit",
+      waiting: "waiting",
+      suspended: "suspended"
+    };
+  }
+
+  // Submits a job to the scheduler (TORQUE, SLURM, or local) by spawning a submission script.
+  // Emit events
+  submit(params, cwd) {
+    var self = this;
+    self.qsub_params = params;
+
+    // Handle local execution
+    if (self.submit_type === "local") {
     // For local execution, params[0] should be the script to execute
-    const script = params[0];
-    logger.info(`LOCAL EXECUTION: ${script}`);
-    logger.info(`Working directory: ${cwd}`);
+      const script = params[0];
+      logger.info(`LOCAL EXECUTION: ${script}`);
+      logger.info(`Working directory: ${cwd}`);
     
-    return self.submit_local(script, params.slice(1), cwd);
-  }
-
-  const scheduler = self.submit_type === "qsub" ? "qsub" : "sbatch";
-  
-  // Create formatted command for logging
-  const fullCommand = `${scheduler} ${params.join(" ")}`;
-  logger.info(`[${scheduler.toUpperCase()} JOB] FULL COMMAND: ${fullCommand}`);
-  logger.info(`[${scheduler.toUpperCase()} JOB] Job submission using ${scheduler} with params: ${JSON.stringify(params)}`);
-  logger.info(`[${scheduler.toUpperCase()} JOB] Working directory: ${cwd}`);
-  
-  try {
-    console.log(`EXECUTING: ${fullCommand}`);
-    var qsub = spawn(scheduler, params, { cwd: cwd });
-    logger.info(`${scheduler} process spawned successfully with pid: ${qsub.pid}`);
-  } catch (error) {
-    logger.error(`Error spawning ${scheduler} process: ${error.message}`);
-    logger.error(error.stack);
-    self.emit("script error", `Failed to spawn ${scheduler} process: ${error.message}`);
-    return;
-  }
-
-  qsub.stderr.on("data", function(data) {
-    const output = data.toString("utf8");
-    logger.info(`${scheduler} stderr: ${output}`);
-    console.log(`${scheduler} STDERR: ${output}`);
-    if (output.includes("error") || output.includes("not found")) {
-      logger.error(`${scheduler} error: ${output}`);
+      return self.submit_local(script, params.slice(1), cwd);
     }
-  });
 
-  qsub.stdout.on("data", function(data) {
-    const output = data.toString("utf8");
-    logger.info(`${scheduler} stdout: ${output}`);
-    console.log(`${scheduler} STDOUT: ${output}`);
-    
+    const scheduler = self.submit_type === "qsub" ? "qsub" : "sbatch";
+  
+    // Create formatted command for logging
+    const fullCommand = `${scheduler} ${params.join(" ")}`;
+    logger.info(`[${scheduler.toUpperCase()} JOB] FULL COMMAND: ${fullCommand}`);
+    logger.info(`[${scheduler.toUpperCase()} JOB] Job submission using ${scheduler} with params: ${JSON.stringify(params)}`);
+    logger.info(`[${scheduler.toUpperCase()} JOB] Working directory: ${cwd}`);
+  
     try {
-      var torque_id = self.submit_type === "qsub" 
-        ? get_torque_id_from_data(data) 
-        : get_slurm_id_from_data(data);
-      
-      logger.info(`Job ID extracted: ${torque_id}`);
-      console.log(`Job ID extracted: ${torque_id}`);
-      self.torque_id = torque_id;
-      self.emit("job created", { torque_id: torque_id });
+      console.log(`EXECUTING: ${fullCommand}`);
+      var qsub = spawn(scheduler, params, { cwd: cwd });
+      logger.info(`${scheduler} process spawned successfully with pid: ${qsub.pid}`);
     } catch (error) {
-      logger.error(`Error extracting job ID: ${error.message}`);
-      logger.error(`Raw output was: ${output}`);
-      console.log(`ERROR extracting job ID: ${error.message}, Raw output: ${output}`);
+      logger.error(`Error spawning ${scheduler} process: ${error.message}`);
+      logger.error(error.stack);
+      self.emit("script error", `Failed to spawn ${scheduler} process: ${error.message}`);
+      return;
     }
-  });
 
-  qsub.on("close", function(code) {
-    logger.info(`${scheduler} process closed with code: ${code}`);
-    console.log(`${scheduler} process closed with code: ${code}`);
-    
-    if (code !== 0) {
-      logger.error(`${scheduler} process exited with non-zero status: ${code}`);
-      console.log(`ERROR: ${scheduler} process exited with non-zero status: ${code}`);
-      // Still try to extract any error information
-      self.emit("script error", `${scheduler} process failed with exit code: ${code}`);
-    } else {
-      logger.info(`Starting status watcher for job: ${self.torque_id}`);
-      console.log(`Starting status watcher for job: ${self.torque_id}`);
-      self.status_watcher();
-    }
-  });
-};
-
-// Local job submission - used when submit_type is 'local'
-jobRunner.prototype.submit_local = function(script, params, cwd) {
-  var self = this;
-  
-  logger.info("[LOCAL JOB] Starting local job submission");
-  logger.info(`[LOCAL JOB] Script: ${script}`);
-  logger.info(`[LOCAL JOB] Params: ${JSON.stringify(params)}`);
-  logger.info(`[LOCAL JOB] Working directory: ${cwd}`);
-  
-  // Log the full command that will be executed
-  const fullCommand = `${script} ${params.join(" ")}`;
-  logger.info(`[LOCAL JOB] FULL COMMAND: ${fullCommand}`);
-  
-  // Log environment variables that will be passed
-  if (params.length > 0) {
-    logger.info("[LOCAL JOB] Environment variables/arguments:");
-    params.forEach((param, index) => {
-      logger.info(`[LOCAL JOB]   [${index}]: ${param}`);
-    });
-  }
-  
-  try {
-    // For local execution, pass params as command line arguments
-    var proc = spawn(script, params, { cwd: cwd });
-    
-    // Store process reference for cancellation
-    self.local_process = proc;
-    
-    // Use a unique job identifier for local runs
-    // Wait for the process to be fully spawned before using pid
-    process.nextTick(() => {
-      self.torque_id = "local_" + Date.now() + "_" + (proc.pid || "nopid");
-      self.emit("job created", { torque_id: self.torque_id });
-    });
-    
-    proc.stderr.on("data", function(data) {
+    qsub.stderr.on("data", function(data) {
       const output = data.toString("utf8");
-      logger.error(`[LOCAL JOB STDERR] ${output.trim()}`);
-      // Emit status updates for stderr (can indicate progress)
-      if (output.trim()) {
-        self.emit("status update", { msg: output.trim() });
+      logger.info(`${scheduler} stderr: ${output}`);
+      console.log(`${scheduler} STDERR: ${output}`);
+      if (output.includes("error") || output.includes("not found")) {
+        logger.error(`${scheduler} error: ${output}`);
       }
     });
-    
-    proc.stdout.on("data", function(data) {
+
+    qsub.stdout.on("data", function(data) {
       const output = data.toString("utf8");
-      logger.info(`[LOCAL JOB STDOUT] ${output.trim()}`);
-      // Emit status updates for stdout
-      if (output.trim()) {
-        self.emit("status update", { msg: output.trim() });
-      }
-    });
+      logger.info(`${scheduler} stdout: ${output}`);
+      console.log(`${scheduler} STDOUT: ${output}`);
     
-    proc.on("error", function(error) {
-      logger.error(`[LOCAL JOB ERROR] Failed to spawn process: ${error.message}`);
-      logger.error(`[LOCAL JOB ERROR] Error details: ${JSON.stringify(error)}`);
-      self.emit("script error", "Local execution failed: " + error.message);
-    });
-    
-    proc.on("close", function(code) {
-      logger.info(`[LOCAL JOB] Process completed with exit code: ${code}`);
-      if (code === 0) {
-        logger.info("[DEBUG JOB] Local job completed successfully, emitting completed event");
-        self.emit(self.states.completed, "");
-      } else {
-        logger.error(`[LOCAL JOB] Job failed with exit code: ${code}`);
-        self.emit("script error", "Local job failed with exit code: " + code);
-      }
-    });
-    
-  } catch (error) {
-    logger.error(`[LOCAL JOB] Exception starting local job: ${error.message}`);
-    logger.error(`[LOCAL JOB] Exception details: ${JSON.stringify(error)}`);
-    self.emit("script error", "Failed to start local job: " + error.message);
-  }
-};
-
-// SLURM job submission with specific parameters
-jobRunner.prototype.submit_slurm = function(script, cwd, slurm_params) {
-  var self = this;
-  
-  logger.info("SLURM job submission", script, slurm_params);
-  
-  var sbatch = spawn("sbatch", slurm_params, { cwd: cwd });
-  
-  sbatch.stderr.on("data", function(data) {
-    logger.info("SLURM stderr: " + data.toString("utf8"));
-  });
-  
-  sbatch.stdout.on("data", function(data) {
-    var job_id = get_slurm_id_from_data(data);
-    self.torque_id = job_id;
-    self.emit("job created", { torque_id: job_id });
-  });
-  
-  sbatch.on("close", function(code) {
-    self.status_watcher();
-  });
-};
-
-// Once the job has been scheduled, we need to watch the files that it
-// sends updates to.
-jobRunner.prototype.status_watcher = function() {
-  var self = this;
-  
-  // Don't create a job status watcher for local jobs
-  if (self.submit_type === "local") {
-    return;
-  }
-  
-  logger.info(`Starting job status watcher for job ID: ${self.torque_id}`);
-  var job_status = new JobStatus(self.torque_id);
-
-  self.metronome_id = job_status.watch(function(error, status_packet) {
-    // Log status updates for debugging
-    if (status_packet) {
-      logger.info(`Status update for job ${self.torque_id}: ${JSON.stringify(status_packet)}`);
-    }
-    
-    // Check if results file exists if there is an error
-    if (error) {
-      logger.warn(`Status error for job ${self.torque_id}: ${error}`);
+      try {
+        var torque_id = self.submit_type === "qsub" 
+          ? get_torque_id_from_data(data) 
+          : get_slurm_id_from_data(data);
       
-      // If a results file was specified, check if it exists and has content
-      if (self.results_fn) {
-        fs.stat(self.results_fn, (err, res) => {
-          if (err) {
-            logger.warn(`[DEBUG JOB] Error checking results file ${self.results_fn}: ${err.message}`);
-          } else {
-            logger.info(`[DEBUG JOB] Results file ${self.results_fn} exists with size ${res.size}`);
-          }
+        logger.info(`Job ID extracted: ${torque_id}`);
+        console.log(`Job ID extracted: ${torque_id}`);
+        self.torque_id = torque_id;
+        self.emit("job created", { torque_id: torque_id });
+      } catch (error) {
+        logger.error(`Error extracting job ID: ${error.message}`);
+        logger.error(`Raw output was: ${output}`);
+        console.log(`ERROR extracting job ID: ${error.message}, Raw output: ${output}`);
+      }
+    });
+
+    qsub.on("close", function(code) {
+      logger.info(`${scheduler} process closed with code: ${code}`);
+      console.log(`${scheduler} process closed with code: ${code}`);
+    
+      if (code !== 0) {
+        logger.error(`${scheduler} process exited with non-zero status: ${code}`);
+        console.log(`ERROR: ${scheduler} process exited with non-zero status: ${code}`);
+        // Still try to extract any error information
+        self.emit("script error", `${scheduler} process failed with exit code: ${code}`);
+      } else {
+        logger.info(`Starting status watcher for job: ${self.torque_id}`);
+        console.log(`Starting status watcher for job: ${self.torque_id}`);
+        self.status_watcher();
+      }
+    });
+  }
+
+  // Local job submission - used when submit_type is 'local'
+  submit_local(script, params, cwd) {
+    var self = this;
+  
+    logger.info("[LOCAL JOB] Starting local job submission");
+    logger.info(`[LOCAL JOB] Script: ${script}`);
+    logger.info(`[LOCAL JOB] Params: ${JSON.stringify(params)}`);
+    logger.info(`[LOCAL JOB] Working directory: ${cwd}`);
+  
+    // Log the full command that will be executed
+    const fullCommand = `${script} ${params.join(" ")}`;
+    logger.info(`[LOCAL JOB] FULL COMMAND: ${fullCommand}`);
+  
+    // Log environment variables that will be passed
+    if (params.length > 0) {
+      logger.info("[LOCAL JOB] Environment variables/arguments:");
+      params.forEach((param, index) => {
+        logger.info(`[LOCAL JOB]   [${index}]: ${param}`);
+      });
+    }
+  
+    try {
+    // For local execution, pass params as command line arguments
+      var proc = spawn(script, params, { cwd: cwd });
+    
+      // Store process reference for cancellation
+      self.local_process = proc;
+    
+      // Use a unique job identifier for local runs
+      // Wait for the process to be fully spawned before using pid
+      process.nextTick(() => {
+        self.torque_id = "local_" + Date.now() + "_" + (proc.pid || "nopid");
+        self.emit("job created", { torque_id: self.torque_id });
+      });
+    
+      proc.stderr.on("data", function(data) {
+        const output = data.toString("utf8");
+        logger.error(`[LOCAL JOB STDERR] ${output.trim()}`);
+        // Emit status updates for stderr (can indicate progress)
+        if (output.trim()) {
+          self.emit("status update", { msg: output.trim() });
+        }
+      });
+    
+      proc.stdout.on("data", function(data) {
+        const output = data.toString("utf8");
+        logger.info(`[LOCAL JOB STDOUT] ${output.trim()}`);
+        // Emit status updates for stdout
+        if (output.trim()) {
+          self.emit("status update", { msg: output.trim() });
+        }
+      });
+    
+      proc.on("error", function(error) {
+        logger.error(`[LOCAL JOB ERROR] Failed to spawn process: ${error.message}`);
+        logger.error(`[LOCAL JOB ERROR] Error details: ${JSON.stringify(error)}`);
+        self.emit("script error", "Local execution failed: " + error.message);
+      });
+    
+      proc.on("close", function(code) {
+        logger.info(`[LOCAL JOB] Process completed with exit code: ${code}`);
+        if (code === 0) {
+          logger.info("[DEBUG JOB] Local job completed successfully, emitting completed event");
+          self.emit(self.states.completed, "");
+        } else {
+          logger.error(`[LOCAL JOB] Job failed with exit code: ${code}`);
+          self.emit("script error", "Local job failed with exit code: " + code);
+        }
+      });
+    
+    } catch (error) {
+      logger.error(`[LOCAL JOB] Exception starting local job: ${error.message}`);
+      logger.error(`[LOCAL JOB] Exception details: ${JSON.stringify(error)}`);
+      self.emit("script error", "Failed to start local job: " + error.message);
+    }
+  }
+
+  // SLURM job submission with specific parameters
+  submit_slurm(script, cwd, slurm_params) {
+    var self = this;
+  
+    logger.info("SLURM job submission", script, slurm_params);
+  
+    var sbatch = spawn("sbatch", slurm_params, { cwd: cwd });
+  
+    sbatch.stderr.on("data", function(data) {
+      logger.info("SLURM stderr: " + data.toString("utf8"));
+    });
+  
+    sbatch.stdout.on("data", function(data) {
+      var job_id = get_slurm_id_from_data(data);
+      self.torque_id = job_id;
+      self.emit("job created", { torque_id: job_id });
+    });
+  
+    sbatch.on("close", function(code) {
+      self.status_watcher();
+    });
+  }
+
+  // Once the job has been scheduled, we need to watch the files that it
+  // sends updates to.
+  status_watcher() {
+    var self = this;
+  
+    // Don't create a job status watcher for local jobs
+    if (self.submit_type === "local") {
+      return;
+    }
+  
+    logger.info(`Starting job status watcher for job ID: ${self.torque_id}`);
+    var job_status = new JobStatus(self.torque_id);
+
+    self.metronome_id = job_status.watch(function(error, status_packet) {
+    // Log status updates for debugging
+      if (status_packet) {
+        logger.info(`Status update for job ${self.torque_id}: ${JSON.stringify(status_packet)}`);
+      }
+    
+      // Check if results file exists if there is an error
+      if (error) {
+        logger.warn(`Status error for job ${self.torque_id}: ${error}`);
+      
+        // If a results file was specified, check if it exists and has content
+        if (self.results_fn) {
+          fs.stat(self.results_fn, (err, res) => {
+            if (err) {
+              logger.warn(`[DEBUG JOB] Error checking results file ${self.results_fn}: ${err.message}`);
+            } else {
+              logger.info(`[DEBUG JOB] Results file ${self.results_fn} exists with size ${res.size}`);
+            }
           
+            self.error_count += 1;
+
+            if (!err && res.size > 0) {
+              logger.info(`[DEBUG JOB] Job ${self.torque_id} completed based on results file (size: ${res.size})`);
+              logger.info(`[DEBUG JOB] Emitting completed event for ${self.torque_id}`);
+              clearInterval(self.metronome_id);
+              self.emit(self.states.completed, "");
+              return;
+            }
+
+            if (self.error_count > self.QSTAT_ERROR_LIMIT) {
+              logger.error(`Job ${self.torque_id} exceeded error limit`);
+              clearInterval(self.metronome_id);
+              self.emit("script error", "");
+              return;
+            }
+          });
+        } else {
           self.error_count += 1;
-
-          if (!err && res.size > 0) {
-            logger.info(`[DEBUG JOB] Job ${self.torque_id} completed based on results file (size: ${res.size})`);
-            logger.info(`[DEBUG JOB] Emitting completed event for ${self.torque_id}`);
-            clearInterval(self.metronome_id);
-            self.emit(self.states.completed, "");
-            return;
-          }
-
+        
           if (self.error_count > self.QSTAT_ERROR_LIMIT) {
-            logger.error(`Job ${self.torque_id} exceeded error limit`);
+            logger.error(`Job ${self.torque_id} exceeded error limit with no results file`);
             clearInterval(self.metronome_id);
             self.emit("script error", "");
             return;
           }
-        });
-      } else {
-        self.error_count += 1;
-        
-        if (self.error_count > self.QSTAT_ERROR_LIMIT) {
-          logger.error(`Job ${self.torque_id} exceeded error limit with no results file`);
-          clearInterval(self.metronome_id);
-          self.emit("script error", "");
-          return;
         }
-      }
-    } else {
-      self.error_count = 0;
+      } else {
+        self.error_count = 0;
 
-      if (
-        status_packet.status == self.states.completed ||
+        if (
+          status_packet.status == self.states.completed ||
         status_packet.status == self.states.exiting
-      ) {
-        logger.info(`[DEBUG JOB] Job ${self.torque_id} completed with status: ${status_packet.status}`);
-        logger.info(`[DEBUG JOB] Emitting completed event for SLURM job ${self.torque_id}`);
-        clearInterval(self.metronome_id);
-        self.emit(self.states.completed, "");
-      } else if (status_packet.status == self.states.queued) {
-        logger.info(`Job ${self.torque_id} is queued`);
+        ) {
+          logger.info(`[DEBUG JOB] Job ${self.torque_id} completed with status: ${status_packet.status}`);
+          logger.info(`[DEBUG JOB] Emitting completed event for SLURM job ${self.torque_id}`);
+          clearInterval(self.metronome_id);
+          self.emit(self.states.completed, "");
+        } else if (status_packet.status == self.states.queued) {
+          logger.info(`Job ${self.torque_id} is queued`);
         
-        // Include more information in the job created event
-        const jobInfo = { 
-          torque_id: self.torque_id,
-          status: status_packet.status,
-          scheduler: self.submit_type === "qsub" ? "torque" : "slurm"
-        };
+          // Include more information in the job created event
+          const jobInfo = { 
+            torque_id: self.torque_id,
+            status: status_packet.status,
+            scheduler: self.submit_type === "qsub" ? "torque" : "slurm"
+          };
         
-        // Add any extra information from the status packet
-        if (status_packet.raw_status) {
-          jobInfo.raw_status = status_packet.raw_status;
+          // Add any extra information from the status packet
+          if (status_packet.raw_status) {
+            jobInfo.raw_status = status_packet.raw_status;
+          }
+        
+          if (status_packet.ctime) {
+            jobInfo.ctime = status_packet.ctime;
+          }
+        
+          self.emit("job created", jobInfo);
+        } else {
+          logger.info(`Job ${self.torque_id} status update: ${status_packet.status}`);
+        
+          // Ensure torque_id is included
+          status_packet.torque_id = self.torque_id;
+        
+          // Add scheduler type
+          status_packet.scheduler = self.submit_type === "qsub" ? "torque" : "slurm";
+        
+          // Emit the job metadata and status update events
+          self.emit("job metadata", status_packet);
+          self.emit("status update", status_packet);
         }
-        
-        if (status_packet.ctime) {
-          jobInfo.ctime = status_packet.ctime;
-        }
-        
-        self.emit("job created", jobInfo);
-      } else {
-        logger.info(`Job ${self.torque_id} status update: ${status_packet.status}`);
-        
-        // Ensure torque_id is included
-        status_packet.torque_id = self.torque_id;
-        
-        // Add scheduler type
-        status_packet.scheduler = self.submit_type === "qsub" ? "torque" : "slurm";
-        
-        // Emit the job metadata and status update events
-        self.emit("job metadata", status_packet);
-        self.emit("status update", status_packet);
       }
-    }
-  });
-};
+    });
+  }
+}
 
 exports.resubscribe = resubscribe;
 exports.cancel = cancel;


### PR DESCRIPTION
## Phase 4c — es-class-runners

Strictly behavior-preserving paradigm modernization: convert the two **leaf** runners that extend `EventEmitter` directly from `util.inherits` to ES class syntax.

### Changes
- `app/job.js` — `jobRunner`: `util.inherits(jobRunner, EventEmitter)` → `class jobRunner extends EventEmitter`. Constructor calls `super()` first; `submit`, `submit_local`, `submit_slurm`, `status_watcher` moved verbatim into class methods. Removed the now-unused `util` require.
- `app/hivtrace/hivtrace.js` — `HivTraceRunner`: `util.inherits(HivTraceRunner, EventEmitter)` → `class HivTraceRunner extends EventEmitter`. Constructor calls `super()` first; `close`, `log_publisher`, `status_watcher`, `submit`, `submit_slurm`, `submit_local` moved verbatim into class methods.

### Explicitly NOT touched (deferred to Phase 4d)
- `util.inherits(hivtrace, hyphyJob)` — the hyphyJob hierarchy.
- The `hyphyJob` base class shape and `lib/analysis-factory.js` generated-constructor inheritance (the 14-descriptor coordination hazard).
- `util` require kept in hivtrace.js (still used by `util.inherits(hivtrace, hyphyJob)` and `util.promisify`).

Closure/`self` semantics preserved — every `var self = this` inside the moved methods is unchanged, so nested closures still capture the correct `this`.

### Paradigm counts
| metric | before | after |
|---|---|---|
| `util.inherits` (app+lib) | 7 | 5 |
| ES classes (leaf runners) | 0 | 2 |

### Behavior-preservation evidence
- `npm run test:ci` — **125 passing**, 1 pending (unchanged from baseline)
- MCP (`mocha --exit test/mcp/mcp.test.js`) — **58 passing**
- golden (`mocha --exit test/golden/*.js`) — **30 passing**
- coverage-gaps (`test/coverage-gaps/*` — exercise jobRunner resubscribe/cancel/lifecycle + HivTraceRunner) — **16 passing**
- `npm run lint` — **0 errors** (31 pre-existing warnings unchanged)
- `node -c` clean on both files
- Runtime sanity: `new jobRunner(...)` `instanceof EventEmitter` && `instanceof jobRunner`; `emit`/`on` round-trip works; constructor state (`torque_id`, `QSTAT_ERROR_LIMIT`, `submit_type`, `states`) identical.

No SLURM jobs submitted; `squeue -u sweaver` empty.

Ref #410.