### PR TITLE
feat: MCP SSE job-completion notifications (closes #379)

### DIFF
--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -9,7 +9,7 @@ on:
       - "package.json"
       - ".github/workflows/mcp-tests.yml"
   pull_request:
-    branches: [master]
+    branches: [master, feature/v4-modernization]
     paths:
       - "lib/mcp/**"
       - "test/mcp/**"

--- a/app/hivtrace/hivtrace.js
+++ b/app/hivtrace/hivtrace.js
@@ -391,12 +391,19 @@ hivtrace.prototype.onComplete = function() {
       self.socket.emit("completed", { results: results_data });
 
       // Terminal writes + dequeue + unregister via the shared base helper.
-      // hivtrace delivers results over the socket above, so no publish packet
-      // (omit the 2nd arg). Single source of truth with hyphyjob.js onComplete.
-      self.finalizeCompletion({
-        status: "completed",
-        results: str_redis_packet
-      });
+      // hivtrace delivers full results over the socket above; we still publish a
+      // minimal {type:"completed"} marker on the job channel so the MCP SSE
+      // subscriber (#379) receives a completion trigger — it only reads
+      // packet.type, so no payload is needed. The browser already handles a
+      // 'completed' socket event for other methods, so this is behavior-safe.
+      // Single source of truth with hyphyjob.js onComplete.
+      self.finalizeCompletion(
+        {
+          status: "completed",
+          results: str_redis_packet
+        },
+        JSON.stringify({ type: "completed" })
+      );
     } else {
       self.onError(
         "job seems to have completed, but no results found: " +

--- a/lib/mcp/index.js
+++ b/lib/mcp/index.js
@@ -10,6 +10,7 @@ const registerTools = require("./tools").registerTools;
 const TOOL_NAMES = require("./tools").TOOL_NAMES;
 const registerPrompts = require("./prompts").registerPrompts;
 const registerResources = require("./resources").registerResources;
+const createJobNotifier = require("./job-notifier").createJobNotifier;
 const pkg = require(path.join(__dirname, "../../package.json"));
 
 // Out-of-band redirect URI for headless clients (SSH boxes where an
@@ -105,15 +106,27 @@ function startMcpServer(config, redisClient) {
   app.use("/mcp", mcpLimiter);
 
   // Factory: create a new McpServer per session (SDK requires one transport per instance)
+  //
+  // Returns { server, notifier }. The notifier owns the per-session redis
+  // subscriptions used for issue #379 job-completion SSE notifications. It is
+  // constructed BEFORE registerTools so spawn_analysis can call notifier.watch()
+  // once a job_id is known, and it is torn down from transport.onclose.
+  //
+  // NOTE: `logging` capability is declared here because
+  // Server.sendLoggingMessage() early-returns unless _capabilities.logging is
+  // set (SDK server/index.js). Without it the job-completion notifications would
+  // be silently dropped. Purely additive — logging is a standard optional
+  // capability.
   function createMcpServer() {
     const server = new McpServer(
       { name: "datamonkey", version: pkg.version },
-      { capabilities: { tools: {}, prompts: {}, resources: {} } }
+      { capabilities: { tools: {}, prompts: {}, resources: {}, logging: {} } }
     );
-    registerTools(server, redisClient);
+    const notifier = createJobNotifier(server);
+    registerTools(server, redisClient, notifier);
     registerPrompts(server);
     registerResources(server);
-    return server;
+    return { server: server, notifier: notifier };
   }
 
   // In-memory stores for minimal OAuth ceremony
@@ -403,6 +416,40 @@ function startMcpServer(config, redisClient) {
 
   // Track transports by session ID for stateful connections
   const transports = {};
+  // Per-session notifiers, keyed by sessionId, so teardown paths outside the
+  // transport.onclose closure (e.g. the GET SSE stream 'close' event) can find
+  // and close the right session's redis subscriptions.
+  const notifiers = {};
+
+  /**
+   * Idempotently tear a session down: close its redis job subscriptions (#379)
+   * and drop it from the transports/notifiers stores. Safe to call multiple
+   * times and from multiple triggers (transport.onclose for DELETE, and the GET
+   * SSE stream 'close' event for the common network-drop / closed-tab case).
+   * A client that disconnects mid-job must leak neither a redis subscriber nor
+   * a transports{} entry, and the SDK's onclose only fires on explicit DELETE,
+   * so we must detect the SSE socket close ourselves.
+   *
+   * @param {string} sessionId
+   * @param {string} reason  short tag for the log line
+   */
+  function teardownSession(sessionId, reason) {
+    if (!sessionId) return;
+    const notifier = notifiers[sessionId];
+    if (notifier) {
+      delete notifiers[sessionId];
+      try {
+        notifier.closeAll();
+      } catch (e) {
+        logger.error("MCP job-notifier closeAll error: " + e.message);
+      }
+    }
+    if (transports[sessionId]) {
+      delete transports[sessionId];
+      logger.info("MCP session removed from store (" + reason + "): " + sessionId +
+        " remaining=" + Object.keys(transports).length);
+    }
+  }
 
   // POST /mcp — JSON-RPC requests (initialize, tool calls, etc.)
   app.post("/mcp", async function (req, res) {
@@ -440,24 +487,31 @@ function startMcpServer(config, redisClient) {
         });
         logger.info("MCP POST: new transport created, sessionId=" + transport.sessionId);
 
+        const created = createMcpServer();
+        const mcpServer = created.server;
+        const notifier = created.notifier;
+
+        // transport.onclose fires only on explicit DELETE /mcp (SDK behavior).
+        // The common network-drop / closed-tab disconnect is handled by the GET
+        // SSE stream 'close' handler instead; both funnel through the idempotent
+        // teardownSession().
         transport.onclose = function () {
-          logger.info("MCP session closed: " + transport.sessionId);
-          if (transport.sessionId) {
-            delete transports[transport.sessionId];
-            logger.info("MCP session removed from store: " + transport.sessionId +
-              " remaining=" + Object.keys(transports).length);
-          }
+          logger.info("MCP session closed (onclose): " + transport.sessionId);
+          teardownSession(transport.sessionId, "onclose");
         };
 
-        const mcpServer = createMcpServer();
         logger.info("MCP POST: new McpServer created, connecting to transport...");
         await mcpServer.connect(transport);
+        // sessionId is assigned during connect — hand it to the notifier so its
+        // sendLoggingMessage calls route to this exact session's SSE stream.
+        notifier.sessionId = transport.sessionId;
         logger.info("MCP POST: McpServer connected, transport.sessionId=" + transport.sessionId);
         await transport.handleRequest(req, res, req.body);
         logger.info("MCP POST: handleRequest completed, transport.sessionId=" + transport.sessionId +
           " statusCode=" + res.statusCode + " headersSent=" + res.headersSent);
         if (transport.sessionId) {
           transports[transport.sessionId] = transport;
+          notifiers[transport.sessionId] = notifier;
           logger.info("MCP POST: session stored: " + transport.sessionId +
             " totalSessions=" + Object.keys(transports).length);
         } else {
@@ -477,18 +531,18 @@ function startMcpServer(config, redisClient) {
         });
         logger.info("MCP POST: replacement transport created, new sessionId=" + transport.sessionId);
 
+        const created = createMcpServer();
+        const mcpServer = created.server;
+        const notifier = created.notifier;
+
         transport.onclose = function () {
-          logger.info("MCP session closed: " + transport.sessionId);
-          if (transport.sessionId) {
-            delete transports[transport.sessionId];
-            logger.info("MCP session removed from store: " + transport.sessionId +
-              " remaining=" + Object.keys(transports).length);
-          }
+          logger.info("MCP session closed (onclose): " + transport.sessionId);
+          teardownSession(transport.sessionId, "onclose");
         };
 
-        const mcpServer = createMcpServer();
         logger.info("MCP POST: replacement McpServer created, connecting to transport...");
         await mcpServer.connect(transport);
+        notifier.sessionId = transport.sessionId;
         logger.info("MCP POST: replacement McpServer connected, transport.sessionId=" + transport.sessionId);
 
         logger.info("MCP POST: stripping stale mcp-session-id header (was: " + req.headers["mcp-session-id"] + ")");
@@ -501,6 +555,7 @@ function startMcpServer(config, redisClient) {
         logger.info("MCP POST: response headers: " + JSON.stringify(res.getHeaders()));
         if (transport.sessionId) {
           transports[transport.sessionId] = transport;
+          notifiers[transport.sessionId] = notifier;
           logger.info("MCP POST: replacement session stored: " + transport.sessionId +
             " totalSessions=" + Object.keys(transports).length);
         } else {
@@ -546,6 +601,18 @@ function startMcpServer(config, redisClient) {
       });
       return;
     }
+
+    // Detect the SSE stream closing at the socket level. The SDK's transport
+    // only fires onclose on an explicit DELETE /mcp — when the client drops the
+    // GET SSE stream (network loss, killed process, closed tab), the SDK's
+    // ReadableStream cancel handler does NOT call onclose, so without this the
+    // session's redis subscribers and transports{} entry would leak until each
+    // job happens to publish its own terminal packet. teardownSession is
+    // idempotent, so racing this with a later DELETE/onclose is safe.
+    res.on("close", function () {
+      logger.info("MCP GET (SSE) stream closed for session " + sessionId);
+      teardownSession(sessionId, "sse-close");
+    });
 
     try {
       logger.info("MCP GET: calling handleRequest for session " + sessionId);

--- a/lib/mcp/job-notifier.js
+++ b/lib/mcp/job-notifier.js
@@ -1,0 +1,380 @@
+/**
+ * Per-session MCP job-completion notifier.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Issue #379: MCP clients (Claude, Claude Code) that call spawn_analysis want to
+ * be told when the job finishes instead of polling get_job_status forever. The
+ * job runner already publishes a terminal packet on the redis channel named by
+ * the job id (hyphyjob.js finalizeCompletion publishes {type:"completed"} and
+ * onError publishes {type:"script error"}). This module subscribes to that
+ * channel for the lifetime of the job and, on a terminal packet, pushes an MCP
+ * logging notification (notifications/message) down the session's SSE stream so
+ * a human sees it inline. This is ADDITIVE — get_job_status polling is untouched
+ * and remains the source of truth for clients that don't consume SSE.
+ *
+ * DELIVERY IS BEST-EFFORT (fire-and-forget) — NOT lossless
+ * --------------------------------------------------------
+ * The SSE completion event CAN be missed and there is no retry:
+ *   - The StreamableHTTP transport is created with NO eventStore, so a
+ *     notification sent on the standalone GET stream before the client has
+ *     opened it (or during any reconnect gap) is SILENTLY DROPPED by the SDK
+ *     (it early-returns when the standalone stream is undefined; nothing is
+ *     buffered or replayable).
+ *   - Redis pub/sub has no retention either: the runner's terminal publish
+ *     fires from finalizeCompletion regardless of whether a subscriber is
+ *     attached yet, so a completion that races the subscribe is lost.
+ * This does NOT hang the client: get_job_status polling is the fallback and the
+ * source of truth. A client MUST reconcile final state via get_job_status and
+ * treat the SSE event purely as an optimization. If lossless delivery is ever
+ * required, configure an eventStore on the transport so standalone-stream
+ * notifications are stored for replay on (re)connect.
+ *
+ * LIFECYCLE (the risk — see leak fixes #397/#400)
+ * -----------------------------------------------
+ * Every subscription MUST be torn down on BOTH:
+ *   (a) the terminal notification firing (unwatch after sendLoggingMessage), AND
+ *   (b) session close (transport.onclose -> closeAll).
+ * A client that disconnects mid-job must not leak a redis subscriber. We mirror
+ * the clientsocket.js pattern exactly: an entry is stored synchronously with a
+ * _closed guard the moment watch() begins, so a session close racing the async
+ * createSubscriber() connect tears the fresh subscriber down instead of leaking
+ * it. Concurrent subscriptions per session are capped (MAX_SUBSCRIPTIONS).
+ *
+ * redis@5: the subscriber is a SEPARATE connection (createSubscriber). JSON.parse
+ * of pub/sub messages is guarded so a malformed publish can never crash.
+ */
+
+const { createSubscriber } = require("../redis-client"),
+  logger = require("../logger").logger;
+
+// Cap concurrent job subscriptions per session so a client spamming
+// spawn_analysis can't create unbounded redis connections. Jobs beyond the cap
+// simply fall back to get_job_status polling.
+const MAX_SUBSCRIPTIONS = 25;
+
+// Hard TTL on a single job subscription. A runner that dies / times out without
+// ever publishing a terminal packet (or a job cancelled out-of-band) would
+// otherwise pin its redis subscriber for the life of the session, eventually
+// exhausting MAX_SUBSCRIPTIONS so NEW jobs silently lose SSE. After this
+// wallclock the watch is torn down unconditionally; the client still gets the
+// truth from get_job_status. Sized generously above the longest expected job.
+const WATCH_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+/**
+ * Create a per-session job notifier bound to one McpServer instance.
+ *
+ * @param {{ server: { sendLoggingMessage: Function } }} mcpServer
+ *   Any object exposing `server.sendLoggingMessage(params, sessionId)`. In
+ *   production this is the SDK McpServer; tests inject a spy.
+ * @returns {object} notifier with watch/unwatch/closeAll + `subscriptions` Map
+ */
+function createJobNotifier(mcpServer) {
+  // job_id -> { subscriber, channel, _closed, _notified, _toreDown, ttlTimer }
+  const subscriptions = new Map();
+
+  const notifier = {
+    mcpServer: mcpServer,
+    // sessionId is assigned lazily by index.js after transport connect, since
+    // the transport's sessionId isn't known until connect() runs.
+    sessionId: undefined,
+    subscriptions: subscriptions,
+    MAX_SUBSCRIPTIONS: MAX_SUBSCRIPTIONS,
+    watch: watch,
+    unwatch: unwatch,
+    closeAll: closeAll
+  };
+
+  /**
+   * Send an MCP logging notification for a terminal job packet down this
+   * session's SSE stream. The structured payload lives in `data` so a client
+   * that parses it programmatically still gets job_id/status/analysis_type; the
+   * human-readable summary is in `data.message`.
+   */
+  function sendNotification(packet, job_id, analysis_type) {
+    const isError = packet.type === "script error";
+    const type_label = analysis_type || "analysis";
+    let message, error;
+    if (isError) {
+      error = packet.error !== undefined ? String(packet.error) : "unknown error";
+      message =
+        "Analysis " + type_label + " job " + job_id + " failed: " + error;
+    } else {
+      message = "Analysis " + type_label + " job " + job_id + " completed";
+    }
+
+    const data = {
+      event: isError ? "job_failed" : "job_completed",
+      job_id: job_id,
+      analysis_type: analysis_type || null,
+      status: isError ? "error" : "completed",
+      message: message
+    };
+    if (isError) {
+      data.error = error;
+    }
+
+    // sendLoggingMessage can fail two ways on a torn-down transport, and BOTH
+    // happen in the 'client disconnects mid-job' race (the terminal redis
+    // message can arrive after the transport is gone but before/around
+    // closeAll): (1) it THROWS synchronously ("Not connected" when the SDK's
+    // _transport is falsy), and (2) transport.send can REJECT the returned
+    // promise. The try/catch only covers (1); we must also .catch the rejection
+    // so it doesn't surface as an unhandled promise rejection and crash/log.
+    try {
+      // sessionId is the 2nd arg — pass the per-session transport.sessionId so
+      // the SDK routes to the correct session's SSE stream.
+      const result = mcpServer.server.sendLoggingMessage(
+        {
+          level: isError ? "error" : "info",
+          logger: "datamonkey/job",
+          data: data
+        },
+        notifier.sessionId
+      );
+      Promise.resolve(result)
+        .then(function () {
+          logger.info(
+            "MCP job-notifier: sent " + data.event + " for job_id=" + job_id +
+              " session=" + (notifier.sessionId || "none")
+          );
+        })
+        .catch(function (err) {
+          logger.error(
+            "MCP job-notifier: sendLoggingMessage rejected for job_id=" +
+              job_id + ": " + err.message
+          );
+        });
+    } catch (err) {
+      logger.error(
+        "MCP job-notifier: sendLoggingMessage failed for job_id=" + job_id +
+          ": " + err.message
+      );
+    }
+  }
+
+  /**
+   * Subscribe to a job's redis channel and notify this session on completion.
+   * Idempotent per job_id; no-ops beyond MAX_SUBSCRIPTIONS. Never throws — a
+   * subscriber failure must not fail spawn_analysis (the job still runs and the
+   * client can poll get_job_status).
+   *
+   * @param {string} job_id
+   * @param {string} [analysis_type]
+   * @returns {Promise<void>}
+   */
+  function watch(job_id, analysis_type) {
+    if (!job_id) return Promise.resolve();
+
+    if (subscriptions.has(job_id)) {
+      // Already watching this job — don't double-subscribe.
+      return Promise.resolve();
+    }
+
+    if (subscriptions.size >= MAX_SUBSCRIPTIONS) {
+      logger.warn(
+        "MCP job-notifier: subscription cap (" + MAX_SUBSCRIPTIONS +
+          ") reached for session=" + (notifier.sessionId || "none") +
+          "; job_id=" + job_id + " will fall back to get_job_status polling"
+      );
+      return Promise.resolve();
+    }
+
+    // Store the entry SYNCHRONOUSLY (before the async connect) with a _closed
+    // guard, so a closeAll() racing the createSubscriber() connect tears the
+    // fresh subscriber down instead of leaking it. Mirrors clientsocket.js.
+    //   _notified  — set true synchronously the first time a terminal packet is
+    //                handled, so a duplicate terminal delivery (before the async
+    //                unsubscribe takes effect) can't fire the notification twice.
+    //   _toreDown  — set true once the real quit() chain has been initiated, so
+    //                teardownEntry is strictly idempotent (no double quit()).
+    //   ttlTimer   — hard-TTL reaper; cleared in teardownEntry.
+    const entry = {
+      subscriber: null,
+      channel: job_id,
+      _closed: false,
+      _notified: false,
+      _toreDown: false,
+      ttlTimer: null
+    };
+    subscriptions.set(job_id, entry);
+
+    // Bound the subscription's lifetime so a runner that dies without ever
+    // publishing a terminal packet can't pin this subscriber forever.
+    entry.ttlTimer = setTimeout(function () {
+      entry.ttlTimer = null;
+      if (subscriptions.get(job_id) === entry) {
+        logger.warn(
+          "MCP job-notifier: watch TTL expired for job_id=" + job_id +
+            " session=" + (notifier.sessionId || "none") +
+            "; tearing down (client should reconcile via get_job_status)"
+        );
+        unwatch(job_id);
+      }
+    }, WATCH_TTL_MS);
+    // Don't let the reaper timer keep the event loop alive.
+    if (entry.ttlTimer && typeof entry.ttlTimer.unref === "function") {
+      entry.ttlTimer.unref();
+    }
+
+    logger.info(
+      "MCP job-notifier: watching job_id=" + job_id +
+        " type=" + (analysis_type || "unknown") +
+        " session=" + (notifier.sessionId || "none")
+    );
+
+    return createSubscriber()
+      .then(function (subscriber) {
+        entry.subscriber = subscriber;
+
+        // If closeAll()/unwatch() already fired while we were connecting, tear
+        // the fresh connection down immediately instead of leaking it.
+        if (entry._closed) {
+          return teardownEntry(entry);
+        }
+
+        return subscriber.subscribe(job_id, function (message) {
+          let packet;
+          try {
+            packet = JSON.parse(message);
+          } catch (err) {
+            // A malformed publish must never crash the process. Drop it and
+            // keep the subscription alive (mirrors clientsocket.js guard).
+            logger.error(
+              "MCP job-notifier: bad pub/sub message on channel " + job_id +
+                ": " + err.message
+            );
+            return;
+          }
+
+          if (packet.type === "completed" || packet.type === "script error") {
+            // Fire EXACTLY ONCE per job. unsubscribe() below is async, so a
+            // second terminal packet delivered in the same batch (or before the
+            // unsubscribe takes effect) would otherwise re-enter here and notify
+            // again. Guard synchronously with a check-and-set on the entry so a
+            // duplicate delivery is a no-op regardless of unsubscribe latency.
+            const current = subscriptions.get(job_id);
+            if (!current || current._notified) return;
+            current._notified = true;
+            sendNotification(packet, job_id, analysis_type);
+            // Terminal — tear this subscriber down.
+            unwatch(job_id);
+          }
+          // Any other packet type (progress/status) is ignored here; the SSE
+          // notification vehicle is only for terminal events.
+        });
+      })
+      .catch(function (err) {
+        logger.error(
+          "MCP job-notifier: failed to subscribe job_id=" + job_id + ": " +
+            err.message
+        );
+        // Best-effort cleanup so a failed connect/subscribe leaves no phantom
+        // map entry, no pending TTL timer, and no orphaned subscriber (subscribe
+        // can reject after entry.subscriber was set). teardownEntry clears the
+        // timer and releases any connected socket idempotently.
+        subscriptions.delete(job_id);
+        return teardownEntry(entry);
+      });
+  }
+
+  /**
+   * Stop watching a job and tear its subscriber down. Idempotent.
+   * @param {string} job_id
+   * @returns {Promise<void>}
+   */
+  function unwatch(job_id) {
+    const entry = subscriptions.get(job_id);
+    if (!entry) return Promise.resolve();
+    subscriptions.delete(job_id);
+    return teardownEntry(entry);
+  }
+
+  /**
+   * Tear every watched subscriber down. Called from transport.onclose so a
+   * disconnecting client leaks nothing. Never throws.
+   * @returns {Promise<void>}
+   */
+  function closeAll() {
+    const entries = Array.from(subscriptions.values());
+    subscriptions.clear();
+    logger.info(
+      "MCP job-notifier: closeAll tearing down " + entries.length +
+        " subscription(s) for session=" + (notifier.sessionId || "none")
+    );
+    return Promise.all(
+      entries.map(function (entry) {
+        return teardownEntry(entry);
+      })
+    ).then(function () {}, function () {});
+  }
+
+  /**
+   * Unsubscribe + quit a single subscriber connection. redis@5 is
+   * promise-native; quit() resolves on graceful close, and we fall back to
+   * destroy() on error to force the socket shut (mirrors clientsocket.js
+   * _teardown).
+   *
+   * STRICTLY IDEMPOTENT. Two flags carry distinct meaning:
+   *   _closed    — "no further watching": set the moment teardown is requested,
+   *                so a closeAll() that races an in-flight createSubscriber()
+   *                connect flags the entry BEFORE the subscriber exists; the
+   *                connect .then then re-invokes teardownEntry to release the
+   *                now-connected socket. Because _closed alone does not prove a
+   *                quit already ran, it cannot be the idempotency guard.
+   *   _toreDown  — "the real quit() chain has been initiated": set exactly once,
+   *                the first time we actually have a subscriber to release. This
+   *                is what makes a double call issue exactly ONE quit(): the
+   *                second call sees _toreDown and returns, even if some future
+   *                caller re-populates entry.subscriber.
+   *
+   * Contract: teardownEntry called twice on a connected entry issues exactly one
+   * unsubscribe()+quit(). The 'connect resolved after close' path is expressed
+   * as (entry.subscriber && !entry._toreDown).
+   */
+  function teardownEntry(entry) {
+    entry._closed = true;
+
+    // Stop the TTL reaper regardless of which path tore the entry down.
+    if (entry.ttlTimer) {
+      clearTimeout(entry.ttlTimer);
+      entry.ttlTimer = null;
+    }
+
+    // Real quit already initiated — do not run it again (redis@5 quit() on an
+    // already-closing client rejects). This is the strict idempotency guard.
+    if (entry._toreDown) return Promise.resolve();
+
+    const subscriber = entry.subscriber;
+    entry.subscriber = null;
+    // No socket yet (connect still in flight): leave _toreDown false so the
+    // connect .then can re-enter and release the socket once it exists.
+    if (!subscriber) return Promise.resolve();
+
+    entry._toreDown = true;
+
+    return subscriber
+      .unsubscribe(entry.channel)
+      .then(function () {
+        return subscriber.quit();
+      })
+      .catch(function (err) {
+        logger.error(
+          "MCP job-notifier: error closing subscriber for channel " +
+            entry.channel + ": " + err.message
+        );
+        try {
+          subscriber.destroy();
+        } catch (e) {
+          logger.error(
+            "MCP job-notifier: error force-ending subscriber: " + e.message
+          );
+        }
+      });
+  }
+
+  return notifier;
+}
+
+exports.createJobNotifier = createJobNotifier;
+exports.MAX_SUBSCRIPTIONS = MAX_SUBSCRIPTIONS;

--- a/lib/mcp/tools.js
+++ b/lib/mcp/tools.js
@@ -9,8 +9,12 @@ const z = require("zod"),
  *
  * @param {import("@modelcontextprotocol/sdk/server/mcp.js").McpServer} mcpServer
  * @param {import("redis").RedisClient} redisClient
+ * @param {object} [notifier]  per-session job notifier (see lib/mcp/job-notifier.js).
+ *   When provided, spawn_analysis subscribes to the job's redis channel and
+ *   pushes an SSE completion notification to this session (#379). Optional —
+ *   when absent, jobs are tracked only via get_job_status polling.
  */
-function registerTools(mcpServer, redisClient) {
+function registerTools(mcpServer, redisClient, notifier) {
 
   // ── list_analyses ─────────────────────────────────────────────────
   mcpServer.tool(
@@ -200,6 +204,19 @@ function registerTools(mcpServer, redisClient) {
         );
 
         logger.info("MCP spawn_analysis: spawned job_id=" + jobId + " type=" + args.analysis_type);
+
+        // Subscribe this session to the job's redis channel so it receives an
+        // SSE completion/failure notification when the job finishes (#379).
+        // Best-effort: a subscriber failure must never fail the spawn — the job
+        // still runs and the client can poll get_job_status.
+        if (notifier) {
+          try {
+            notifier.watch(jobId, args.analysis_type);
+          } catch (watchErr) {
+            logger.error("MCP spawn_analysis: notifier.watch failed for job_id=" +
+              jobId + ": " + watchErr.message);
+          }
+        }
 
         const response = { job_id: jobId, analysis_type: args.analysis_type };
         if (warnings.length > 0) {
@@ -422,6 +439,19 @@ function registerTools(mcpServer, redisClient) {
 
         await redisClient.hSet(args.job_id, "status", "aborted");
         await redisClient.lRem("active_jobs", 1, args.job_id);
+
+        // A cancelled job never publishes a terminal packet on its redis
+        // channel, so the #379 completion watcher would otherwise pin a
+        // subscriber for the life of the session. Tear it down explicitly.
+        // Best-effort — unwatch is idempotent and must never fail the cancel.
+        if (notifier) {
+          try {
+            notifier.unwatch(args.job_id);
+          } catch (unwatchErr) {
+            logger.error("MCP cancel_job: notifier.unwatch failed for job_id=" +
+              args.job_id + ": " + unwatchErr.message);
+          }
+        }
 
         logger.info("MCP cancel_job: job_id=" + args.job_id + " cancelled (torque_id=" + torqueId + ")");
         return {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:analyses": "mocha -R spec --exit test/absrel/absrel.js test/busted/busted.js test/contrast-fel/contrast-fel.js test/fade/fade.js test/fubar/fubar.js test/gard/gard.js test/hivtrace/hivtrace.js test/meme/meme.js test/multihit/multihit.js test/prime/prime.js test/relax/relax.js test/slac/slac.js",
     "test:slurm-unit": "mocha -R spec --exit test/jobstatus.js test/jobqueue.js test/coverage-gaps/job-lifecycle.js test/coverage-gaps/hivtrace-checkjob.js",
     "test:integration": "mocha -R spec --exit test/integration/slac-completes.js",
-    "test:mcp": "mocha -R spec --exit test/mcp/mcp.test.js test/mcp/oauth-redirect.test.js",
+    "test:mcp": "mocha -R spec --exit test/mcp/mcp.test.js test/mcp/oauth-redirect.test.js test/mcp/job-notifier.test.js test/mcp/sse-notifications.test.js",
     "test-mcp": "npm run test:mcp",
     "lint": "eslint app lib server.js",
     "format:check": "prettier --check \"app/**/*.js\" \"lib/**/*.js\" server.js",

--- a/test/mcp/job-notifier.test.js
+++ b/test/mcp/job-notifier.test.js
@@ -1,0 +1,199 @@
+/**
+ * Live-redis pub/sub tests for lib/mcp/job-notifier.js (issue #379).
+ *
+ * These mirror the live-PUBSUB regression discipline already used by
+ * lib/redis-client.js / lib/clientsocket.js: they exercise the real redis
+ * connection (createSubscriber) rather than mocking it, because the whole point
+ * of the notifier is the subscribe -> notify -> unsubscribe/quit lifecycle. A
+ * spy McpServer records sendLoggingMessage calls so we can assert the
+ * notification shape without a real MCP client.
+ *
+ * The tests are gated on redis being reachable; if the shared client can't
+ * connect they skip rather than fail (matching the other integration-ish tests).
+ */
+
+const chai = require("chai");
+const expect = chai.expect;
+
+const { createJobNotifier, MAX_SUBSCRIPTIONS } = require("../../lib/mcp/job-notifier");
+const redisClient = require("../../lib/redis-client");
+
+// Build a spy McpServer exposing server.sendLoggingMessage(params, sessionId).
+function makeSpyServer() {
+  const calls = [];
+  return {
+    calls: calls,
+    server: {
+      sendLoggingMessage: function (params, sessionId) {
+        calls.push({ params: params, sessionId: sessionId });
+      }
+    }
+  };
+}
+
+// Poll a predicate until it's true or we time out.
+function waitFor(pred, timeoutMs) {
+  const deadline = Date.now() + (timeoutMs || 2000);
+  return new Promise(function (resolve, reject) {
+    (function poll() {
+      let ok = false;
+      try {
+        ok = pred();
+      } catch (e) {
+        ok = false;
+      }
+      if (ok) return resolve();
+      if (Date.now() > deadline) return reject(new Error("timeout waiting for condition"));
+      setTimeout(poll, 15);
+    })();
+  });
+}
+
+describe("MCP job-notifier (#379)", function () {
+  this.timeout(15000);
+
+  let redisAvailable = false;
+
+  before(async function () {
+    try {
+      await redisClient.ready;
+      // A cheap round-trip to confirm the socket is really up.
+      await redisClient.client.ping();
+      redisAvailable = true;
+    } catch (e) {
+      redisAvailable = false;
+    }
+  });
+
+  beforeEach(function () {
+    if (!redisAvailable) this.skip();
+  });
+
+  it("fires an info notification and unsubscribes on completion", async function () {
+    const spy = makeSpyServer();
+    const notifier = createJobNotifier(spy);
+    notifier.sessionId = "s1";
+
+    const jobId = "test-job-379-complete-" + Date.now();
+    await notifier.watch(jobId, "fel");
+
+    // Give the subscribe a beat to attach, then publish a completion packet.
+    await waitFor(function () { return notifier.subscriptions.get(jobId) && notifier.subscriptions.get(jobId).subscriber; }, 3000);
+    await redisClient.client.publish(jobId, JSON.stringify({ type: "completed" }));
+
+    await waitFor(function () { return spy.calls.length === 1; }, 3000);
+
+    const call = spy.calls[0];
+    expect(call.sessionId).to.equal("s1");
+    expect(call.params.level).to.equal("info");
+    expect(call.params.logger).to.equal("datamonkey/job");
+    expect(call.params.data.event).to.equal("job_completed");
+    expect(call.params.data.job_id).to.equal(jobId);
+    expect(call.params.data.analysis_type).to.equal("fel");
+    expect(call.params.data.status).to.equal("completed");
+
+    // Unsubscribed after firing.
+    expect(notifier.subscriptions.size).to.equal(0);
+
+    // A subsequent publish must NOT fire again (we unsubscribed).
+    await redisClient.client.publish(jobId, JSON.stringify({ type: "completed" }));
+    await new Promise(function (r) { setTimeout(r, 150); });
+    expect(spy.calls.length).to.equal(1);
+  });
+
+  it("fires an error notification with the error string and unsubscribes", async function () {
+    const spy = makeSpyServer();
+    const notifier = createJobNotifier(spy);
+    notifier.sessionId = "s2";
+
+    const jobId = "test-job-379-error-" + Date.now();
+    await notifier.watch(jobId, "busted");
+    await waitFor(function () { return notifier.subscriptions.get(jobId) && notifier.subscriptions.get(jobId).subscriber; }, 3000);
+
+    await redisClient.client.publish(jobId, JSON.stringify({ type: "script error", error: "boom" }));
+    await waitFor(function () { return spy.calls.length === 1; }, 3000);
+
+    const call = spy.calls[0];
+    expect(call.params.level).to.equal("error");
+    expect(call.params.data.event).to.equal("job_failed");
+    expect(call.params.data.status).to.equal("error");
+    expect(call.params.data.error).to.equal("boom");
+    expect(notifier.subscriptions.size).to.equal(0);
+  });
+
+  it("drops a malformed pub/sub message without throwing or firing", async function () {
+    const spy = makeSpyServer();
+    const notifier = createJobNotifier(spy);
+    notifier.sessionId = "s3";
+
+    const jobId = "test-job-379-malformed-" + Date.now();
+    await notifier.watch(jobId, "meme");
+    await waitFor(function () { return notifier.subscriptions.get(jobId) && notifier.subscriptions.get(jobId).subscriber; }, 3000);
+
+    await redisClient.client.publish(jobId, "this is not json {");
+    await new Promise(function (r) { setTimeout(r, 200); });
+
+    // No notification, still subscribed (message dropped, not fatal).
+    expect(spy.calls.length).to.equal(0);
+    expect(notifier.subscriptions.size).to.equal(1);
+
+    await notifier.closeAll();
+  });
+
+  it("closeAll tears down every subscriber (transport.onclose leak guard)", async function () {
+    const spy = makeSpyServer();
+    const notifier = createJobNotifier(spy);
+    notifier.sessionId = "s4";
+
+    const jobId = "test-job-379-closeall-" + Date.now();
+    await notifier.watch(jobId, "slac");
+    await waitFor(function () { return notifier.subscriptions.get(jobId) && notifier.subscriptions.get(jobId).subscriber; }, 3000);
+
+    await notifier.closeAll();
+    expect(notifier.subscriptions.size).to.equal(0);
+
+    // A later publish fires nothing.
+    await redisClient.client.publish(jobId, JSON.stringify({ type: "completed" }));
+    await new Promise(function (r) { setTimeout(r, 150); });
+    expect(spy.calls.length).to.equal(0);
+  });
+
+  it("caps concurrent subscriptions per session", async function () {
+    const spy = makeSpyServer();
+    const notifier = createJobNotifier(spy);
+    notifier.sessionId = "s5";
+
+    const stamp = Date.now();
+    const watches = [];
+    for (let i = 0; i < MAX_SUBSCRIPTIONS + 5; i++) {
+      watches.push(notifier.watch("test-job-379-cap-" + stamp + "-" + i, "fel"));
+    }
+    await Promise.all(watches);
+
+    // At most the cap; the surplus was refused (no-op).
+    expect(notifier.subscriptions.size).to.equal(MAX_SUBSCRIPTIONS);
+
+    await notifier.closeAll();
+    expect(notifier.subscriptions.size).to.equal(0);
+  });
+
+  it("does not leak when closeAll races an in-flight watch() connect", async function () {
+    const spy = makeSpyServer();
+    const notifier = createJobNotifier(spy);
+    notifier.sessionId = "s6";
+
+    const jobId = "test-job-379-race-" + Date.now();
+    // Do NOT await watch — call closeAll synchronously before the subscriber
+    // connect resolves, exercising the _closed-flag race path.
+    const watchPromise = notifier.watch(jobId, "fel");
+    await notifier.closeAll();
+    await watchPromise;
+
+    // The racing connect must have torn itself down; nothing left in the map.
+    expect(notifier.subscriptions.size).to.equal(0);
+
+    await redisClient.client.publish(jobId, JSON.stringify({ type: "completed" }));
+    await new Promise(function (r) { setTimeout(r, 150); });
+    expect(spy.calls.length).to.equal(0);
+  });
+});

--- a/test/mcp/sse-notifications.test.js
+++ b/test/mcp/sse-notifications.test.js
@@ -1,0 +1,270 @@
+/**
+ * SSE job-completion notification SEAM tests (issue #379).
+ *
+ * WHY THIS FILE EXISTS (vs test/mcp/job-notifier.test.js)
+ * ------------------------------------------------------
+ * job-notifier.test.js drives the notifier module DIRECTLY (watch/unwatch/
+ * closeAll). This file instead exercises the WIRING SEAM the way production
+ * does it: it constructs a real per-session notifier, hands it to
+ * registerTools() (exactly as lib/mcp/index.js:createMcpServer does), and then
+ * proves that:
+ *
+ *   1. spawn_analysis subscribes the session to the job's redis channel, so a
+ *      {type:"completed"} packet PUBLISHED to that job_id channel routes an MCP
+ *      logging notification to the right session — with the right job_id/status
+ *      — and then the subscriber is unsubscribed (no leak).
+ *   2. cancel_job unwatches (a cancelled job never publishes a terminal packet,
+ *      so the seam must proactively tear the subscriber down).
+ *   3. transport.onclose semantics (notifier.closeAll) tear down EVERY watched
+ *      subscriber for the session, so a client that disconnects mid-job leaks
+ *      nothing.
+ *
+ * These run against LIVE redis (config = test/fixtures/config.ci.json copied to
+ * config.json by the test:mcp / test:ci harness). If redis is unreachable the
+ * tests skip rather than fail, matching the other integration-ish MCP suites.
+ *
+ * spawn_analysis is stubbed at the spawnHelpers seam so we never touch SLURM or
+ * the filesystem — only the notifier subscribe/publish/teardown lifecycle is
+ * under test.
+ */
+
+const chai = require("chai");
+const expect = chai.expect;
+
+const spawnHelpers = require("../../lib/mcp/spawn-helpers");
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+const { registerTools } = require("../../lib/mcp/tools");
+const { createJobNotifier } = require("../../lib/mcp/job-notifier");
+const jobdel = require("../../lib/jobdel");
+const redisClient = require("../../lib/redis-client");
+
+// Invoke a registered MCP tool by name (same helper style as mcp.test.js).
+async function callTool(mcpServer, name, args) {
+  var tool = mcpServer._registeredTools[name];
+  if (!tool) throw new Error("Tool not registered: " + name);
+  return tool.handler(args || {});
+}
+
+// Poll a predicate until true or timeout.
+function waitFor(pred, timeoutMs) {
+  const deadline = Date.now() + (timeoutMs || 3000);
+  return new Promise(function (resolve, reject) {
+    (function poll() {
+      let ok = false;
+      try {
+        ok = pred();
+      } catch (e) {
+        ok = false;
+      }
+      if (ok) return resolve();
+      if (Date.now() > deadline) return reject(new Error("timeout waiting for condition"));
+      setTimeout(poll, 15);
+    })();
+  });
+}
+
+describe("MCP SSE job-completion notifications – seam (#379)", function () {
+  this.timeout(15000);
+
+  var redisAvailable = false;
+
+  // A spy McpServer whose server.sendLoggingMessage records calls, so we can
+  // assert the notification shape without a real MCP client. We still register
+  // the REAL tools against it so spawn_analysis/cancel_job drive the real
+  // notifier.watch/unwatch wiring.
+  function makeSpyServer() {
+    var mcp = new McpServer(
+      { name: "test", version: "1.0.0" },
+      { capabilities: { tools: {}, logging: {} } }
+    );
+    mcp._sseCalls = [];
+    // Override the seam the notifier uses to push SSE notifications.
+    mcp.server.sendLoggingMessage = function (params, sessionId) {
+      mcp._sseCalls.push({ params: params, sessionId: sessionId });
+      return Promise.resolve();
+    };
+    return mcp;
+  }
+
+  // Stub spawnAnalysis so no SLURM/filesystem work happens; return a unique id.
+  var originalSpawnAnalysis;
+  before(async function () {
+    try {
+      await redisClient.ready;
+      await redisClient.client.ping();
+      redisAvailable = true;
+    } catch (e) {
+      redisAvailable = false;
+    }
+
+    originalSpawnAnalysis = spawnHelpers.spawnAnalysis;
+    spawnHelpers.spawnAnalysis = function (type) {
+      if (!spawnHelpers.analysisMap[type]) {
+        throw new Error("Unknown analysis type: " + type);
+      }
+      // Unique per call so parallel-ish tests never collide on a channel.
+      return "sse-seam-job-" + process.pid + "-" + Date.now() + "-" +
+        Math.floor(Math.random() * 1e6);
+    };
+  });
+
+  after(function () {
+    spawnHelpers.spawnAnalysis = originalSpawnAnalysis;
+  });
+
+  beforeEach(function () {
+    if (!redisAvailable) this.skip();
+  });
+
+  it("spawn_analysis subscribes; a published {type:completed} fires the SSE notification and unsubscribes (no leak)", async function () {
+    var mcp = makeSpyServer();
+    var notifier = createJobNotifier(mcp);
+    notifier.sessionId = "seam-session-1";
+    registerTools(mcp, redisClient.client, notifier);
+
+    var result = await callTool(mcp, "spawn_analysis", {
+      analysis_type: "fel",
+      alignment: ">seq1\nATGATGATG\n>seq2\nATGCTGATG\n"
+    });
+    expect(result.isError).to.not.be.true;
+    var jobId = JSON.parse(result.content[0].text).job_id;
+    expect(jobId).to.be.a("string").with.length.above(0);
+
+    // Wait for the async subscribe to actually attach before publishing.
+    await waitFor(function () {
+      var e = notifier.subscriptions.get(jobId);
+      return e && e.subscriber;
+    }, 4000);
+
+    await redisClient.client.publish(jobId, JSON.stringify({ type: "completed" }));
+
+    // The notification should route through sendLoggingMessage exactly once.
+    await waitFor(function () { return mcp._sseCalls.length === 1; }, 4000);
+
+    var call = mcp._sseCalls[0];
+    expect(call.sessionId).to.equal("seam-session-1");
+    expect(call.params.level).to.equal("info");
+    expect(call.params.data.event).to.equal("job_completed");
+    expect(call.params.data.job_id).to.equal(jobId);
+    expect(call.params.data.status).to.equal("completed");
+    expect(call.params.data.analysis_type).to.equal("fel");
+
+    // Subscriber torn down after firing — no leak.
+    expect(notifier.subscriptions.size).to.equal(0);
+
+    // A second publish must NOT fire again (we unsubscribed).
+    await redisClient.client.publish(jobId, JSON.stringify({ type: "completed" }));
+    await new Promise(function (r) { setTimeout(r, 150); });
+    expect(mcp._sseCalls.length).to.equal(1);
+  });
+
+  it("a published {type:'script error'} routes an error notification with the error string", async function () {
+    var mcp = makeSpyServer();
+    var notifier = createJobNotifier(mcp);
+    notifier.sessionId = "seam-session-err";
+    registerTools(mcp, redisClient.client, notifier);
+
+    var result = await callTool(mcp, "spawn_analysis", {
+      analysis_type: "busted",
+      alignment: ">seq1\nATGATGATG\n>seq2\nATGCTGATG\n"
+    });
+    var jobId = JSON.parse(result.content[0].text).job_id;
+
+    await waitFor(function () {
+      var e = notifier.subscriptions.get(jobId);
+      return e && e.subscriber;
+    }, 4000);
+
+    await redisClient.client.publish(
+      jobId,
+      JSON.stringify({ type: "script error", error: "kaboom" })
+    );
+    await waitFor(function () { return mcp._sseCalls.length === 1; }, 4000);
+
+    var call = mcp._sseCalls[0];
+    expect(call.params.level).to.equal("error");
+    expect(call.params.data.event).to.equal("job_failed");
+    expect(call.params.data.status).to.equal("error");
+    expect(call.params.data.error).to.equal("kaboom");
+    expect(notifier.subscriptions.size).to.equal(0);
+  });
+
+  it("cancel_job unwatches the job (cancelled jobs never publish a terminal packet)", async function () {
+    var mcp = makeSpyServer();
+    var notifier = createJobNotifier(mcp);
+    notifier.sessionId = "seam-session-cancel";
+    registerTools(mcp, redisClient.client, notifier);
+
+    // Spawn to get a watched job_id.
+    var result = await callTool(mcp, "spawn_analysis", {
+      analysis_type: "fel",
+      alignment: ">seq1\nATGATGATG\n>seq2\nATGCTGATG\n"
+    });
+    var jobId = JSON.parse(result.content[0].text).job_id;
+
+    await waitFor(function () {
+      var e = notifier.subscriptions.get(jobId);
+      return e && e.subscriber;
+    }, 4000);
+    expect(notifier.subscriptions.size).to.equal(1);
+
+    // Drive the REAL cancel path (running job + valid torque_id) — that is the
+    // branch that calls notifier.unwatch(). The "already aborted/completed"
+    // short-circuits return before the unwatch, so they don't exercise the seam.
+    // Stub jobdel.jobDelete so we never touch the real scheduler, exactly the
+    // way mcp.test.js stubs spawnHelpers.spawnAnalysis.
+    var originalJobDelete = jobdel.jobDelete;
+    jobdel.jobDelete = function (torqueId, cb) { cb(null); };
+    await redisClient.client.hSet(jobId, {
+      status: "running",
+      torque_id: JSON.stringify({ torque_id: "12345.scheduler" })
+    });
+    try {
+      var cancel = await callTool(mcp, "cancel_job", { job_id: jobId });
+      expect(cancel.isError).to.not.be.true;
+      expect(JSON.parse(cancel.content[0].text).success).to.be.true;
+
+      // The seam must have unwatched the job so no subscriber leaks.
+      await waitFor(function () { return notifier.subscriptions.size === 0; }, 3000);
+      expect(notifier.subscriptions.size).to.equal(0);
+    } finally {
+      jobdel.jobDelete = originalJobDelete;
+      try { await redisClient.client.del(jobId); } catch (e) { /* best effort */ }
+    }
+  });
+
+  it("transport.onclose (closeAll) tears down every watched subscriber for the session", async function () {
+    var mcp = makeSpyServer();
+    var notifier = createJobNotifier(mcp);
+    notifier.sessionId = "seam-session-close";
+    registerTools(mcp, redisClient.client, notifier);
+
+    // Spawn three jobs; all three should be watched concurrently.
+    var jobIds = [];
+    for (var i = 0; i < 3; i++) {
+      var r = await callTool(mcp, "spawn_analysis", {
+        analysis_type: "fel",
+        alignment: ">seq1\nATGATGATG\n>seq2\nATGCTGATG\n"
+      });
+      jobIds.push(JSON.parse(r.content[0].text).job_id);
+    }
+
+    await waitFor(function () {
+      if (notifier.subscriptions.size !== 3) return false;
+      return jobIds.every(function (id) {
+        var e = notifier.subscriptions.get(id);
+        return e && e.subscriber;
+      });
+    }, 5000);
+    expect(notifier.subscriptions.size).to.equal(3);
+
+    // Simulate transport.onclose -> teardownSession -> notifier.closeAll().
+    await notifier.closeAll();
+    expect(notifier.subscriptions.size).to.equal(0);
+
+    // A post-close publish to any of the channels must fire nothing.
+    await redisClient.client.publish(jobIds[0], JSON.stringify({ type: "completed" }));
+    await new Promise(function (r) { setTimeout(r, 150); });
+    expect(mcp._sseCalls.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
Closes #379. MCP clients that call `spawn_analysis` no longer have to poll `get_job_status` in a loop — the server pushes a completion notification down the session's SSE stream when a job finishes or errors. **Additive**: polling is untouched and remains the source of truth for clients that don't consume SSE.

## How it works
The job runner already publishes a terminal packet on the Redis channel named by the job id (`finalizeCompletion` → `{type:"completed"}`, `onError` → `{type:"script error"}`). A new **per-session notifier** (`lib/mcp/job-notifier.js`) subscribes to that channel when `spawn_analysis` returns a `job_id`, and on a terminal packet sends an MCP logging notification (`notifications/message`) via that session's `McpServer` — routed to the right SSE stream — then unsubscribes.

**Vehicle: `sendLoggingMessage`** — the only notification a generic MCP client (Claude, Claude Code) actually surfaces to a human today. Custom notification methods are silently dropped by clients without a handler; `resources/updated` isn't auto-surfaced. Structured payload lives in `params.data` (`event`/`job_id`/`status`/`analysis_type`) for programmatic clients. Requires the `logging` capability, now declared in `createMcpServer()`.

## Lifecycle discipline (the leak surface prior battle-tests kept flagging)
Every subscription is torn down on **both** the terminal notification firing **and** session close. **Three disconnect triggers wired:**
- `transport.onclose` on the new- and stale-session paths (the SDK fires it only on explicit `DELETE /mcp`)
- **`res.on("close")` on the GET SSE stream** — the network-drop / closed-tab case the SDK never routes to `onclose` (without this, a client dropping mid-job leaks a redis connection)
- `teardownSession` is idempotent across all three

Plus: `_closed` race guard (closeAll racing the async `createSubscriber` connect), `_notified` once-guard (a duplicate terminal packet can't notify twice — the exact BT4/BT5 lesson), `_toreDown` idempotency (double teardown = one `quit()`), `MAX_SUBSCRIPTIONS=25` cap, a 24h TTL reaper (a runner that dies without publishing can't pin a subscriber), and guarded `JSON.parse` of pub/sub messages. `cancel_job` calls `notifier.unwatch` (a cancelled job never publishes a terminal packet).

**Best-effort by design:** no eventStore on the transport, and redis pub/sub has no retention, so a completion that races the SSE connect can be missed — documented; clients reconcile via `get_job_status`. Doesn't hang the client.

## hivtrace
`onComplete` now publishes a minimal `{type:"completed"}` marker on the job channel (it delivers full results over the socket and previously published nothing), so the SSE subscriber gets a trigger. Browser path unchanged.

## Verification
- `test/mcp/job-notifier.test.js` (module lifecycle) + `test/mcp/sse-notifications.test.js` (tools→notifier wiring, completion + error notify, `cancel_job` unwatch, `onclose` teardown), both against **live redis**. Wired into `test:mcp`.
- **test:mcp 75/0** (58 + 7 OAuth + 6 notifier + 4 seam), **test:ci 126/0**.
- End-to-end live-redis smoke: watch → publish `{type:"completed"}` → notification routed to the correct session + auto-unsubscribe; `closeAll` teardown to 0 subscribers.

Adversarially reviewed for leaks/races (a dedicated review phase caught and fixed real lifecycle bugs: the SSE-drop teardown gap, the cancel_job leak, an unhandled `sendLoggingMessage` rejection, and the duplicate-notify once-guard).