### PR TITLE
fix: hivtrace onJobCreated active_jobs leak (#410 BT5)

### DIFF
--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -422,11 +422,18 @@ hivtrace.prototype.onComplete = function() {
 hivtrace.prototype.onJobCreated = function(torque_id) {
   const self = this;
 
-  self.push_active_job = function(id) {
-    client.rPush("active_jobs", self.id);
-  };
-
-  self.push_job_once = once(self.push_active_job);
+  // Build the once()-guarded active_jobs push exactly ONCE per job instance.
+  // onJobCreated is bound to the runner's "job created" event, which the
+  // scheduler stdout 'data' handlers (and the pub/sub re-emit) can fire more
+  // than once; rebuilding the guard each call gave a fresh once() every time,
+  // leaking duplicate active_jobs entries. Same fix as hyphyjob.js onJobCreated
+  // (this override doesn't inherit the parent's guard — util.inherits).
+  if (!self.push_job_once) {
+    self.push_active_job = function() {
+      client.rPush("active_jobs", self.id);
+    };
+    self.push_job_once = once(self.push_active_job);
+  }
   self.setTorqueParameters(torque_id);
   const redis_packet = torque_id;
   redis_packet.type = "job created";


### PR DESCRIPTION
Battle-test #5 (confirmation run after #444). Tests were green (test:ci 126/0, test:mcp 58/0, coverage-gaps 16/0), but the regression lens caught **the same `active_jobs` duplicate-entry leak that #444 fixed in the `hyphyJob` base — in hivtrace's OWN `onJobCreated` override**. Because hivtrace uses `util.inherits` (not `class extends`), it never inherited the parent's fix.

`hivtrace.prototype.onJobCreated` rebuilt `push_job_once = once(push_active_job)` on every call (no guard). The event fires from the qsub/sbatch stdout `'data'` handlers (can fire >once per submission) and the pub/sub re-emit, while the terminal path removes only one entry (`lRem count=1`) → N emissions leak N-1 phantom `active_jobs` entries until restart.

**Fix:** wrap the assignment in `if (!self.push_job_once) { ... }`, mirroring `hyphyjob.js`. *Verified: 5 `onJobCreated` calls now push once, not five.*

hivtrace is the **only** other `onJobCreated` override (grep-confirmed), so the once() leak class is now fully swept across the base + all overrides. Verified its `onStatusUpdate` (non-terminal) already has `.catch` + guarded parse.

**Root-cause note for v4.1:** this is the 2nd time a `util.inherits` override silently missed a base fix (BT4: gard/difFubar onComplete; BT5: hivtrace onJobCreated). Converting these to `class extends hyphyJob` (the ranked v4.1 arch item) would structurally prevent this whole class of missed-override bug.

**Verified:** test:ci 126/0, test:mcp 58/0, coverage-gaps 16/0.