### PR TITLE
fix: dead SLURM scheduler check + load-smoke dependency guard (#410)

### DIFF
--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -529,8 +529,14 @@ hyphyJob.prototype.setTorqueParameters = function(torque_id) {
     self.torque_id = torque_id.toString();
   }
   
-  // Determine scheduler type
-  const isSlurm = config.submit_type === "sbatch";
+  // Determine scheduler type.
+  // NOTE: config.submit_type is one of "slurm" | "qsub" | "local" (see
+  // lib/config.js). This previously compared against "sbatch" — a value the
+  // enum never holds — so isSlurm was ALWAYS false and the SLURM log-path
+  // branch below was dead code: onError() then read the (nonexistent)
+  // torque-style log path instead of the real SLURM <type>_<id>_<jobid>.err
+  // files, dropping stderr from error reports. See #410 (2nd battle-test).
+  const isSlurm = config.submit_type === "slurm";
   self.scheduler = isSlurm ? "slurm" : "torque";
   
   // Set output file paths based on scheduler type

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "test": "npm run test:ci && npm run test:slurm",
-    "test:ci": "mocha -R spec --exit test/regression/leaks.js test/error-paths/validation.js test/validation/results.js test/mock/lifecycle.js test/golden/qsub-params.js test/golden/factory-parity.js test/routes/analysis-routes.js test/sanitize-names.test.js test/difFubar.test.js test/difFubar.integration.test.js test/fubar-redirection.test.js",
+    "test:ci": "mocha -R spec --exit test/load-smoke.js test/regression/leaks.js test/error-paths/validation.js test/validation/results.js test/mock/lifecycle.js test/golden/qsub-params.js test/golden/factory-parity.js test/routes/analysis-routes.js test/sanitize-names.test.js test/difFubar.test.js test/difFubar.integration.test.js test/fubar-redirection.test.js",
     "test:slurm": "npm run test:analyses && npm run test:slurm-unit && npm run test:integration",
     "test:analyses": "mocha -R spec --exit test/absrel/absrel.js test/busted/busted.js test/contrast-fel/contrast-fel.js test/fade/fade.js test/fubar/fubar.js test/gard/gard.js test/hivtrace/hivtrace.js test/meme/meme.js test/multihit/multihit.js test/prime/prime.js test/relax/relax.js test/slac/slac.js",
     "test:slurm-unit": "mocha -R spec --exit test/jobstatus.js test/jobqueue.js test/coverage-gaps/job-lifecycle.js test/coverage-gaps/hivtrace-checkjob.js",

--- a/test/load-smoke.js
+++ b/test/load-smoke.js
@@ -1,0 +1,62 @@
+/**
+ * Load-smoke test: statically verify every app/lib source module's require()
+ * targets resolve. Catches the class of bug where a dependency is removed from
+ * package.json but a module still requires it (which passes the unit suite only
+ * because the dev node_modules still has the stale package). See #410.
+ *
+ * This is a STATIC check (parses require strings, resolves package names) — it
+ * does NOT execute the modules (which would open redis/SLURM connections).
+ */
+var fs = require("fs");
+var path = require("path");
+var should = require("should"); // eslint-disable-line no-unused-vars
+
+var ROOT = path.join(__dirname, "..");
+
+function jsFiles(dir) {
+  var out = [];
+  fs.readdirSync(dir, { withFileTypes: true }).forEach(function (e) {
+    if (e.name === "node_modules" || e.name === "output" || e.name.startsWith(".")) return;
+    var full = path.join(dir, e.name);
+    if (e.isDirectory()) out = out.concat(jsFiles(full));
+    else if (e.name.endsWith(".js")) out.push(full);
+  });
+  return out;
+}
+
+// External package requires (not relative paths, not node builtins).
+var BUILTINS = new Set([
+  "fs", "path", "util", "crypto", "events", "child_process", "os", "stream",
+  "http", "https", "url", "querystring", "zlib", "assert", "net"
+]);
+
+describe("load-smoke: all source require() targets resolve", function () {
+  var files = jsFiles(path.join(ROOT, "app")).concat(jsFiles(path.join(ROOT, "lib")));
+  files.push(path.join(ROOT, "server.js"));
+
+  it("every external package required by app/lib/server.js is installed", function () {
+    var missing = [];
+    files.forEach(function (file) {
+      var src = fs.readFileSync(file, "utf8");
+      var re = /require\((['"])([^'"]+)\1\)/g;
+      var m;
+      while ((m = re.exec(src))) {
+        var mod = m[2];
+        if (mod.startsWith(".") || mod.startsWith("/")) continue; // relative
+        var pkg = mod.startsWith("@") ? mod.split("/").slice(0, 2).join("/") : mod.split("/")[0];
+        if (BUILTINS.has(pkg)) continue;
+        try {
+          // Resolve the FULL import (mod), not just the package name — packages
+          // with an "exports" map (e.g. @modelcontextprotocol/sdk) expose only
+          // subpaths, so resolving the bare name would false-alarm. A genuinely
+          // missing package still fails here (the whole require can't resolve).
+          require.resolve(mod, { paths: [ROOT] });
+        } catch (e) {
+          missing.push(mod + "  (required by " + path.relative(ROOT, file) + ")");
+        }
+      }
+    });
+    var unique = Array.from(new Set(missing));
+    unique.should.eql([], "unresolvable package requires:\n  " + unique.join("\n  "));
+  });
+});


### PR DESCRIPTION
Two fixes from the second battle-test.

### 1. 🟠 Dead SLURM-scheduler check (real bug)
`app/hyphyjob.js:533` compared `config.submit_type === "sbatch"` — but the config enum is `slurm | qsub | local` (`lib/config.js`), so `"sbatch"` is a value it can **never** hold. `isSlurm` was therefore **always false**, and the SLURM log-path branch was dead code. Effect: on SLURM, `onError()` read the job's stderr from the torque-style path (`<script>.sh.e<id>`, which doesn't exist under SLURM), so **error reports silently dropped the job's stderr**.

Fixed to `=== "slurm"`. **Verified** the resulting SLURM log path (`<type>_<id>_<jobid>.err`) matches the factory's actual sbatch `--error` filename **byte-for-byte** — so this now reads the real log files.

### 2. 🛡️ Load-smoke dependency guard (prevents a whole bug class)
`test/load-smoke.js` statically resolves every external `require()` in `app/lib/server.js`. It catches the class of bug where a dependency is **removed from package.json but a module still requires it** — which passes the unit suite only because the dev `node_modules` is stale (a real clean-deploy failure). **Mutation-proven** (a fake require fails it). Wired into `test:ci`.

### On the battle-test's "q dependency" finding — it was a FALSE POSITIVE
The audit flagged `hyphyjob.js`/`hivtrace.js` as still requiring `q` (removed from package.json in Phase 1) → a clean-deploy crash. **I verified this is not real**: no `app/lib` file actually requires `q` anymore — both were already migrated to `util.promisify(fs.readFile)` + native `Promise.allSettled`; the two `Q.` references are just comments. The agent read pre-migration line numbers. The load-smoke guard confirms it (passes) and would catch a genuine future recurrence. (I initially took the finding at face value and ran a clean-install test that showed `q` missing — but failed to check that nothing *needs* it. Caught my own error before "fixing" a non-bug.)

### Verification
test:ci **126** (was 125 + load-smoke), MCP **58**, coverage-gaps **16**, lint **0 errors**. Diff is just hyphyjob.js (1 line + comment) + the new test + package.json.