### PR TITLE
chore: Resolve QC-review residual nits (MCP DRY + OAuth store sweep + log levels)

### DIFF
--- a/lib/mcp/index.js
+++ b/lib/mcp/index.js
@@ -13,6 +13,13 @@ const registerResources = require("./resources").registerResources;
 const createJobNotifier = require("./job-notifier").createJobNotifier;
 const pkg = require(path.join(__dirname, "../../package.json"));
 
+// OAuth token lifetimes + the interval at which the in-memory OAuth stores are
+// swept of expired entries (they would otherwise grow unbounded for the process
+// lifetime). Access-token TTL matches the advertised expires_in (1h).
+const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // 1h
+const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30d
+const OAUTH_SWEEP_INTERVAL_MS = 10 * 60 * 1000; // 10m
+
 // Out-of-band redirect URI for headless clients (SSH boxes where an
 // http://localhost callback isn't reachable from the user's browser). The
 // code is rendered as an HTML copy-paste page instead of being 302-redirected.
@@ -133,6 +140,34 @@ function startMcpServer(config, redisClient) {
   const clients = {};
   const authCodes = {};
   const tokens = {};
+
+  // Periodically reap expired authorization codes and tokens so these in-memory
+  // stores don't grow unbounded for the process lifetime. authCodes and tokens
+  // carry an `expires` timestamp; anything past it is dropped. `clients` (from
+  // dynamic registration) is intentionally not swept — a registered client is
+  // long-lived and small. unref'd so the timer never keeps the process alive.
+  const oauthSweep = setInterval(function () {
+    const now = Date.now();
+    let reaped = 0;
+    for (const code in authCodes) {
+      if (authCodes[code] && authCodes[code].expires < now) {
+        delete authCodes[code];
+        reaped++;
+      }
+    }
+    for (const tok in tokens) {
+      if (tokens[tok] && tokens[tok].expires && tokens[tok].expires < now) {
+        delete tokens[tok];
+        reaped++;
+      }
+    }
+    if (reaped > 0) {
+      logger.info("MCP OAuth sweep: reaped " + reaped + " expired code(s)/token(s)");
+    }
+  }, OAUTH_SWEEP_INTERVAL_MS);
+  if (oauthSweep && typeof oauthSweep.unref === "function") {
+    oauthSweep.unref();
+  }
 
   // OAuth Discovery — server metadata
   app.get("/.well-known/oauth-authorization-server", function (req, res) {
@@ -331,8 +366,11 @@ function startMcpServer(config, redisClient) {
 
       const accessToken = crypto.randomUUID();
       const refreshToken = crypto.randomUUID();
-      tokens[accessToken] = { type: "access", client_id: stored.client_id, resource: tokenResource };
-      tokens[refreshToken] = { type: "refresh", client_id: stored.client_id, resource: tokenResource };
+      // Stamp expiries so the periodic sweep can reap them (bounds memory) and
+      // so an expired access token is actually rejected. Access matches the
+      // advertised expires_in (1h); refresh lives long enough to refresh (30d).
+      tokens[accessToken] = { type: "access", client_id: stored.client_id, resource: tokenResource, expires: Date.now() + ACCESS_TOKEN_TTL_MS };
+      tokens[refreshToken] = { type: "refresh", client_id: stored.client_id, resource: tokenResource, expires: Date.now() + REFRESH_TOKEN_TTL_MS };
 
       logger.info("MCP OAuth token: issued access_token for clientId=" + stored.client_id);
       res.json({
@@ -351,7 +389,7 @@ function startMcpServer(config, redisClient) {
       }
 
       const newAccessToken = crypto.randomUUID();
-      tokens[newAccessToken] = { type: "access", client_id: tokens[rt].client_id, resource: tokens[rt].resource };
+      tokens[newAccessToken] = { type: "access", client_id: tokens[rt].client_id, resource: tokens[rt].resource, expires: Date.now() + ACCESS_TOKEN_TTL_MS };
 
       logger.info("MCP OAuth token: refreshed access_token for clientId=" + tokens[rt].client_id);
       res.json({
@@ -390,7 +428,13 @@ function startMcpServer(config, redisClient) {
 
     const token = authHeader.substring(7);
     const tokenRecord = tokens[token];
-    if (!tokenRecord || tokenRecord.type !== "access") {
+    // Reject a missing, wrong-type, or EXPIRED access token. Expiry makes the
+    // "invalid or expired token" message honest and lets the sweep reap it.
+    if (!tokenRecord || tokenRecord.type !== "access" ||
+        (tokenRecord.expires && tokenRecord.expires < Date.now())) {
+      if (tokenRecord && tokenRecord.expires && tokenRecord.expires < Date.now()) {
+        delete tokens[token];
+      }
       res.set("WWW-Authenticate", 'Bearer resource_metadata="' + issuer + '/.well-known/oauth-protected-resource/mcp"');
       return res.status(401).json({
         jsonrpc: "2.0",
@@ -451,6 +495,52 @@ function startMcpServer(config, redisClient) {
     }
   }
 
+  /**
+   * Create a fresh McpServer + notifier for a transport, wire the idempotent
+   * teardownSession onclose handler, connect, and hand the assigned sessionId to
+   * the notifier. Shared by both POST /mcp branches (brand-new session and
+   * replacement-for-stale-session) so the two paths cannot drift. The caller
+   * still owns the differing bits: the stale path strips the mcp-session-id
+   * header before handleRequest, and each caller invokes handleRequest + then
+   * storeSession(transport, notifier) itself (session id is only known after
+   * connect/handleRequest).
+   *
+   * @param {object} transport  a fresh StreamableHTTPServerTransport
+   * @returns {Promise<{notifier: object}>}
+   */
+  async function setupSession(transport) {
+    const created = createMcpServer();
+    const mcpServer = created.server;
+    const notifier = created.notifier;
+
+    // transport.onclose fires only on explicit DELETE /mcp (SDK behavior); the
+    // common network-drop / closed-tab disconnect is caught by the GET SSE
+    // stream 'close' handler. Both funnel through the idempotent teardownSession.
+    transport.onclose = function () {
+      logger.info("MCP session closed (onclose): " + transport.sessionId);
+      teardownSession(transport.sessionId, "onclose");
+    };
+
+    await mcpServer.connect(transport);
+    // sessionId is assigned during connect — hand it to the notifier so its
+    // sendLoggingMessage calls route to this exact session's SSE stream.
+    notifier.sessionId = transport.sessionId;
+    logger.info("MCP POST: McpServer connected, transport.sessionId=" + transport.sessionId);
+    return { notifier: notifier };
+  }
+
+  // Store a connected session (after handleRequest assigned its sessionId).
+  function storeSession(transport, notifier, label) {
+    if (transport.sessionId) {
+      transports[transport.sessionId] = transport;
+      notifiers[transport.sessionId] = notifier;
+      logger.info("MCP POST: " + label + " session stored: " + transport.sessionId +
+        " totalSessions=" + Object.keys(transports).length);
+    } else {
+      logger.warn("MCP POST: " + label + " transport.sessionId still undefined after handleRequest — not storing");
+    }
+  }
+
   // POST /mcp — JSON-RPC requests (initialize, tool calls, etc.)
   app.post("/mcp", async function (req, res) {
     try {
@@ -462,14 +552,17 @@ function startMcpServer(config, redisClient) {
 
       logger.info("MCP POST: method=" + method + " rpcId=" + rpcId +
         " sessionId=" + (sessionId || "none") + " activeSessions=" + activeSessions);
-      logger.info("MCP POST: request headers: " + JSON.stringify({
+      // Full header/body/session dumps are debug-only: they're high-volume and
+      // the body can contain sensitive params (alignments, tokens). The info
+      // line above carries the useful per-request summary.
+      logger.debug("MCP POST: request headers: " + JSON.stringify({
         "mcp-session-id": req.headers["mcp-session-id"] || "not set",
         "content-type": req.headers["content-type"] || "not set",
         "accept": req.headers["accept"] || "not set",
         "user-agent": req.headers["user-agent"] || "not set"
       }));
-      logger.info("MCP POST: request body: " + JSON.stringify(req.body));
-      logger.info("MCP POST: known session IDs: [" + activeSessionIds.join(", ") + "]");
+      logger.debug("MCP POST: request body: " + JSON.stringify(req.body));
+      logger.debug("MCP POST: known session IDs: [" + activeSessionIds.join(", ") + "]");
 
       if (sessionId && transports[sessionId]) {
         // Existing session — reuse transport
@@ -487,36 +580,11 @@ function startMcpServer(config, redisClient) {
         });
         logger.info("MCP POST: new transport created, sessionId=" + transport.sessionId);
 
-        const created = createMcpServer();
-        const mcpServer = created.server;
-        const notifier = created.notifier;
-
-        // transport.onclose fires only on explicit DELETE /mcp (SDK behavior).
-        // The common network-drop / closed-tab disconnect is handled by the GET
-        // SSE stream 'close' handler instead; both funnel through the idempotent
-        // teardownSession().
-        transport.onclose = function () {
-          logger.info("MCP session closed (onclose): " + transport.sessionId);
-          teardownSession(transport.sessionId, "onclose");
-        };
-
-        logger.info("MCP POST: new McpServer created, connecting to transport...");
-        await mcpServer.connect(transport);
-        // sessionId is assigned during connect — hand it to the notifier so its
-        // sendLoggingMessage calls route to this exact session's SSE stream.
-        notifier.sessionId = transport.sessionId;
-        logger.info("MCP POST: McpServer connected, transport.sessionId=" + transport.sessionId);
+        const { notifier } = await setupSession(transport);
         await transport.handleRequest(req, res, req.body);
         logger.info("MCP POST: handleRequest completed, transport.sessionId=" + transport.sessionId +
           " statusCode=" + res.statusCode + " headersSent=" + res.headersSent);
-        if (transport.sessionId) {
-          transports[transport.sessionId] = transport;
-          notifiers[transport.sessionId] = notifier;
-          logger.info("MCP POST: session stored: " + transport.sessionId +
-            " totalSessions=" + Object.keys(transports).length);
-        } else {
-          logger.warn("MCP POST: transport.sessionId still undefined after handleRequest — not storing");
-        }
+        storeSession(transport, notifier, "new");
       } else {
         // Unknown session ID — create a fresh session instead of rejecting.
         // This handles reconnects after server restarts or session expiry.
@@ -531,36 +599,16 @@ function startMcpServer(config, redisClient) {
         });
         logger.info("MCP POST: replacement transport created, new sessionId=" + transport.sessionId);
 
-        const created = createMcpServer();
-        const mcpServer = created.server;
-        const notifier = created.notifier;
+        const { notifier } = await setupSession(transport);
 
-        transport.onclose = function () {
-          logger.info("MCP session closed (onclose): " + transport.sessionId);
-          teardownSession(transport.sessionId, "onclose");
-        };
-
-        logger.info("MCP POST: replacement McpServer created, connecting to transport...");
-        await mcpServer.connect(transport);
-        notifier.sessionId = transport.sessionId;
-        logger.info("MCP POST: replacement McpServer connected, transport.sessionId=" + transport.sessionId);
-
+        // The only bit that differs from the new-session path: strip the stale
+        // mcp-session-id header so the SDK treats this as a fresh initialize.
         logger.info("MCP POST: stripping stale mcp-session-id header (was: " + req.headers["mcp-session-id"] + ")");
         delete req.headers["mcp-session-id"];
-        logger.info("MCP POST: mcp-session-id header after delete: " + (req.headers["mcp-session-id"] || "undefined (good)"));
-        logger.info("MCP POST: calling handleRequest on replacement transport...");
         await transport.handleRequest(req, res, req.body);
         logger.info("MCP POST: handleRequest completed for replacement session " + transport.sessionId +
           " statusCode=" + res.statusCode + " headersSent=" + res.headersSent);
-        logger.info("MCP POST: response headers: " + JSON.stringify(res.getHeaders()));
-        if (transport.sessionId) {
-          transports[transport.sessionId] = transport;
-          notifiers[transport.sessionId] = notifier;
-          logger.info("MCP POST: replacement session stored: " + transport.sessionId +
-            " totalSessions=" + Object.keys(transports).length);
-        } else {
-          logger.warn("MCP POST: replacement transport.sessionId still undefined after handleRequest — not storing");
-        }
+        storeSession(transport, notifier, "replacement");
       }
     } catch (err) {
       logger.error("MCP POST error: " + err.message);
@@ -584,12 +632,12 @@ function startMcpServer(config, redisClient) {
     logger.info("MCP GET (SSE): sessionId=" + (sessionId || "none") +
       " known=" + (sessionId ? !!transports[sessionId] : false) +
       " activeSessions=" + activeSessionIds.length);
-    logger.info("MCP GET: request headers: " + JSON.stringify({
+    logger.debug("MCP GET: request headers: " + JSON.stringify({
       "mcp-session-id": req.headers["mcp-session-id"] || "not set",
       "accept": req.headers["accept"] || "not set",
       "user-agent": req.headers["user-agent"] || "not set"
     }));
-    logger.info("MCP GET: known session IDs: [" + activeSessionIds.join(", ") + "]");
+    logger.debug("MCP GET: known session IDs: [" + activeSessionIds.join(", ") + "]");
 
     if (!sessionId || !transports[sessionId]) {
       logger.warn("MCP GET: rejected — invalid or missing session " + (sessionId || "none") +


### PR DESCRIPTION
The three non-blocking residual nits from the post-SSE QC review (#410), all in `lib/mcp/index.js`.

## 1. DRY the two duplicate POST /mcp session-setup blocks
The new-session and replacement-for-stale-session branches were near-verbatim copies (create transport → createMcpServer → wire `onclose` → connect → set `notifier.sessionId` → store). Extracted `setupSession(transport)` + `storeSession(transport, notifier, label)`. The only per-branch difference left is the stale path stripping the `mcp-session-id` header before `handleRequest`. **The two paths can no longer drift** — which is what the reviewer flagged.

## 2. Bound the in-memory OAuth stores (were unbounded)
`authCodes`/`tokens` grew for the whole process lifetime. Now:
- Tokens stamped with `expires` (access **1h** — matching the advertised `expires_in`; refresh **30d**)
- Bearer validation rejects (and drops) an **expired** access token — the `"invalid or expired token"` message already promised this; it's now true
- A 10-min unref'd sweep reaps expired `authCodes` + `tokens`
- `clients` (dynamic registration) intentionally left — long-lived and small

Verified the sweep + expiry logic in isolation (reaps expired, keeps valid; expired access → 401).

## 3. Demote high-volume / sensitive per-request logs to debug
Full request body, header dumps, and known-session-id lists (POST + GET) go from `info` → `debug`. The one-line per-request summary stays at `info`. The request body can carry alignments/tokens, so it shouldn't print at `info`.

**Verified:** test:mcp 75/0, test:ci 126/0. No behavior change to the request flow; the only functional change is expired OAuth tokens are now rejected.