### PR TITLE
fix: Registry/active_jobs leaks in gard/difFubar onComplete (#410 BT4)

### DIFF
--- a/app/difFubar/difFubar.js
+++ b/app/difFubar/difFubar.js
@@ -3,7 +3,8 @@ const config = require("../../lib/config"),
   logger = require("../../lib/logger.js").logger,
   util = require("util"),
   fs = require("fs"),
-  path = require("path");
+  path = require("path"),
+  jobRegistry = require("../../lib/jobregistry.js");
 
 // Shared redis v5 client (promise-native, camelCased commands). Reused across
 // onComplete calls instead of creating (and leaking) a client per job
@@ -278,14 +279,31 @@ difFubar.prototype.onComplete = function() {
           const str_redis_packet = JSON.stringify(redis_packet);
           
           self.log("complete", "success (direct file transmission)");
-          
+
           // Reuse the shared redis client (GH #400). redis v5 hSet takes a
           // field/value object for multiple fields (the old variadic
           // field,value,field,value form silently drops extra pairs).
-          client.hSet(self.id, { results: str_redis_packet, status: "completed" });
-          client.publish(self.id, str_redis_packet);
-          client.lRem("active_jobs", 1, self.id);
-          
+          // Batch the terminal writes under Promise.all().catch (not
+          // fire-and-forget): a rejected redis write would otherwise leave the
+          // job never marked completed / never dequeued — a silent zombie.
+          // (Mirrors hyphyjob.js onComplete; the small-results branch below
+          // already delegates to hyphyJob.prototype.onComplete which does this.)
+          Promise.all([
+            client.hSet(self.id, { results: str_redis_packet, status: "completed" }),
+            client.publish(self.id, str_redis_packet),
+            client.lRem("active_jobs", 1, self.id)
+          ]).catch(function(werr) {
+            logger.error(
+              "[REDIS] Terminal completion write failed for difFubar job " +
+                self.id + " - job may be left as a zombie: " + werr.message
+            );
+          });
+
+          // Match the parent completion contract: drop the finished job from
+          // the live registry (the small-results path does this via the parent
+          // onComplete; this large-file path must do it explicitly).
+          jobRegistry.unregister(self.id);
+
           logger.info(`[DEBUG] difFUBAR ${self.id}: Sent results via direct socket + Redis completion`);
         });
       });

--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -6,7 +6,8 @@ const config = require("../../lib/config"),
   datatypes = require("../type").type,
   code = require("../code").code,
   path = require("path"),
-  utilities = require("../../lib/utilities");
+  utilities = require("../../lib/utilities"),
+  jobRegistry = require("../../lib/jobregistry.js");
 
 // Use the shared redis v5 client (promise-native, camelCased commands).
 const { client } = require("../../lib/redis-client");
@@ -345,14 +346,30 @@ gard.prototype.onComplete = function() {
           // Log that the job has been completed
           self.log("complete", "success");
 
-          // Store packet in redis and publish to channel
-          client.hSet(self.id, "results", str_redis_packet);
-          client.hSet(self.id, "status", "completed");
-          client.publish(self.id, str_redis_packet);
+          // Store packet in redis and publish to channel. Terminal writes are
+          // batched under Promise.all().catch (not fire-and-forget): a rejected
+          // redis@5 write would otherwise leave the job never marked completed
+          // and never dequeued — a silent zombie. Mirrors hyphyjob.js onComplete.
+          Promise.all([
+            client.hSet(self.id, {
+              results: str_redis_packet,
+              status: "completed"
+            }),
+            client.publish(self.id, str_redis_packet),
+            // Remove id from active_job queue
+            client.lRem("active_jobs", 1, self.id)
+          ]).catch(function(werr) {
+            logger.error(
+              "[REDIS] Terminal completion write failed for gard job " +
+                self.id + " - job may be left as a zombie: " + werr.message
+            );
+          });
 
-          // Remove id from active_job queue
-          client.lRem("active_jobs", 1, self.id);
-        }    
+          // Match the parent completion contract (hyphyjob.js onComplete):
+          // drop the finished job from the live registry so a later cancelAll
+          // broadcast can't act on a completed job.
+          jobRegistry.unregister(self.id);
+        }
       });
     }
   });

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -235,11 +235,18 @@ hyphyJob.prototype.spawn = function() {
 hyphyJob.prototype.onJobCreated = function(torque_id) {
   const self = this;
 
-  self.push_active_job = function() {
-    client.rPush("active_jobs", self.id);
-  };
-
-  self.push_job_once = once(self.push_active_job);
+  // onJobCreated fires on EVERY "job created" emission, and the status watcher
+  // re-emits "job created" on every queued poll tick (job.js status_watcher).
+  // Build the once()-guarded active_jobs push exactly ONCE per job instance —
+  // rebuilding it here each call gave a fresh guard every tick, so a job queued
+  // for N ticks pushed self.id into active_jobs N times (only one removed by the
+  // terminal lRem count=1), leaking N-1 phantom entries until restart.
+  if (!self.push_job_once) {
+    self.push_active_job = function() {
+      client.rPush("active_jobs", self.id);
+    };
+    self.push_job_once = once(self.push_active_job);
+  }
   self.setTorqueParameters(torque_id);
 
   // Enhanced job info for client

--- a/test/golden/qsub-params.js
+++ b/test/golden/qsub-params.js
@@ -69,9 +69,27 @@ function mkParams() {
 
 // Replace per-run volatile substrings with stable placeholders so the snapshot
 // is deterministic: the "check-<timestamp>" id and absolute repo paths.
+//
+// julia_path / julia_project are host-specific config values that difFubar
+// embeds verbatim into its export string. The committed snapshot pins the
+// portable CI-fixture values; normalize whatever THIS host's config.json holds
+// to the same tokens so the golden passes regardless of the local julia
+// install (otherwise a dev config with an absolute juliaup path drifts).
+var JULIA_PATH = config.julia_path || "/usr/local/bin/julia";
+var JULIA_PROJECT = config.julia_project || "../../.julia_env";
 function normalize(arr) {
   return (arr || []).map(function (entry) {
-    return String(entry)
+    var s = String(entry);
+    // Pin config-derived julia paths to the portable snapshot tokens FIRST,
+    // before the ABS_ROOT/HOME substitutions could rewrite an absolute julia
+    // path into <HOME>/... and stop it matching config.julia_path. difFubar
+    // embeds julia both as a bare positional element (local exec array) and as
+    // a "julia_path=<v>" token (slurm --export), so handle both forms.
+    if (s === JULIA_PATH) return "/usr/local/bin/julia";
+    if (s === JULIA_PROJECT) return "../../.julia_env";
+    s = s.split("julia_path=" + JULIA_PATH).join("julia_path=/usr/local/bin/julia")
+      .split("julia_project=" + JULIA_PROJECT).join("julia_project=../../.julia_env");
+    return s
       .split(ABS_ROOT).join("<ROOT>")
       .split(HOME).join("<HOME>")
       .replace(/check-\d+/g, "check-<TS>");


### PR DESCRIPTION
Battle-test #4 of the v4 branch (23-agent adversarial workflow, anti-stale discipline). Tests were green (test:ci 126/0, test:mcp 58/0), but it found **3 confirmed-real correctness bugs** — the same crash-guard / registry-cleanup class Phase 4a + #442 applied to hyphyjob and hivtrace, but **missed in the gard/difFubar `onComplete` overrides**. All independently re-verified against current code.

## 🔴 HIGH — `active_jobs` duplicate-entry leak (`app/hyphyjob.js`)
`onJobCreated` rebuilt `push_job_once = once(push_active_job)` on **every** call, so the `once()` guard was fresh each time. The status watcher re-emits `"job created"` on every queued poll tick (`job.js` `status_watcher`), so a job queued N ticks pushed `self.id` into `active_jobs` **N times**; the terminal `lRem(count=1)` removes only one → **N-1 phantom entries leak until restart**, inflating every `lLen`-based queue-depth metric. Fix: build the guard once per instance. *Verified: 5 `onJobCreated` calls now push once, not five.*

## 🟠 MED — gard/difFubar leak completed jobs in `jobRegistry`
Both override `onComplete` and never called `jobRegistry.unregister(self.id)` (parent contract in `hyphyjob.js`). During the window a `cancelAll` broadcast acts on a completed job → stray `jobDelete` on a dead torque_id + spurious client error. Added `unregister` to gard's success path and difFubar's >5MB direct-transmission branch (the small-file branch already delegates to the parent).

## 🟠 MED — gard/difFubar terminal redis writes fire-and-forget
Bare `hSet`/`publish`/`lRem` with no `.catch`; a rejected redis@5 write → silent zombie (never marked completed / never dequeued). Batched under `Promise.all([...]).catch` with a job-scoped error log, mirroring `hyphyjob.js` onComplete.

## Also: golden-snapshot portability
`test/golden/qsub-params.js` reads live `lib/config`, so difFubar's `julia_path`/`julia_project` drifted from the snapshot on any host with a non-default julia install — `test:ci` would fail there. `normalize()` now pins the config-derived julia values to the portable tokens (both the bare local-exec array element and the slurm `julia_path=` token). Verified with a dev config AND the CI fixture.

## Not in this PR (v4.1 roadmap, documented on #410)
The workflow also produced a ranked old-paradigm modernization plan (util.inherits→class extends across hyphyJob + difFubar/gard/hivtrace, callback→promise, MCP enum de-dup) and nits (server.js stale version, dead listener, dead config keys). Non-blocking — separate v4.1 pass.

**Verified:** test:ci 126/0, test:mcp 58/0, coverage-gaps 16/0; golden portable both ways.