### PR TITLE
Fix FUBAR: run single process under SLURM (fixes fscanf RawREWIND race)

### DIFF
--- a/app/fubar/fubar.sh
+++ b/app/fubar/fubar.sh
@@ -120,8 +120,13 @@ if [ -n "$SLURM_JOB_ID" ]; then
   # Using SLURM srun
   echo "Using SLURM execution: $HYPHY"
   export TOLERATE_NUMERICAL_ERRORS=1
-  echo "srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH fubar --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --concentration_parameter $CONCENTRATION --grid $GRIDPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
-  srun --mpi=$MPI_TYPE -n $PROCS $HYPHY LIBPATH=$HYPHY_PATH fubar --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --concentration_parameter $CONCENTRATION --grid $GRIDPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
+  # FUBAR uses the non-MPI HYPHYMP binary and parallelizes the grid INTERNALLY.
+  # Launching it as srun -n $PROCS (e.g. 48) ran 48 independent copies racing on
+  # the same alignment/cache/output files -> "Could not read all the parameters
+  # requested in call to fscanf(path,\"RawREWIND\")" and tasks 0-N exit 1.
+  # Classic DM2 runs FUBAR as a single plain process; force -n 1 to match.
+  echo "srun --mpi=$MPI_TYPE -n 1 $HYPHY LIBPATH=$HYPHY_PATH fubar --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --concentration_parameter $CONCENTRATION --grid $GRIDPOINTS --output $RESULTS_FN > \"$PROGRESS_FILE\""
+  srun --mpi=$MPI_TYPE -n 1 $HYPHY LIBPATH=$HYPHY_PATH fubar --alignment $FN --tree $TREE_FN --code $GENETIC_CODE --concentration_parameter $CONCENTRATION --grid $GRIDPOINTS --output $RESULTS_FN > "$PROGRESS_FILE"
 else
   # For local execution, use the HYPHY executable determined above
   echo "Using local HYPHY execution: $HYPHY"


### PR DESCRIPTION
## Summary
FUBAR jobs fail under SLURM with a file-race error:

```
Error: Could not read all the parameters requested. in call to fscanf(path,"RawREWIND", contents, );
srun: error: nodeN: tasks 0-47: Exited with exit code 1
```

## Root cause
FUBAR uses the non-MPI `HYPHYMP` binary and parallelizes its grid **internally**. `app/fubar/fubar.sh` launched it as `srun --mpi=pmix -n $PROCS` with `PROCS=48`, spawning 48 independent copies of the single-process binary that race on the same alignment, cache, and output files — hence the `fscanf(RawREWIND)` read failure and all tasks exiting 1. No result file is produced.

FUBAR is not an MPI-partitioned analysis (unlike GARD, which correctly uses `HYPHYMPI`). Classic DM2 runs FUBAR as a single plain process.

## Change
Force `-n 1` in the SLURM branch so exactly one FUBAR process runs (keeping `srun` for mounts / SLURM accounting), eliminating the race.

## Testing
Confirmed against the classic DM2 FUBAR invocation (single process, high success rate) and the failure signature in production logs. A live FUBAR job on the cluster is the final confirmation.
