### PR TITLE
Fix GARD: guard against unsupported codon + rate-variation combination

### DIFF
--- a/app/gard/gard.sh
+++ b/app/gard/gard.sh
@@ -96,6 +96,18 @@ RATE_CLASSES="${rate_classes:-2}"
 DATATYPE="${datatype:-codon}"
 RUN_MODE="${run_mode:-Normal}"
 MAX_BREAKPOINTS="${max_breakpoints:-10000}"
+
+# --- GARD codon + rate-variation guard ---
+# HyPhy GARD does not support rate variation with codon data: the run never
+# converges and HYPHY aborts ("MG_REV.ModelDescription needs 2 parameters,
+# but 1 were supplied"). See veg/hyphy#981 (maintainer: codon+RV unsupported;
+# classic datamonkey removed the codon option for this reason). Coerce RV off
+# for codon so the job completes instead of guaranteed-aborting.
+if [ "$DATATYPE" = "codon" ] && [ "$RATE_VARIATION" != "None" ]; then
+  echo "WARNING: GARD codon data does not support rate variation ('$RATE_VARIATION'); forcing --rv None (veg/hyphy#981)."
+  RATE_VARIATION="None"
+fi
+# --- end guard ---
 MODEL="${model:-JTT}"
 PROCS=${procs:-48}
 


### PR DESCRIPTION
## Summary
Follow-up to #391 / #450. #391 fixed the missing `--code` on GARD codon jobs, but codon jobs **with rate variation** (`--rv Gamma` / `--rv GDD`) still abort with the same error even when `--code` is supplied:

```
Error: User-defined function 'models.codon.MG_REV.ModelDescription' needs 2 parameters, but 1 were supplied.
```

## Root cause
GARD's rate-variation wrappers (`gard.model.withGamma` / `withGDD`) call the model generator via `Call(gard.model.generator.base, options)` with a **single** argument. The codon generator `MG_REV.ModelDescription(type, code)` needs two, so it aborts regardless of `--code`. Per veg/hyphy#981 (maintainer), the codon option does not support rate variation ("would not ever finish"), and classic Datamonkey removed the codon option for this reason.

## Change
In `app/gard/gard.sh`, when `datatype=codon` and rate variation is not `None`, force `--rv None` with a logged warning so the job completes instead of guaranteed-aborting.

## Testing
- Reproduced the abort with `--type codon --rv Gamma` (0-byte result).
- With `--rv None`, the codon run proceeds past model setup into the real analysis and only stops on genuine per-alignment data issues.

## Alternative
Per veg/hyphy#981, the cleaner long-term option is to drop the `codon` datatype from the GARD UI/job builder entirely (as classic Datamonkey did). Flagging for maintainer preference.

Closes #450.
