### PR TITLE
refactor: ES class inheritance + shared completion helper (v4.1, #410)

### DIFF
--- a/app/difFubar/difFubar.js
+++ b/app/difFubar/difFubar.js
@@ -1,97 +1,97 @@
 const config = require("../../lib/config"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
   logger = require("../../lib/logger.js").logger,
-  util = require("util"),
   fs = require("fs"),
-  path = require("path"),
-  jobRegistry = require("../../lib/jobregistry.js");
+  path = require("path");
 
 // Shared redis v5 client (promise-native, camelCased commands). Reused across
 // onComplete calls instead of creating (and leaking) a client per job
 // (GH #400).
 const { client } = require("../../lib/redis-client");
 
-const difFubar = function(socket, stream, params) {
-  const self = this;
-  self.socket = socket;
-  self.stream = stream;
-  self.params = params;
+class difFubar extends hyphyJob {
+  constructor(socket, stream, params) {
+    super();
+    const self = this;
+    self.socket = socket;
+    self.stream = stream;
+    self.params = params;
 
-  // object specific attributes
-  self.type = "difFubar";
-  self.qsub_script_name = "difFubar.sh";
-  self.qsub_script = __dirname + "/" + self.qsub_script_name;
+    // object specific attributes
+    self.type = "difFubar";
+    self.qsub_script_name = "difFubar.sh";
+    self.qsub_script = __dirname + "/" + self.qsub_script_name;
 
-  // parameter attributes
-  self.msaid = self.params.msa && self.params.msa[0] && self.params.msa[0]._id;
-  self.id = self.params.analysis._id;
-  self.nj = self.params.msa[0].nj;
+    // parameter attributes
+    self.msaid = self.params.msa && self.params.msa[0] && self.params.msa[0]._id;
+    self.id = self.params.analysis._id;
+    self.nj = self.params.msa[0].nj;
   
-  // Use tagged tree if available, otherwise fall back to neighbor-joining tree
-  if (self.params.analysis.tagged_nwk_tree) {
-    self.nwk_tree = self.params.analysis.tagged_nwk_tree;
-    self.treemode = "user";
-  } else {
-    self.nwk_tree = self.nj;
-    self.treemode = "nj";
-  }
-
-  // parameter-derived attributes
-  self.fn = __dirname + "/output/" + self.id;
-  self.output_dir = path.dirname(self.fn);
-  self.results_short_fn = self.fn + ".difFubar";
-  self.results_fn = self.fn + ".difFubar.json";
-  self.progress_fn = self.fn + ".difFubar.progress";
-  self.tree_fn = self.fn + ".tre";
-
-  // difFUBAR specific options
-  self.number_of_grid_points = self.params.analysis.number_of_grid_points;
-  self.concentration_of_dirichlet_prior =
-    self.params.analysis.concentration_of_dirichlet_prior;
-  self.mcmc_iterations = self.params.analysis.mcmc_iterations;
-  self.burnin_samples = self.params.analysis.burnin_samples;
-  self.pos_threshold = self.params.analysis.pos_threshold;
-
-  // Configure parameters based on execution type
-  if (config.submit_type === "local") {
-    // For local execution, pass arguments directly to the script
-    self.qsub_params = [
-      self.qsub_script,
-      self.fn,
-      self.tree_fn,
-      self.results_short_fn,
-      self.progress_fn,
-      self.pos_threshold,
-      self.mcmc_iterations,
-      self.burnin_samples,
-      self.concentration_of_dirichlet_prior,
-      config.julia_path,
-      config.julia_project
-    ];
-  } else if (config.submit_type === "slurm") {
-    // Convert walltime from PBS format to SLURM format
-    let slurmTime = "24:00:00"; // Default 24 hours
-    if (config.difFubar_walltime) {
-      const parts = config.difFubar_walltime.split(":");
-      if (parts.length === 4) {
-        // Convert D:HH:MM:SS to SLURM format
-        const days = parseInt(parts[0]);
-        const hours = parseInt(parts[1]) + (days * 24);
-        slurmTime = `${hours}:${parts[2]}:${parts[3]}`;
-      } else if (parts.length === 3) {
-        // HH:MM:SS format, already compatible with SLURM
-        slurmTime = config.difFubar_walltime;
-      }
+    // Use tagged tree if available, otherwise fall back to neighbor-joining tree
+    if (self.params.analysis.tagged_nwk_tree) {
+      self.nwk_tree = self.params.analysis.tagged_nwk_tree;
+      self.treemode = "user";
+    } else {
+      self.nwk_tree = self.nj;
+      self.treemode = "nj";
     }
 
-    self.qsub_params = [
-      `--ntasks=${config.difFubar_procs || "8"}`,
-      "--cpus-per-task=1",
-      `--time=${slurmTime}`,
-      `--partition=${config.slurm_partition || "datamonkey"}`,
-      `--nodes=${config.difFubar_nodes || "1"}`,
-      `--mem=${config.difFubar_memory || "32GB"}`,
-      "--export=ALL,slurm_mpi_type=" + 
+    // parameter-derived attributes
+    self.fn = __dirname + "/output/" + self.id;
+    self.output_dir = path.dirname(self.fn);
+    self.results_short_fn = self.fn + ".difFubar";
+    self.results_fn = self.fn + ".difFubar.json";
+    self.progress_fn = self.fn + ".difFubar.progress";
+    self.tree_fn = self.fn + ".tre";
+
+    // difFUBAR specific options
+    self.number_of_grid_points = self.params.analysis.number_of_grid_points;
+    self.concentration_of_dirichlet_prior =
+    self.params.analysis.concentration_of_dirichlet_prior;
+    self.mcmc_iterations = self.params.analysis.mcmc_iterations;
+    self.burnin_samples = self.params.analysis.burnin_samples;
+    self.pos_threshold = self.params.analysis.pos_threshold;
+
+    // Configure parameters based on execution type
+    if (config.submit_type === "local") {
+    // For local execution, pass arguments directly to the script
+      self.qsub_params = [
+        self.qsub_script,
+        self.fn,
+        self.tree_fn,
+        self.results_short_fn,
+        self.progress_fn,
+        self.pos_threshold,
+        self.mcmc_iterations,
+        self.burnin_samples,
+        self.concentration_of_dirichlet_prior,
+        config.julia_path,
+        config.julia_project
+      ];
+    } else if (config.submit_type === "slurm") {
+    // Convert walltime from PBS format to SLURM format
+      let slurmTime = "24:00:00"; // Default 24 hours
+      if (config.difFubar_walltime) {
+        const parts = config.difFubar_walltime.split(":");
+        if (parts.length === 4) {
+        // Convert D:HH:MM:SS to SLURM format
+          const days = parseInt(parts[0]);
+          const hours = parseInt(parts[1]) + (days * 24);
+          slurmTime = `${hours}:${parts[2]}:${parts[3]}`;
+        } else if (parts.length === 3) {
+        // HH:MM:SS format, already compatible with SLURM
+          slurmTime = config.difFubar_walltime;
+        }
+      }
+
+      self.qsub_params = [
+        `--ntasks=${config.difFubar_procs || "8"}`,
+        "--cpus-per-task=1",
+        `--time=${slurmTime}`,
+        `--partition=${config.slurm_partition || "datamonkey"}`,
+        `--nodes=${config.difFubar_nodes || "1"}`,
+        `--mem=${config.difFubar_memory || "32GB"}`,
+        "--export=ALL,slurm_mpi_type=" + 
       (config.slurm_mpi_type || "pmix") + 
       "," +
       "fn=" +
@@ -124,22 +124,22 @@ const difFubar = function(socket, stream, params) {
       (config.julia_path || "/usr/local/bin/julia") +
       ",julia_project=" +
       (config.julia_project || "../../.julia_env"),
-      `--output=${self.output_dir}/difFubar_${self.id}_%j.out`,
-      `--error=${self.output_dir}/difFubar_${self.id}_%j.err`,
-      self.qsub_script
-    ];
-  } else {
+        `--output=${self.output_dir}/difFubar_${self.id}_%j.out`,
+        `--error=${self.output_dir}/difFubar_${self.id}_%j.err`,
+        self.qsub_script
+      ];
+    } else {
     // For cluster execution (PBS/Torque qsub)
-    self.qsub_params = [
-      "-l walltime=" + 
+      self.qsub_params = [
+        "-l walltime=" + 
       config.difFubar_walltime + 
       ",nodes=" + config.difFubar_nodes + ":ppn=" + 
       config.difFubar_procs + 
       ",mem=" + config.difFubar_memory,
-      "-q",
-      config.qsub_queue,
-      "-v",
-      "fn=" +
+        "-q",
+        config.qsub_queue,
+        "-v",
+        "fn=" +
         self.fn +
         ",tree_fn=" +
         self.tree_fn +
@@ -169,35 +169,36 @@ const difFubar = function(socket, stream, params) {
         config.julia_path +
         ",julia_project=" +
         config.julia_project,
-      "-o",
-      self.output_dir,
-      "-e",
-      self.output_dir,
-      self.qsub_script
-    ];
-  }
-
-  // Write tree to a file
-  fs.writeFile(self.tree_fn, self.nwk_tree, function(err) {
-    if (err) {
-      logger.error(`difFUBAR ${self.id}: Error writing tree file: ${err.message}`);
-      self.socket.emit("script error", {
-        error: "Failed to write tree file: " + err.message
-      });
-      return;
+        "-o",
+        self.output_dir,
+        "-e",
+        self.output_dir,
+        self.qsub_script
+      ];
     }
-  });
 
-  // Ensure the progress file exists
-  fs.openSync(self.progress_fn, "w");
+    // Write tree to a file
+    fs.writeFile(self.tree_fn, self.nwk_tree, function(err) {
+      if (err) {
+        logger.error(`difFUBAR ${self.id}: Error writing tree file: ${err.message}`);
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message
+        });
+        return;
+      }
+    });
+
+    // Ensure the progress file exists
+    fs.openSync(self.progress_fn, "w");
   
-  // Add debug logging for job lifecycle
-  logger.info(`[DEBUG] difFUBAR ${self.id}: Constructor completed, calling init()`);
-  logger.info(`[DEBUG] difFUBAR ${self.id}: Results file will be: ${self.results_fn}`);
-  logger.info(`[DEBUG] difFUBAR ${self.id}: Progress file: ${self.progress_fn}`);
+    // Add debug logging for job lifecycle
+    logger.info(`[DEBUG] difFUBAR ${self.id}: Constructor completed, calling init()`);
+    logger.info(`[DEBUG] difFUBAR ${self.id}: Results file will be: ${self.results_fn}`);
+    logger.info(`[DEBUG] difFUBAR ${self.id}: Progress file: ${self.progress_fn}`);
   
-  self.init();
-};
+    self.init();
+  }
+}
 
 difFubar.prototype.sendPlotFiles = function(cb) {
   const self = this;
@@ -280,29 +281,14 @@ difFubar.prototype.onComplete = function() {
           
           self.log("complete", "success (direct file transmission)");
 
-          // Reuse the shared redis client (GH #400). redis v5 hSet takes a
-          // field/value object for multiple fields (the old variadic
-          // field,value,field,value form silently drops extra pairs).
-          // Batch the terminal writes under Promise.all().catch (not
-          // fire-and-forget): a rejected redis write would otherwise leave the
-          // job never marked completed / never dequeued — a silent zombie.
-          // (Mirrors hyphyjob.js onComplete; the small-results branch below
-          // already delegates to hyphyJob.prototype.onComplete which does this.)
-          Promise.all([
-            client.hSet(self.id, { results: str_redis_packet, status: "completed" }),
-            client.publish(self.id, str_redis_packet),
-            client.lRem("active_jobs", 1, self.id)
-          ]).catch(function(werr) {
-            logger.error(
-              "[REDIS] Terminal completion write failed for difFubar job " +
-                self.id + " - job may be left as a zombie: " + werr.message
-            );
-          });
-
-          // Match the parent completion contract: drop the finished job from
-          // the live registry (the small-results path does this via the parent
-          // onComplete; this large-file path must do it explicitly).
-          jobRegistry.unregister(self.id);
+          // Terminal writes + dequeue + unregister via the shared base helper
+          // (guarded Promise.all().catch; single source of truth with
+          // hyphyjob.js onComplete). The small-results branch below reaches the
+          // same helper through hyphyJob.prototype.onComplete.
+          self.finalizeCompletion(
+            { results: str_redis_packet, status: "completed" },
+            str_redis_packet
+          );
 
           logger.info(`[DEBUG] difFUBAR ${self.id}: Sent results via direct socket + Redis completion`);
         });
@@ -322,5 +308,4 @@ difFubar.prototype.onComplete = function() {
   });
 };
 
-util.inherits(difFubar, hyphyJob);
 exports.difFubar = difFubar;

--- a/app/gard/gard.js
+++ b/app/gard/gard.js
@@ -1,182 +1,182 @@
 const config = require("../../lib/config"),
   hyphyJob = require("../hyphyjob.js").hyphyJob,
-  util = require("util"),
   logger = require("../../lib/logger").logger,
   fs = require("fs"),
   datatypes = require("../type").type,
   code = require("../code").code,
   path = require("path"),
-  utilities = require("../../lib/utilities"),
-  jobRegistry = require("../../lib/jobregistry.js");
+  utilities = require("../../lib/utilities");
 
 // Use the shared redis v5 client (promise-native, camelCased commands).
 const { client } = require("../../lib/redis-client");
 
-const gard = function(socket, stream, params) {
-  const self = this;
-  self.socket = socket;
-  self.stream = stream;
-  self.params = params;
+class gard extends hyphyJob {
+  constructor(socket, stream, params) {
+    super();
+    const self = this;
+    self.socket = socket;
+    self.stream = stream;
+    self.params = params;
   
-  // Check if this is a check-only operation
-  const isCheckOnly = params.checkOnly || false;
+    // Check if this is a check-only operation
+    const isCheckOnly = params.checkOnly || false;
   
-  logger.info("GARD constructor called with:", {
-    stream_type: typeof stream,
-    stream_length: stream ? stream.length : 0,
-    stream_content: stream ? (stream.length > 100 ? stream.substring(0, 100) + "..." : stream) : "null",
-    params_keys: Object.keys(params),
-    params_full: JSON.stringify(params),
-    checkOnly: isCheckOnly
-  });
+    logger.info("GARD constructor called with:", {
+      stream_type: typeof stream,
+      stream_length: stream ? stream.length : 0,
+      stream_content: stream ? (stream.length > 100 ? stream.substring(0, 100) + "..." : stream) : "null",
+      params_keys: Object.keys(params),
+      params_full: JSON.stringify(params),
+      checkOnly: isCheckOnly
+    });
 
-  // object specific attributes
-  self.type = "gard";
-  self.qsub_script_name = "gard.sh";
-  self.qsub_script = __dirname + "/" + self.qsub_script_name;
+    // object specific attributes
+    self.type = "gard";
+    self.qsub_script_name = "gard.sh";
+    self.qsub_script = __dirname + "/" + self.qsub_script_name;
 
-  const variation_map = { none: "None", general_discrete: "GDD", beta_gamma: "Gamma" };
+    const variation_map = { none: "None", general_discrete: "GDD", beta_gamma: "Gamma" };
 
-  // For check operations, we only need minimal initialization
-  if (isCheckOnly) {
+    // For check operations, we only need minimal initialization
+    if (isCheckOnly) {
     // Set defaults for required fields with complete parameter coverage
-    self.genetic_code = params.genetic_code || "Universal";
-    self.site_to_site_variation = params.site_to_site_variation || "none";
-    self.rate_variation = variation_map[self.site_to_site_variation] || "None";
-    self.rate_classes = parseInt(params.rate_classes || params.classes || 2);
-    self.run_mode = params.run_mode === "1" || params.run_mode === "Faster" ? "Faster" : "Normal";
-    self.datatype = params.datatype || "codon";
-    self.max_breakpoints = parseInt(params.max_breakpoints || 10000);
-    self.model = params.model || "JTT";
-    self.id = "check-" + Date.now();
-    self.msaid = "check";
-    self.nwk_tree = params.nwk_tree || params.tree || "";
-    self.fn = __dirname + "/output/" + self.id;
-    self.output_dir = path.dirname(self.fn);
-    self.status_fn = self.fn + ".status";
-    self.results_fn = self.fn + ".GARD.json";
-    self.progress_fn = self.fn + ".GARD.progress";
-    self.tree_fn = self.fn + ".tre";
-    self.finalout_results_fn = self.fn + ".best-gard";
-  } else {
+      self.genetic_code = params.genetic_code || "Universal";
+      self.site_to_site_variation = params.site_to_site_variation || "none";
+      self.rate_variation = variation_map[self.site_to_site_variation] || "None";
+      self.rate_classes = parseInt(params.rate_classes || params.classes || 2);
+      self.run_mode = params.run_mode === "1" || params.run_mode === "Faster" ? "Faster" : "Normal";
+      self.datatype = params.datatype || "codon";
+      self.max_breakpoints = parseInt(params.max_breakpoints || 10000);
+      self.model = params.model || "JTT";
+      self.id = "check-" + Date.now();
+      self.msaid = "check";
+      self.nwk_tree = params.nwk_tree || params.tree || "";
+      self.fn = __dirname + "/output/" + self.id;
+      self.output_dir = path.dirname(self.fn);
+      self.status_fn = self.fn + ".status";
+      self.results_fn = self.fn + ".GARD.json";
+      self.progress_fn = self.fn + ".GARD.progress";
+      self.tree_fn = self.fn + ".tre";
+      self.finalout_results_fn = self.fn + ".best-gard";
+    } else {
     // Normal operation with full parameters
-    const analysisParams = self.params.analysis || self.params;
+      const analysisParams = self.params.analysis || self.params;
     
-    // parameter attributes with fallbacks
-    if (self.params.msa) {
-      self.msaid = self.params.msa._id;
-      self.genetic_code = self.params.msa[0] ? (code[self.params.msa[0].gencodeid + 1] || "Universal") : "Universal";
-      self.nwk_tree = self.params.msa[0] ? (self.params.msa[0].usertree || self.params.msa[0].nj) : "";
-      // Use analysis.tagged_nwk_tree if available (for unified format)
-      if (self.params.analysis && self.params.analysis.tagged_nwk_tree) {
-        self.nwk_tree = self.params.analysis.tagged_nwk_tree;
+      // parameter attributes with fallbacks
+      if (self.params.msa) {
+        self.msaid = self.params.msa._id;
+        self.genetic_code = self.params.msa[0] ? (code[self.params.msa[0].gencodeid + 1] || "Universal") : "Universal";
+        self.nwk_tree = self.params.msa[0] ? (self.params.msa[0].usertree || self.params.msa[0].nj) : "";
+        // Use analysis.tagged_nwk_tree if available (for unified format)
+        if (self.params.analysis && self.params.analysis.tagged_nwk_tree) {
+          self.nwk_tree = self.params.analysis.tagged_nwk_tree;
+        }
+      } else {
+        self.msaid = self.params.msaid || "unknown";
+        self.genetic_code = self.params.genetic_code || "Universal";
+        self.nwk_tree = self.params.nwk_tree || self.params.tree || "";
       }
-    } else {
-      self.msaid = self.params.msaid || "unknown";
-      self.genetic_code = self.params.genetic_code || "Universal";
-      self.nwk_tree = self.params.nwk_tree || self.params.tree || "";
-    }
     
-    if (self.params.analysis) {
-      self.id = self.params.analysis._id || (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
-      // Use FEL-style tree assignment for unified format compatibility
-      self.nwk_tree = self.params.analysis.tagged_nwk_tree || self.params.nwk_tree || self.params.tree || "";
-      // GARD specific attributes with complete parameter coverage
-      self.site_to_site_variation = analysisParams.site_to_site_variation || "none";
-      self.rate_variation = variation_map[self.site_to_site_variation] || "None";
-      self.rate_classes = parseInt(analysisParams.rate_classes || analysisParams.classes || 2);
-      self.run_mode = analysisParams.run_mode == "1" || analysisParams.run_mode == "Faster" ? "Faster" : "Normal";
-      self.datatype = analysisParams.datatype || "0";
-      self.datatype = datatypes[self.datatype] || "codon";
-      self.max_breakpoints = parseInt(analysisParams.max_breakpoints || 10000);
-      self.model = analysisParams.model || "JTT";
-    } else {
-      self.id = (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
-      // GARD specific attributes with complete parameter coverage
-      self.site_to_site_variation = self.params.site_to_site_variation || "none";
-      self.rate_variation = variation_map[self.site_to_site_variation] || "None";
-      self.rate_classes = parseInt(self.params.rate_classes || self.params.classes || 2);
-      self.run_mode = self.params.run_mode === "1" || self.params.run_mode === "Faster" ? "Faster" : "Normal";
-      self.datatype = datatypes[self.params.datatype] || self.params.datatype || "codon";
-      self.max_breakpoints = parseInt(self.params.max_breakpoints || 10000);
-      self.model = self.params.model || "JTT";
-    }
+      if (self.params.analysis) {
+        self.id = self.params.analysis._id || (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
+        // Use FEL-style tree assignment for unified format compatibility
+        self.nwk_tree = self.params.analysis.tagged_nwk_tree || self.params.nwk_tree || self.params.tree || "";
+        // GARD specific attributes with complete parameter coverage
+        self.site_to_site_variation = analysisParams.site_to_site_variation || "none";
+        self.rate_variation = variation_map[self.site_to_site_variation] || "None";
+        self.rate_classes = parseInt(analysisParams.rate_classes || analysisParams.classes || 2);
+        self.run_mode = analysisParams.run_mode == "1" || analysisParams.run_mode == "Faster" ? "Faster" : "Normal";
+        self.datatype = analysisParams.datatype || "0";
+        self.datatype = datatypes[self.datatype] || "codon";
+        self.max_breakpoints = parseInt(analysisParams.max_breakpoints || 10000);
+        self.model = analysisParams.model || "JTT";
+      } else {
+        self.id = (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
+        // GARD specific attributes with complete parameter coverage
+        self.site_to_site_variation = self.params.site_to_site_variation || "none";
+        self.rate_variation = variation_map[self.site_to_site_variation] || "None";
+        self.rate_classes = parseInt(self.params.rate_classes || self.params.classes || 2);
+        self.run_mode = self.params.run_mode === "1" || self.params.run_mode === "Faster" ? "Faster" : "Normal";
+        self.datatype = datatypes[self.params.datatype] || self.params.datatype || "codon";
+        self.max_breakpoints = parseInt(self.params.max_breakpoints || 10000);
+        self.model = self.params.model || "JTT";
+      }
     
+      // parameter-derived attributes
+      self.fn = __dirname + "/output/" + self.id;
+      self.output_dir = path.dirname(self.fn);
+      self.status_fn = self.fn + ".status";
+      self.results_fn = self.fn + ".GARD.json";
+      self.progress_fn = self.fn + ".GARD.progress";
+      self.tree_fn = self.fn + ".tre";
+      self.finalout_results_fn = self.fn + ".best-gard";
+    }
+
+    // Set treemode with default value
+    self.treemode = self.params.treemode || "0";
+
     // parameter-derived attributes
     self.fn = __dirname + "/output/" + self.id;
     self.output_dir = path.dirname(self.fn);
+    // Ensure output directory exists
+    utilities.ensureDirectoryExists(self.output_dir);
     self.status_fn = self.fn + ".status";
     self.results_fn = self.fn + ".GARD.json";
     self.progress_fn = self.fn + ".GARD.progress";
     self.tree_fn = self.fn + ".tre";
+
+    // output fn
     self.finalout_results_fn = self.fn + ".best-gard";
-  }
 
-  // Set treemode with default value
-  self.treemode = self.params.treemode || "0";
-
-  // parameter-derived attributes
-  self.fn = __dirname + "/output/" + self.id;
-  self.output_dir = path.dirname(self.fn);
-  // Ensure output directory exists
-  utilities.ensureDirectoryExists(self.output_dir);
-  self.status_fn = self.fn + ".status";
-  self.results_fn = self.fn + ".GARD.json";
-  self.progress_fn = self.fn + ".GARD.progress";
-  self.tree_fn = self.fn + ".tre";
-
-  // output fn
-  self.finalout_results_fn = self.fn + ".best-gard";
-
-  // Define parameters for job submission (different formats for qsub vs slurm vs local)
-  if (config.submit_type === "local") {
+    // Define parameters for job submission (different formats for qsub vs slurm vs local)
+    if (config.submit_type === "local") {
     // For local execution, the script path must be first
-    self.qsub_params = [
-      self.qsub_script,
-      "fn=" + self.fn,
-      "tree_fn=" + self.tree_fn,
-      "sfn=" + self.status_fn,
-      "pfn=" + self.progress_fn,
-      "rfn=" + self.results_fn,
-      "treemode=" + self.treemode,
-      "genetic_code=" + self.genetic_code,
-      "rate_var=" + self.rate_variation,
-      "rate_classes=" + self.rate_classes,
-      "datatype=" + self.datatype,
-      "run_mode=" + self.run_mode,
-      "max_breakpoints=" + self.max_breakpoints,
-      "model=" + self.model,
-      "analysis_type=" + self.type,
-      "cwd=" + __dirname,
-      "msaid=" + self.msaid,
-      "procs=" + (config.gard_procs || 48)
-    ];
-  } else if (config.submit_type === "slurm") {
+      self.qsub_params = [
+        self.qsub_script,
+        "fn=" + self.fn,
+        "tree_fn=" + self.tree_fn,
+        "sfn=" + self.status_fn,
+        "pfn=" + self.progress_fn,
+        "rfn=" + self.results_fn,
+        "treemode=" + self.treemode,
+        "genetic_code=" + self.genetic_code,
+        "rate_var=" + self.rate_variation,
+        "rate_classes=" + self.rate_classes,
+        "datatype=" + self.datatype,
+        "run_mode=" + self.run_mode,
+        "max_breakpoints=" + self.max_breakpoints,
+        "model=" + self.model,
+        "analysis_type=" + self.type,
+        "cwd=" + __dirname,
+        "msaid=" + self.msaid,
+        "procs=" + (config.gard_procs || 48)
+      ];
+    } else if (config.submit_type === "slurm") {
     // Convert walltime from PBS format (DD:HH:MM:SS) to SLURM format (HH:MM:SS or minutes)
-    let slurmTime = "72:00:00"; // Default 3 days
-    if (config.gard_walltime) {
-      const parts = config.gard_walltime.split(":");
-      if (parts.length === 4) {
+      let slurmTime = "72:00:00"; // Default 3 days
+      if (config.gard_walltime) {
+        const parts = config.gard_walltime.split(":");
+        if (parts.length === 4) {
         // Convert D:HH:MM:SS to SLURM format
-        const days = parseInt(parts[0]);
-        const hours = parseInt(parts[1]) + (days * 24);
-        slurmTime = `${hours}:${parts[2]}:${parts[3]}`;
-      } else if (parts.length === 3) {
+          const days = parseInt(parts[0]);
+          const hours = parseInt(parts[1]) + (days * 24);
+          slurmTime = `${hours}:${parts[2]}:${parts[3]}`;
+        } else if (parts.length === 3) {
         // HH:MM:SS format, already compatible with SLURM
-        slurmTime = config.gard_walltime;
+          slurmTime = config.gard_walltime;
+        }
       }
-    }
     
-    logger.info(`Converted walltime from ${config.gard_walltime} to SLURM format: ${slurmTime}`);
-    console.log(`Converted walltime from ${config.gard_walltime} to SLURM format: ${slurmTime}`);
+      logger.info(`Converted walltime from ${config.gard_walltime} to SLURM format: ${slurmTime}`);
+      console.log(`Converted walltime from ${config.gard_walltime} to SLURM format: ${slurmTime}`);
     
-    self.qsub_params = [
-      `--ntasks=${config.gard_procs || 4}`,                       // Use multiple tasks for MPI
-      "--cpus-per-task=1",                                  // One CPU per task for MPI
-      `--time=${slurmTime}`,                                // Converted time limit
-      `--partition=${config.slurm_partition || "datamonkey"}`,    // Use configured partition
-      "--nodes=1",                                          // Run on a single node
-      "--export=ALL,slurm_mpi_type=" + 
+      self.qsub_params = [
+        `--ntasks=${config.gard_procs || 4}`,                       // Use multiple tasks for MPI
+        "--cpus-per-task=1",                                  // One CPU per task for MPI
+        `--time=${slurmTime}`,                                // Converted time limit
+        `--partition=${config.slurm_partition || "datamonkey"}`,    // Use configured partition
+        "--nodes=1",                                          // Run on a single node
+        "--export=ALL,slurm_mpi_type=" + 
       (config.slurm_mpi_type || "pmix") + 
       "," +
       "fn=" +
@@ -213,17 +213,17 @@ const gard = function(socket, stream, params) {
       self.msaid +
       ",procs=" +
       (config.gard_procs || 48),
-      `--output=${self.output_dir}/gard_${self.id}_%j.out`,
-      `--error=${self.output_dir}/gard_${self.id}_%j.err`,
-      self.qsub_script
-    ];
-  } else {
-    self.qsub_params = [
-      "-l walltime=" + config.gard_walltime + ",nodes=" + config.gard_nodes + ":ppn=" + config.gard_procs,
-      "-q",
-      config.qsub_queue,
-      "-v",
-      "fn=" +
+        `--output=${self.output_dir}/gard_${self.id}_%j.out`,
+        `--error=${self.output_dir}/gard_${self.id}_%j.err`,
+        self.qsub_script
+      ];
+    } else {
+      self.qsub_params = [
+        "-l walltime=" + config.gard_walltime + ",nodes=" + config.gard_nodes + ":ppn=" + config.gard_procs,
+        "-q",
+        config.qsub_queue,
+        "-v",
+        "fn=" +
         self.fn +
         ",tree_fn=" +
         self.tree_fn +
@@ -257,49 +257,48 @@ const gard = function(socket, stream, params) {
         self.msaid +
         ",procs=" +
         (config.gard_procs || 48),
-      "-o",
-      self.output_dir,
-      "-e",
-      self.output_dir,
-      self.qsub_script
-    ];
-  }
-
-  // Log the parameters being used
-  logger.info(`GARD job ${self.id}: Using ${config.submit_type} parameters: ${JSON.stringify(self.qsub_params)}`);
-
-  // Skip file operations for check-only mode
-  if (!isCheckOnly) {
-    // Ensure output directory exists BEFORE writing files
-    logger.info(`GARD job ${self.id}: Ensuring output directory exists at ${self.output_dir}`);
-    utilities.ensureDirectoryExists(self.output_dir);
-
-    // Clean tree data and write to file
-    const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
-    logger.info(`GARD job ${self.id}: Writing cleaned tree file to ${self.tree_fn}`, {
-      original_length: self.nwk_tree ? self.nwk_tree.length : 0,
-      cleaned_length: cleanTree ? cleanTree.length : 0,
-      tree_preview: cleanTree ? (cleanTree.length > 100 ? cleanTree.substring(0, 100) + "..." : cleanTree) : "null"
-    });
-    try {
-      fs.writeFileSync(self.tree_fn, cleanTree);
-      logger.info(`GARD job ${self.id}: Tree file written successfully`);
-    } catch (err) {
-      logger.error(`GARD job ${self.id}: Error writing tree file: ${err.message}`);
-      throw err;
+        "-o",
+        self.output_dir,
+        "-e",
+        self.output_dir,
+        self.qsub_script
+      ];
     }
 
-    // Ensure the progress file exists
-    logger.info(`GARD job ${self.id}: Creating progress file at ${self.progress_fn}`);
-    fs.openSync(self.progress_fn, "w");
-  }
-  
-  logger.info(`GARD job ${self.id}: Initializing job`);
-  self.init();
-  logger.info(`GARD job ${self.id}: Job initialized`);
-};
+    // Log the parameters being used
+    logger.info(`GARD job ${self.id}: Using ${config.submit_type} parameters: ${JSON.stringify(self.qsub_params)}`);
 
-util.inherits(gard, hyphyJob);
+    // Skip file operations for check-only mode
+    if (!isCheckOnly) {
+    // Ensure output directory exists BEFORE writing files
+      logger.info(`GARD job ${self.id}: Ensuring output directory exists at ${self.output_dir}`);
+      utilities.ensureDirectoryExists(self.output_dir);
+
+      // Clean tree data and write to file
+      const cleanTree = utilities.cleanTreeToNewick(self.nwk_tree);
+      logger.info(`GARD job ${self.id}: Writing cleaned tree file to ${self.tree_fn}`, {
+        original_length: self.nwk_tree ? self.nwk_tree.length : 0,
+        cleaned_length: cleanTree ? cleanTree.length : 0,
+        tree_preview: cleanTree ? (cleanTree.length > 100 ? cleanTree.substring(0, 100) + "..." : cleanTree) : "null"
+      });
+      try {
+        fs.writeFileSync(self.tree_fn, cleanTree);
+        logger.info(`GARD job ${self.id}: Tree file written successfully`);
+      } catch (err) {
+        logger.error(`GARD job ${self.id}: Error writing tree file: ${err.message}`);
+        throw err;
+      }
+
+      // Ensure the progress file exists
+      logger.info(`GARD job ${self.id}: Creating progress file at ${self.progress_fn}`);
+      fs.openSync(self.progress_fn, "w");
+    }
+  
+    logger.info(`GARD job ${self.id}: Initializing job`);
+    self.init();
+    logger.info(`GARD job ${self.id}: Job initialized`);
+  }
+}
 
 gard.prototype.sendNexusFile = function(cb) {
   const self = this;
@@ -346,29 +345,13 @@ gard.prototype.onComplete = function() {
           // Log that the job has been completed
           self.log("complete", "success");
 
-          // Store packet in redis and publish to channel. Terminal writes are
-          // batched under Promise.all().catch (not fire-and-forget): a rejected
-          // redis@5 write would otherwise leave the job never marked completed
-          // and never dequeued — a silent zombie. Mirrors hyphyjob.js onComplete.
-          Promise.all([
-            client.hSet(self.id, {
-              results: str_redis_packet,
-              status: "completed"
-            }),
-            client.publish(self.id, str_redis_packet),
-            // Remove id from active_job queue
-            client.lRem("active_jobs", 1, self.id)
-          ]).catch(function(werr) {
-            logger.error(
-              "[REDIS] Terminal completion write failed for gard job " +
-                self.id + " - job may be left as a zombie: " + werr.message
-            );
-          });
-
-          // Match the parent completion contract (hyphyjob.js onComplete):
-          // drop the finished job from the live registry so a later cancelAll
-          // broadcast can't act on a completed job.
-          jobRegistry.unregister(self.id);
+          // Terminal writes + dequeue + unregister via the shared base helper
+          // (guarded Promise.all().catch — a rejected redis write can't zombie
+          // the job; single source of truth with hyphyjob.js onComplete).
+          self.finalizeCompletion(
+            { results: str_redis_packet, status: "completed" },
+            str_redis_packet
+          );
         }
       });
     }

--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -34,95 +34,97 @@ function once(fn) {
 // Promisified fs.readFile (replaces Q.nfcall(fs.readFile, ...)).
 const readFileAsync = util.promisify(fs.readFile);
 
-const hivtrace = function(socket, stream, params) {
-  const self = this;
+class hivtrace extends hyphyJob {
+  constructor(socket, stream, params) {
+    super();
+    const self = this;
 
-  self.status_states = {
-    PENDING: 1,
-    RUNNING: 2,
-    COMPLETED: 3
-  };
+    self.status_states = {
+      PENDING: 1,
+      RUNNING: 2,
+      COMPLETED: 3
+    };
 
-  const cluster_output_suffix = "_user.trace.json",
-    tn93_json_suffix = "_user.tn93output.json",
-    tn93_csv_suffix = "_user.tn93output.csv",
-    custom_reference_suffix = "_custom_reference.fas",
-    hivtrace_log_suffix = ".hivtrace.log",
-    output_fasta_suffix = "_output.fasta";
+    const cluster_output_suffix = "_user.trace.json",
+      tn93_json_suffix = "_user.tn93output.json",
+      tn93_csv_suffix = "_user.tn93output.csv",
+      custom_reference_suffix = "_custom_reference.fas",
+      hivtrace_log_suffix = ".hivtrace.log",
+      output_fasta_suffix = "_output.fasta";
 
-  self.socket = socket;
-  self.stream = stream;
-  self.params = params;
+    self.socket = socket;
+    self.stream = stream;
+    self.params = params;
 
-  // object specific attributes
-  self.python = path.join(__dirname, "../../.python/env/bin/python");
-  self.output_dir = path.join(__dirname, "/output/");
-  self.qsub_script_name = "hivtrace_submit.sh";
-  self.qsub_script = path.join(__dirname, self.qsub_script_name);
-  self.hivtrace = path.join(__dirname, "../../.python/env/bin/hivtrace");
-  self.custom_reference_fn = "";
-  self.type = "hivtrace";
-  self.submit_type = config.submit_type || "qsub";
+    // object specific attributes
+    self.python = path.join(__dirname, "../../.python/env/bin/python");
+    self.output_dir = path.join(__dirname, "/output/");
+    self.qsub_script_name = "hivtrace_submit.sh";
+    self.qsub_script = path.join(__dirname, self.qsub_script_name);
+    self.hivtrace = path.join(__dirname, "../../.python/env/bin/hivtrace");
+    self.custom_reference_fn = "";
+    self.type = "hivtrace";
+    self.submit_type = config.submit_type || "qsub";
 
-  // parameter attributes
-  self.id = params._id;
-  self.distance_threshold = params.distance_threshold;
-  self.ambiguity_handling = params.ambiguity_handling;
-  self.fraction = params.fraction;
-  self.reference = params.reference;
-  self.filter_edges = params.filter_edges;
-  self.reference_strip = params.reference_strip;
-  self.min_overlap = params.min_overlap;
-  self.status_stack = params.status_stack;
-  self.lanl_compare = params.lanl_compare;
-  self.prealigned = params.prealigned;
-  self.strip_drams = params.strip_drams == "no" ? false : params.strip_drams;
+    // parameter attributes
+    self.id = params._id;
+    self.distance_threshold = params.distance_threshold;
+    self.ambiguity_handling = params.ambiguity_handling;
+    self.fraction = params.fraction;
+    self.reference = params.reference;
+    self.filter_edges = params.filter_edges;
+    self.reference_strip = params.reference_strip;
+    self.min_overlap = params.min_overlap;
+    self.status_stack = params.status_stack;
+    self.lanl_compare = params.lanl_compare;
+    self.prealigned = params.prealigned;
+    self.strip_drams = params.strip_drams == "no" ? false : params.strip_drams;
 
-  // parameter-derived attributes.
-  // NOTE: self.filepath MUST be set before the Custom-reference block below,
-  // which derives custom_reference_fn from it. Previously filepath was assigned
-  // after that block, so a Custom reference was written to
-  // "undefined_custom_reference.fas" and never found. See #403 follow-up.
-  self.filepath = path.join(self.output_dir, self.id);
+    // parameter-derived attributes.
+    // NOTE: self.filepath MUST be set before the Custom-reference block below,
+    // which derives custom_reference_fn from it. Previously filepath was assigned
+    // after that block, so a Custom reference was written to
+    // "undefined_custom_reference.fas" and never found. See #403 follow-up.
+    self.filepath = path.join(self.output_dir, self.id);
 
-  if (params.reference == "Custom") {
-    self.custom_reference_fn = self.filepath + custom_reference_suffix;
-    self.custom_reference = params.custom_reference;
-    self.reference = self.custom_reference_fn;
-    // Check if reference is custom, and write to a file if so. Log write
-    // failures instead of swallowing them — the analysis depends on this file,
-    // and a silent failure surfaces later as a confusing "file not found".
-    fs.writeFile(self.custom_reference_fn, self.custom_reference, function(err) {
-      if (err) {
-        logger.error(
-          "hivtrace failed to write custom reference file " +
+    if (params.reference == "Custom") {
+      self.custom_reference_fn = self.filepath + custom_reference_suffix;
+      self.custom_reference = params.custom_reference;
+      self.reference = self.custom_reference_fn;
+      // Check if reference is custom, and write to a file if so. Log write
+      // failures instead of swallowing them — the analysis depends on this file,
+      // and a silent failure surfaces later as a confusing "file not found".
+      fs.writeFile(self.custom_reference_fn, self.custom_reference, function(err) {
+        if (err) {
+          logger.error(
+            "hivtrace failed to write custom reference file " +
             self.custom_reference_fn + ": " + err.message
-        );
-      }
+          );
+        }
+      });
+    }
+
+    self.status_fn = self.filepath + "_status";
+    self.output_cluster_output = self.filepath + cluster_output_suffix;
+    self.tn93_stdout = self.filepath + tn93_json_suffix;
+    self.tn93_results = self.filepath + tn93_csv_suffix;
+    self.tn93_lanl_results = self.filepath + tn93_csv_suffix;
+    self.aligned_fasta = self.filepath + output_fasta_suffix;
+    self.hivtrace_log = self.filepath + hivtrace_log_suffix;
+
+    const initial_statuses = [];
+    (self.status_stack || []).forEach(function(d) {
+      initial_statuses.push({ title: d, status: self.status_states.PENDING });
     });
-  }
 
-  self.status_fn = self.filepath + "_status";
-  self.output_cluster_output = self.filepath + cluster_output_suffix;
-  self.tn93_stdout = self.filepath + tn93_json_suffix;
-  self.tn93_results = self.filepath + tn93_csv_suffix;
-  self.tn93_lanl_results = self.filepath + tn93_csv_suffix;
-  self.aligned_fasta = self.filepath + output_fasta_suffix;
-  self.hivtrace_log = self.filepath + hivtrace_log_suffix;
+    client.hSet(
+      self.id,
+      "complete phase status",
+      JSON.stringify(initial_statuses)
+    );
 
-  const initial_statuses = [];
-  (self.status_stack || []).forEach(function(d) {
-    initial_statuses.push({ title: d, status: self.status_states.PENDING });
-  });
-
-  client.hSet(
-    self.id,
-    "complete phase status",
-    JSON.stringify(initial_statuses)
-  );
-
-  // Create parameter string for job submission
-  self.params_string = "fn=" +
+    // Create parameter string for job submission
+    self.params_string = "fn=" +
     self.filepath +
     ",python=" +
     self.python +
@@ -155,38 +157,37 @@ const hivtrace = function(socket, stream, params) {
     ",custom_reference_fn=" +
     self.custom_reference_fn;
 
-  // Prepare qsub params with unique output/error file names
-  self.qsub_params = [
-    "-l walltime=" + 
+    // Prepare qsub params with unique output/error file names
+    self.qsub_params = [
+      "-l walltime=" + 
     config.hivtrace_walltime + 
     ",nodes=1:ppn=" + 
     config.hivtrace_procs,
-    "-q",
-    config.qsub_queue,
-    "-v",
-    self.params_string,
-    "-o",
-    path.join(self.output_dir, `hivtrace_${self.id}.o`),
-    "-e",
-    path.join(self.output_dir, `hivtrace_${self.id}.e`),
-    self.qsub_script
-  ];
+      "-q",
+      config.qsub_queue,
+      "-v",
+      self.params_string,
+      "-o",
+      path.join(self.output_dir, `hivtrace_${self.id}.o`),
+      "-e",
+      path.join(self.output_dir, `hivtrace_${self.id}.e`),
+      self.qsub_script
+    ];
 
-  // Prepare sbatch params for SLURM with unique output/error file names
-  self.slurm_params = [
-    "--ntasks=1",
-    "--cpus-per-task=" + config.hivtrace_procs,
-    "--time=" + config.hivtrace_walltime,
-    "--output=" + path.join(self.output_dir, `hivtrace_${self.id}_%j.out`),
-    "--error=" + path.join(self.output_dir, `hivtrace_${self.id}_%j.err`),
-    "--export=" + self.params_string,
-    self.qsub_script
-  ];
+    // Prepare sbatch params for SLURM with unique output/error file names
+    self.slurm_params = [
+      "--ntasks=1",
+      "--cpus-per-task=" + config.hivtrace_procs,
+      "--time=" + config.hivtrace_walltime,
+      "--output=" + path.join(self.output_dir, `hivtrace_${self.id}_%j.out`),
+      "--error=" + path.join(self.output_dir, `hivtrace_${self.id}_%j.err`),
+      "--export=" + self.params_string,
+      self.qsub_script
+    ];
 
-  self.spawn();
-};
-
-util.inherits(hivtrace, hyphyJob);
+    self.spawn();
+  }
+}
 
 hivtrace.prototype.spawn = function() {
   const self = this;
@@ -389,23 +390,13 @@ hivtrace.prototype.onComplete = function() {
 
       self.socket.emit("completed", { results: results_data });
 
-      // Terminal writes: status + results + dequeue. A failure here would
-      // otherwise leave the job as a zombie, so catch and log loudly rather
-      // than fire-and-forget (mirrors hyphyjob.js onComplete).
-      Promise.all([
-        client.hSet(self.id, {
-          status: "completed",
-          results: str_redis_packet
-        }),
-        client.lRem("active_jobs", 1, self.id)
-      ]).catch(function(err) {
-        logger.error(
-          "[REDIS] Terminal completion write failed for hivtrace job " +
-            self.id + " - job may be left as a zombie: " + err.message
-        );
+      // Terminal writes + dequeue + unregister via the shared base helper.
+      // hivtrace delivers results over the socket above, so no publish packet
+      // (omit the 2nd arg). Single source of truth with hyphyjob.js onComplete.
+      self.finalizeCompletion({
+        status: "completed",
+        results: str_redis_packet
       });
-
-      jobRegistry.unregister(self.id);
     } else {
       self.onError(
         "job seems to have completed, but no results found: " +

--- a/app/hyphyjob.js
+++ b/app/hyphyjob.js
@@ -43,7 +43,12 @@ function injectSubmissionSource(qsub_params, source, submit_type) {
   return ["--comment=source=" + source].concat(qsub_params);
 }
 
-const hyphyJob = function() {};
+// Base job runner. Declared as a class so subclasses can use `class X extends
+// hyphyJob` (ES inheritance) instead of util.inherits. The methods are attached
+// to the prototype below (valid on a class prototype) rather than inlined, to
+// keep this a minimal, low-risk conversion — no method bodies move. No code
+// ever does `new hyphyJob` directly; it is only ever subclassed.
+class hyphyJob {}
 
 hyphyJob.prototype.log = function(notification, complementary_info) {
   const self = this;
@@ -303,6 +308,40 @@ hyphyJob.prototype.onJobCreated = function(torque_id) {
   self.push_job_once(self.id);
 };
 
+/**
+ * Shared terminal-completion finalizer. Every onComplete path (base and the
+ * gard/difFubar/hivtrace overrides) MUST route its terminal redis writes
+ * through here so the hardening lives in one place: batched hSet/publish/lRem
+ * under Promise.all().catch (a rejected redis@5 write can't silently zombie the
+ * job) plus jobRegistry.unregister (drop the finished job from the live map so
+ * a later cancelAll can't act on it). Historically each override re-implemented
+ * this and battle-tests kept finding one that had drifted (missing unregister,
+ * fire-and-forget writes); a single helper removes that whole bug class.
+ *
+ * @param {object} hashFields  fields to hSet on self.id (e.g. {results, status})
+ * @param {string} [publishPacket]  stringified packet to publish on self.id.
+ *   Omit (undefined) to skip the publish — hivtrace delivers results via the
+ *   socket directly and does not publish a completion packet.
+ */
+hyphyJob.prototype.finalizeCompletion = function(hashFields, publishPacket) {
+  const self = this;
+  const writes = [
+    client.hSet(self.id, hashFields),
+    // Remove id from active_job queue
+    client.lRem("active_jobs", 1, self.id)
+  ];
+  if (publishPacket !== undefined) {
+    writes.push(client.publish(self.id, publishPacket));
+  }
+  Promise.all(writes).catch(function(err) {
+    logger.error(
+      `[REDIS] Terminal completion write failed for job ${self.id} - job may be left as a zombie: ${err.message}`
+    );
+  });
+  // Drop the finished job from the live registry.
+  jobRegistry.unregister(self.id);
+};
+
 hyphyJob.prototype.onComplete = function() {
   const self = this;
 
@@ -326,7 +365,7 @@ hyphyJob.prototype.onComplete = function() {
         logger.info(`[DEBUG REDIS] Completion data length: ${str_redis_packet.length} bytes`);
         logger.info(`[DEBUG REDIS] Completion packet type: ${redis_packet.type}`);
         logger.info(`[DEBUG REDIS] Results data length: ${data.length} bytes`);
-        
+
         // Check if message is too large (Redis default max is 512MB but practical limit is lower)
         const MAX_REDIS_MESSAGE_SIZE = 50 * 1024 * 1024; // 50MB
         if (str_redis_packet.length > MAX_REDIS_MESSAGE_SIZE) {
@@ -334,23 +373,12 @@ hyphyJob.prototype.onComplete = function() {
           logger.warn("[DEBUG REDIS] This may cause issues with Redis pub/sub");
         }
 
-        // Store packet in redis and publish to channel
-        Promise.all([
-          client.hSet(self.id, {
-            results: str_redis_packet,
-            status: "completed"
-          }),
-          client.publish(self.id, str_redis_packet),
-          // Remove id from active_job queue
-          client.lRem("active_jobs", 1, self.id)
-        ]).catch(function(err) {
-          logger.error(
-            `[REDIS] Terminal completion write failed for job ${self.id} - job may be left as a zombie: ${err.message}`
-          );
-        });
+        // Store packet in redis + publish + dequeue + unregister (shared helper).
+        self.finalizeCompletion(
+          { results: str_redis_packet, status: "completed" },
+          str_redis_packet
+        );
         logger.info(`[DEBUG REDIS] Published completion event to Redis channel: ${self.id}`);
-
-        jobRegistry.unregister(self.id);
       } else {
         // Empty results file
         self.onError("job seems to have completed, but no results found");

--- a/lib/analysis-factory.js
+++ b/lib/analysis-factory.js
@@ -56,7 +56,6 @@
  */
 
 const path = require("path");
-const util = require("util");
 const config = require("./config");
 const logger = require("./logger").logger;
 const hyphyJob = require("../app/hyphyjob.js").hyphyJob;
@@ -88,73 +87,75 @@ function toSlurmTime(walltime) {
 function makeAnalysis(descriptor) {
   const ctx = { code: code, model: model };
 
-  function Analysis(socket, stream, params) {
-    const self = this;
-    self.socket = socket;
-    self.stream = stream;
-    self.params = params;
+  class Analysis extends hyphyJob {
+    constructor(socket, stream, params) {
+      super();
+      const self = this;
+      self.socket = socket;
+      self.stream = stream;
+      self.params = params;
 
-    const isCheckOnly = params.checkOnly || false;
-    self.type = descriptor.type;
+      const isCheckOnly = params.checkOnly || false;
+      self.type = descriptor.type;
 
-    // --- resolve analysis-specific fields (checkOnly reads params; normal reads
-    // analysisParams). The descriptor decides which; we pass both. ---
-    const analysisParams = isCheckOnly ? params : (self.params.analysis || self.params);
-    descriptor.fields(self, params, analysisParams, ctx);
+      // --- resolve analysis-specific fields (checkOnly reads params; normal reads
+      // analysisParams). The descriptor decides which; we pass both. ---
+      const analysisParams = isCheckOnly ? params : (self.params.analysis || self.params);
+      descriptor.fields(self, params, analysisParams, ctx);
 
-    // --- id / msaid / genetic_code / tree (the common fallback dance) ---
-    if (isCheckOnly) {
-      self.id = "check-" + Date.now();
-      self.msaid = "check";
-    } else {
-      if (self.params.msa) {
-        self.msaid = self.params.msa._id;
+      // --- id / msaid / genetic_code / tree (the common fallback dance) ---
+      if (isCheckOnly) {
+        self.id = "check-" + Date.now();
+        self.msaid = "check";
       } else {
-        self.msaid = self.params.msaid || "unknown";
-      }
-      if (self.params.analysis) {
-        self.id =
+        if (self.params.msa) {
+          self.msaid = self.params.msa._id;
+        } else {
+          self.msaid = self.params.msaid || "unknown";
+        }
+        if (self.params.analysis) {
+          self.id =
           self.params.analysis._id ||
           (self.params.job && self.params.job.id) ||
           self.params.id ||
           "unknown-" + Date.now();
-      } else {
-        self.id =
+        } else {
+          self.id =
           (self.params.job && self.params.job.id) || self.params.id || "unknown-" + Date.now();
+        }
       }
+
+      if (descriptor.afterFields) descriptor.afterFields(self);
+
+      // --- file-path derivation (identical across analyses except suffixes) ---
+      self.fn = descriptor.dir + "/output/" + self.id;
+      self.output_dir = path.dirname(self.fn);
+      self.status_fn = self.fn + ".status";
+      self.results_short_fn = self.fn + "." + descriptor.suffixes.short;
+      self.results_fn = self.fn + "." + descriptor.suffixes.results + ".json";
+      self.progress_fn = self.fn + "." + descriptor.suffixes.progress + ".progress";
+      self.tree_fn = self.fn + ".tre";
+
+      self.treemode = self.params.treemode || "0";
+
+      self.qsub_script_name = descriptor.script;
+      self.qsub_script = descriptor.dir + "/" + self.qsub_script_name;
+
+      self.qsub_params = buildQsubParams(self, descriptor);
+
+      // Non-checkOnly side effects — sanitize the tree, write the tree file,
+      // ensure the output dir exists, and create the progress file — exactly as
+      // the original hand-written module did before self.init(). Declared per
+      // analysis via the descriptor's optional beforeInit hook (checkOnly skips
+      // it, matching the original `if (!isCheckOnly)` guard).
+      if (!isCheckOnly && descriptor.beforeInit) {
+        descriptor.beforeInit(self, ctx);
+      }
+
+      self.init();
     }
-
-    if (descriptor.afterFields) descriptor.afterFields(self);
-
-    // --- file-path derivation (identical across analyses except suffixes) ---
-    self.fn = descriptor.dir + "/output/" + self.id;
-    self.output_dir = path.dirname(self.fn);
-    self.status_fn = self.fn + ".status";
-    self.results_short_fn = self.fn + "." + descriptor.suffixes.short;
-    self.results_fn = self.fn + "." + descriptor.suffixes.results + ".json";
-    self.progress_fn = self.fn + "." + descriptor.suffixes.progress + ".progress";
-    self.tree_fn = self.fn + ".tre";
-
-    self.treemode = self.params.treemode || "0";
-
-    self.qsub_script_name = descriptor.script;
-    self.qsub_script = descriptor.dir + "/" + self.qsub_script_name;
-
-    self.qsub_params = buildQsubParams(self, descriptor);
-
-    // Non-checkOnly side effects — sanitize the tree, write the tree file,
-    // ensure the output dir exists, and create the progress file — exactly as
-    // the original hand-written module did before self.init(). Declared per
-    // analysis via the descriptor's optional beforeInit hook (checkOnly skips
-    // it, matching the original `if (!isCheckOnly)` guard).
-    if (!isCheckOnly && descriptor.beforeInit) {
-      descriptor.beforeInit(self, ctx);
-    }
-
-    self.init();
   }
 
-  util.inherits(Analysis, hyphyJob);
   return Analysis;
 }
 


### PR DESCRIPTION
Attacks the ROOT CAUSE of the recurring battle-test finding: "a base fix that `util.inherits` overrides silently missed" (BT3 hivtrace, BT4 gard/difFubar, BT5 hivtrace again). Two structural changes, both behavior-preserving and golden-gated.

## 1. Shared completion finalizer (the actual bug-prevention)
`hyphyJob.prototype.finalizeCompletion(hashFields, publishPacket?)` centralizes the hardened terminal-completion pattern: batch `hSet`/`publish`/`lRem` under `Promise.all().catch` (a rejected redis@5 write can't silently zombie the job) + `jobRegistry.unregister`. The base `onComplete` and all three overrides (gard, difFubar large-results, hivtrace) now route their terminal writes through it instead of each re-implementing (and drifting from) the guard. `publishPacket` is optional — hivtrace delivers results over the socket and passes no packet. gard/difFubar dropped their own `jobRegistry` require.

**This is what prevents the recurrence:** the hardening now lives in one place, so a future override that calls `finalizeCompletion` can't miss the unregister or the write-guard.

## 2. util.inherits → ES class extends
`hyphyJob` is now `class hyphyJob {}` (methods still attached to the prototype — minimal, no bodies move). `difFubar`/`gard`/`hivtrace` + the analysis-factory synthesized `Analysis` are now `class X extends hyphyJob { constructor(...) { super(); ... } }`. `util.inherits` and unused `util` requires removed. Because subclasses now inherit via the real prototype chain, base additions (like `finalizeCompletion`) reach every subclass automatically.

## Why it's safe
No code ever does `new hyphyJob` directly (only ever subclassed). Class-prototype augmentation + `extends` is equivalent to `function` + `util.inherits`. The golden factory-parity + qsub-params snapshots — which construct every analysis via the converted factory + difFubar — remain **byte-identical**.

**Verified:** test:ci 126/0, test:mcp 58/0, coverage-gaps 16/0; ESLint clean (auto-fixed the indentation from the added class-nesting level); MCP analysisMap = 17 working constructors; golden byte-identical with both a dev config and the CI fixture.