### PR TITLE
feat: AxoMEME job lifecycle (PR3/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ app/hivtrace/output
 app/hivtrace/res/LANL.FASTA
 app/hivtrace/res/LANL.UNALIGNED.FASTA
 **/output
+# Analysis output dirs must exist in a fresh checkout (jobs write into them).
+# Re-including a file under an ignored DIRECTORY needs three steps: un-ignore
+# the dir itself, re-ignore its contents, then un-ignore just the .gitkeep.
+!app/*/output/
+app/*/output/*
+!app/*/output/.gitkeep
 .hyphy*
 .python
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,14 +22,20 @@
 - Located in `lib/mcp/` — uses `@modelcontextprotocol/sdk` with StreamableHTTP transport.
 - Runs on a separate Express instance on `config.mcp_port` (default 7016).
 - Stdio transport at `lib/mcp/stdio.js` for local Claude Code usage.
-- Tools: `list_analyses`, `spawn_analysis`, `job_status`, `get_results`, `cancel_job`, `validate_alignment`.
+- Tools: `list_analyses`, `spawn_analysis`, `job_status`, `get_results`, `cancel_job`, `validate_alignment`, `axomeme_scan`.
 - `spawnAnalysis` in `lib/mcp/spawn-helpers.js` bridges MCP tool calls to the existing analysis constructors.
+
+### AxoMEME
+
+- AxoMEME is NOT a HyPhy method — it is an ONNX neural surrogate for MEME (`lib/axomeme/`), run as a Node CLI behind the standard job lifecycle (no `.bf`, no MPI).
+- The `axomeme_scan` MCP tool runs synchronous scans without going through the job queue.
+- Requires a tree WITH branch lengths; genetic code is fixed (universal) and there is no branch selection.
 
 ### Tree parameter routing
 
 Different analyses read the tree from different locations in the params object:
 - **FEL/aBSREL/BUSTED/RELAX**: `params.analysis.tagged_nwk_tree` or `params.tree`
-- **MEME/PRIME/SLAC**: `params.msa[0].nj`, then prefer `params.analysis.msa[0].usertree`
+- **MEME/PRIME/SLAC/axomeme**: `params.msa[0].nj`, then prefer `params.analysis.msa[0].usertree`
 
 `spawnAnalysis` sets the tree in all locations (`params.tree`, `msa[0].nj`, `msa[0].usertree`, `analysis.msa[0]`) to ensure every analysis constructor finds it.
 

--- a/CLIENT_INTEGRATION_GUIDE.md
+++ b/CLIENT_INTEGRATION_GUIDE.md
@@ -69,6 +69,7 @@ The server provides the following bioinformatics analyses:
 - **cfel** - Contrast-FEL
 - **relax** - RELAX test
 - **meme** - Mixed Effects Model of Evolution
+- **axomeme** - AxoMEME 2.0 neural surrogate for MEME (requires a tree with branch lengths; options call_mode, max_species, reference_sequence)
 - **slac** - Single Likelihood Ancestor Counting
 - **gard** - Genetic Algorithm for Recombination Detection
 - **fubar** - Fast, Unconstrained Bayesian AppRoximation
@@ -237,6 +238,18 @@ const memeParams = {
 };
 
 runUnifiedAnalysis('meme', alignmentData, treeData, memeParams);
+
+// Example AxoMEME analysis using unified format
+// Note: AxoMEME is a neural surrogate for MEME (not HyPhy) — the tree MUST have
+// branch lengths, the genetic code is fixed (universal), and there is no branch selection.
+const axomemeParams = {
+  analysis_type: 'axomeme',
+  call_mode: 'percentile',          // Site-calling mode: 'percentile', 'zscore', 'pvalue' (default: 'percentile')
+  max_species: 512,                 // Taxon cap, clamped to 2-512 (default: 512)
+  reference_sequence: 'Human'       // Optional reference sequence name; must match a sequence in the alignment
+};
+
+runUnifiedAnalysis('axomeme', alignmentData, treeData, axomemeParams);
 
 // Example SLAC analysis using unified format
 const slacParams = {

--- a/app/axomeme/axomeme.js
+++ b/app/axomeme/axomeme.js
@@ -1,0 +1,1 @@
+module.exports = require("./descriptor.js");

--- a/app/axomeme/axomeme.sh
+++ b/app/axomeme/axomeme.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# AxoMEME job script. Unlike the sibling HyPhy scripts there is no HYPHYMPI,
+# no srun, no lmod: AxoMEME is a neural surrogate for MEME and the runner
+# (lib/axomeme/cli.js) is a single-process node program, so SLURM and local
+# execution are the same command line.
+
+export PATH=/usr/local/bin:$PATH
+
+# Under SLURM these keys arrive as ENVIRONMENT VARIABLES via the sbatch
+# --export=ALL,... list and "$@" is empty, so this loop is a no-op and the
+# exported values win. On local submits the same key=val pairs arrive as
+# arguments and the loop populates them.
+for arg in "$@"; do
+  case $arg in
+    fn=*)
+      fn="${arg#*=}"
+      ;;
+    tree_fn=*)
+      tree_fn="${arg#*=}"
+      ;;
+    sfn=*)
+      sfn="${arg#*=}"
+      ;;
+    pfn=*)
+      pfn="${arg#*=}"
+      ;;
+    rfn=*)
+      rfn="${arg#*=}"
+      ;;
+    treemode=*)
+      treemode="${arg#*=}"
+      ;;
+    call_mode=*)
+      call_mode="${arg#*=}"
+      ;;
+    max_species=*)
+      max_species="${arg#*=}"
+      ;;
+    reference_sequence=*)
+      reference_sequence="${arg#*=}"
+      ;;
+    genetic_code=*)
+      genetic_code="${arg#*=}"
+      ;;
+    analysis_type=*)
+      analysis_type="${arg#*=}"
+      ;;
+    cwd=*)
+      cwd="${arg#*=}"
+      ;;
+    msaid=*)
+      msaid="${arg#*=}"
+      ;;
+    procs=*)
+      procs="${arg#*=}"
+      ;;
+  esac
+done
+
+FN=$fn
+CWD=$cwd
+TREE_FN=$tree_fn
+STATUS_FILE=$sfn
+PROGRESS_FILE=$pfn
+RESULTS_FN=$fn.AXOMEME.json
+CALL_MODE="${call_mode:-percentile}"
+MAX_SPECIES="${max_species:-512}"
+REFERENCE_SEQUENCE="$reference_sequence"
+# Log parity only — the model has no genetic-code option (universal baked in).
+GENETIC_CODE="${genetic_code:-Universal}"
+PROCS=${procs:-1}
+
+trap 'echo "Error" > "$STATUS_FILE"; exit 1' ERR
+
+echo "PROCS: $PROCS"
+echo "SLURM_JOB_ID: $SLURM_JOB_ID"
+echo "PROGRESS_FILE: '$PROGRESS_FILE'"
+echo "STATUS_FILE: '$STATUS_FILE'"
+echo "FN: '$FN'"
+echo "TREE_FN: '$TREE_FN'"
+echo "RESULTS_FN: '$RESULTS_FN'"
+echo "CALL_MODE: '$CALL_MODE'"
+echo "MAX_SPECIES: '$MAX_SPECIES'"
+echo "REFERENCE_SEQUENCE: '$REFERENCE_SEQUENCE'"
+echo "GENETIC_CODE: '$GENETIC_CODE'"
+
+NODE_BIN=$(command -v node || echo /usr/local/bin/node)
+echo "NODE_BIN: '$NODE_BIN'"
+
+echo "$NODE_BIN $CWD/../../lib/axomeme/cli.js --alignment $FN --tree $TREE_FN --output $RESULTS_FN --call-mode $CALL_MODE --max-species $MAX_SPECIES --reference-sequence $REFERENCE_SEQUENCE --threads $PROCS > \"$PROGRESS_FILE\""
+"$NODE_BIN" "$CWD/../../lib/axomeme/cli.js" --alignment "$FN" --tree "$TREE_FN" --output "$RESULTS_FN" --call-mode "$CALL_MODE" --max-species "$MAX_SPECIES" --reference-sequence "$REFERENCE_SEQUENCE" --threads "$PROCS" > "$PROGRESS_FILE"
+
+echo "Completed" > "$STATUS_FILE"

--- a/app/axomeme/descriptor.js
+++ b/app/axomeme/descriptor.js
@@ -1,0 +1,272 @@
+/**
+ * AxoMEME analysis descriptor.
+ *
+ * AxoMEME is a neural SURROGATE for MEME, not a HyPhy method: there is no .bf,
+ * no MPI, no genetic-code option (universal is baked into the model) and no
+ * branch selection. The job script (axomeme.sh) runs lib/axomeme/cli.js — a
+ * single-process node program — instead of HYPHYMPI, but the job lifecycle
+ * (SLURM submission, status/progress/results files, redis publishing) is the
+ * standard lib/analysis-factory.js one, so the descriptor shape mirrors
+ * app/meme/descriptor.js.
+ *
+ * NOTE on the script name: "axomeme.sh" MUST share its basename with
+ * descriptor.type ("axomeme"). setTorqueParameters derives the SLURM err/out
+ * log paths from the SCRIPT name while the factory builds --output/--error
+ * from the TYPE — a mismatch breaks failure reporting (stderr would be read
+ * from a path SLURM never wrote).
+ */
+
+const factory = require("../../lib/analysis-factory.js");
+const fs = require("fs");
+const utilities = require("../../lib/utilities");
+const logger = require("../../lib/logger").logger;
+// ONE definition of the option whitelists, shared with the MCP tool and the
+// CLI. SAFE_SEQUENCE_NAME is a security control, not cosmetics: the
+// reference_sequence value is interpolated into the comma-joined SLURM
+// --export string, so anything outside the whitelist either breaks the export
+// list or injects into it. (Requiring predict.js is cheap — onnxruntime-node
+// is lazily required inside loadSession(), not at module scope.)
+const {
+  CALL_MODES,
+  SAFE_SEQUENCE_NAME,
+} = require("../../lib/axomeme/predict.js");
+const {
+  treeHasBranchLengths,
+} = require("../../lib/axomeme/vendor/tree-inspect.js");
+
+const descriptor = {
+  type: "axomeme",
+  dir: __dirname,
+  script: "axomeme.sh",
+  suffixes: { short: "axomeme", results: "AXOMEME", progress: "axomeme" },
+  procsKey: "axomeme_procs",
+  walltimeKey: "axomeme_walltime",
+
+  // Set analysis-specific self.<field> values. In checkOnly mode `src` is the
+  // raw params; in normal mode it is params.analysis (or params). Every value
+  // that reaches the --export string is validated or clamped HERE, before it
+  // can be interpolated.
+  fields: function (self, params, src) {
+    self.call_mode = CALL_MODES.includes(src.call_mode)
+      ? src.call_mode
+      : "percentile";
+
+    const maxSpecies = parseInt(src.max_species, 10);
+    self.max_species = Number.isFinite(maxSpecies)
+      ? Math.min(512, Math.max(2, maxSpecies))
+      : 512;
+
+    // Whitelist, don't sanitize: a name that fails the pattern is dropped to
+    // "" (auto-pick), never rewritten into something the user did not type.
+    self.reference_sequence =
+      typeof src.reference_sequence === "string" &&
+      SAFE_SEQUENCE_NAME.test(src.reference_sequence)
+        ? src.reference_sequence
+        : "";
+
+    // Log parity only — the model has no genetic-code option.
+    self.genetic_code = "Universal";
+
+    const isCheckOnly = params.checkOnly || false;
+    if (isCheckOnly) {
+      self.nj = "";
+    } else if (self.params.msa) {
+      self.nj = self.params.msa?.[0]?.nj || "";
+    } else {
+      self.nj = self.params.nj || self.params.tree || "";
+    }
+  },
+
+  // Non-checkOnly side effects (MEME-family tree selection preferring
+  // usertree, sanitization, output-dir creation BEFORE the tree-file write,
+  // progress-file creation) that run before self.init().
+  beforeInit: function (self) {
+    // Determine the tree to use — prefer usertree over NJ tree.
+    self.selectedTree = self.nj;
+
+    if (
+      self.params &&
+      self.params.analysis &&
+      self.params.analysis.msa &&
+      typeof self.params.analysis.msa === "object"
+    ) {
+      const msa = self.params.analysis.msa[0];
+
+      if (msa && msa.usertree && msa.usertree.trim()) {
+        // Use the usertree if it is populated.
+        self.selectedTree = msa.usertree;
+      }
+    }
+
+    // Sanitize tree node names for Newick compatibility.
+    self.selectedTree = utilities.sanitizeTreeNodeNames(self.selectedTree);
+    // Sanitize FASTA names to match tree node names.
+    if (self.stream && typeof self.stream === "string") {
+      self.stream = utilities.sanitizeFastaNames(self.stream);
+    }
+
+    // Ensure output directory exists BEFORE writing files.
+    logger.info(
+      "AXOMEME job " +
+        self.id +
+        ": Ensuring output directory exists at " +
+        self.output_dir
+    );
+    utilities.ensureDirectoryExists(self.output_dir);
+
+    // Write tree to a file.
+    logger.info(
+      "AXOMEME job " + self.id + ": Writing tree file to " + self.tree_fn,
+      {
+        tree_content: self.selectedTree
+          ? self.selectedTree.length > 100
+            ? self.selectedTree.substring(0, 100) + "..."
+            : self.selectedTree
+          : "null",
+      }
+    );
+    fs.writeFile(self.tree_fn, self.selectedTree, function (err) {
+      if (err) {
+        logger.error(
+          "AXOMEME job " + self.id + ": Error writing tree file: " + err.message
+        );
+        self.socket.emit("script error", {
+          error: "Failed to write tree file: " + err.message,
+        });
+        return;
+      }
+      logger.info(
+        "AXOMEME job " + self.id + ": Tree file written successfully"
+      );
+    });
+
+    // Ensure the progress file exists.
+    logger.info(
+      "AXOMEME job " +
+        self.id +
+        ": Creating progress file at " +
+        self.progress_fn
+    );
+    fs.openSync(self.progress_fn, "w");
+  },
+
+  // The ordered export keys AFTER the common fn/tree_fn/sfn/pfn/rfn/treemode
+  // prefix. genetic_code is exported for log parity only (see fields).
+  exportKeys: [
+    [
+      "call_mode",
+      function (self) {
+        return self.call_mode;
+      },
+    ],
+    [
+      "max_species",
+      function (self) {
+        return self.max_species;
+      },
+    ],
+    [
+      "reference_sequence",
+      function (self) {
+        return self.reference_sequence;
+      },
+    ],
+    [
+      "genetic_code",
+      function (self) {
+        return self.genetic_code;
+      },
+    ],
+    [
+      "analysis_type",
+      function (self) {
+        return self.type;
+      },
+    ],
+    [
+      "cwd",
+      function (self) {
+        return __dirname;
+      },
+    ],
+    [
+      "msaid",
+      function (self) {
+        return self.msaid;
+      },
+    ],
+    [
+      "procs",
+      function (self, config) {
+        return config.axomeme_procs;
+      },
+    ],
+  ],
+};
+
+const axomeme = factory.makeAnalysis(descriptor);
+
+// Override the base checkOnly validator: hyphyJob.prototype.validateParameters
+// hard-requires params.genetic_code, which AxoMEME does not have (the model
+// has no code option). Validate what AxoMEME actually needs instead — and
+// emit EXACTLY the base's payload shape (test/validation/results.js asserts
+// {valid, errors}).
+axomeme.prototype.validateParameters = function () {
+  const self = this;
+  const errors = [];
+
+  if (
+    self.params.call_mode != null &&
+    !CALL_MODES.includes(self.params.call_mode)
+  ) {
+    errors.push("call_mode must be one of: " + CALL_MODES.join(", "));
+  }
+
+  if (self.params.max_species != null) {
+    const n = parseInt(self.params.max_species, 10);
+    if (!Number.isFinite(n) || n < 2 || n > 512) {
+      errors.push("max_species must be an integer between 2 and 512");
+    }
+  }
+
+  if (
+    self.params.reference_sequence != null &&
+    self.params.reference_sequence !== "" &&
+    !SAFE_SEQUENCE_NAME.test(self.params.reference_sequence)
+  ) {
+    errors.push(
+      "reference_sequence must match " +
+        SAFE_SEQUENCE_NAME.toString() +
+        " (letters, digits, and _.|:- only, at most 128 characters)"
+    );
+  }
+
+  // AxoMEME cannot run without a tree, and a topology-only tree must be
+  // refused, not scored: the model reads branch lengths as evolutionary
+  // distances, and without them it returns confident numbers computed from
+  // nothing.
+  const tree =
+    self.params.tree ||
+    self.params.msa?.[0]?.usertree ||
+    self.params.msa?.[0]?.nj;
+  if (!tree) {
+    errors.push(
+      "a phylogenetic tree is required (params.tree or msa[0].usertree / msa[0].nj)"
+    );
+  } else if (!treeHasBranchLengths(tree)) {
+    errors.push(
+      "the tree must carry branch lengths — AxoMEME reads them as evolutionary distances"
+    );
+  }
+
+  self.socket.emit("validated", {
+    valid: errors.length === 0,
+    errors: errors,
+  });
+
+  self.socket.disconnect();
+};
+
+// Preserve the standard module export shape: exports.axomeme is the constructor.
+exports.axomeme = axomeme;
+exports.descriptor = descriptor;

--- a/config.json.tpl
+++ b/config.json.tpl
@@ -13,6 +13,8 @@
   "hivtrace_walltime"      : "3:00:00:00",
   "absrel_procs"           : "32",
   "absrel_walltime"        : "3:00:00:00",
+  "axomeme_procs"          : "4",
+  "axomeme_walltime"       : "4:00:00",
   "bgm_procs"              : "32",
   "bgm_walltime"           : "3:00:00:00",
   "busted_procs"           : "32",

--- a/lib/axomeme/cli.js
+++ b/lib/axomeme/cli.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * cli.js — the AxoMEME job runner invoked by app/axomeme/axomeme.sh.
+ *
+ * STDOUT IS THE PROGRESS FILE. The shell script redirects this process's
+ * stdout into the job's .progress file, and hyphyjob republishes the WHOLE
+ * file through redis on every tick — so output must stay bounded: one line
+ * per phase plus at most one per decile of scoring progress, never a line
+ * per site.
+ *
+ * COMPLETION CONTRACT: results file written + exit 0. The local path in
+ * app/job.js keys on the exit code; the SLURM path stats the results file.
+ * The results file is therefore written (and fsync'd) BEFORE the final
+ * progress line, so no observer can see "done" before the results exist.
+ *
+ * Errors go to stderr and set a non-zero exit code — the shell's ERR trap
+ * then writes "Error" to the status file.
+ */
+
+const fs = require("fs");
+const { predictAxomeme } = require("./predict.js");
+
+const USAGE =
+  "Usage: cli.js --alignment <file> --tree <file> --output <file>\n" +
+  "              [--call-mode percentile|zscore|pvalue] [--max-species 2..512]\n" +
+  "              [--reference-sequence <name>] [--threads <n>]\n";
+
+/**
+ * Hand-rolled flag parser (no new deps): accepts `--flag value` and
+ * `--flag=value`. Unknown flags are collected too; main() only reads the
+ * ones it knows.
+ */
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const eq = arg.indexOf("=");
+    if (eq !== -1) {
+      args[arg.slice(2, eq)] = arg.slice(eq + 1);
+    } else {
+      args[arg.slice(2)] = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+/** Parse an optional integer flag; absent, empty or unparsable means "not set". */
+function intOrUndefined(value) {
+  if (value == null || value === "") return undefined;
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Print progress updates to stdout, bounded: a line when the phase changes or
+ * when the percent crosses into a new decile, otherwise silence. With the
+ * runner's phases (parsing/preparing/loading/running/processing) this is at
+ * most ~11 lines regardless of alignment size.
+ */
+function makeProgressPrinter() {
+  let lastPhase = null;
+  let lastDecile = -1;
+  return function (update) {
+    const decile = Math.floor(update.percent / 10);
+    if (update.phase === lastPhase && decile <= lastDecile) return;
+    lastPhase = update.phase;
+    lastDecile = Math.max(lastDecile, decile);
+    process.stdout.write(
+      "[" + update.phase + "] " + update.percent + "% " + update.message + "\n"
+    );
+  };
+}
+
+/** Write + fsync + close, so the bytes are durable before we signal completion. */
+function writeFileWithFsync(path, data) {
+  const fd = fs.openSync(path, "w");
+  try {
+    // writeSync may perform a SHORT write without throwing (ENOSPC/EIO mid-write);
+    // exiting 0 after one would deliver truncated JSON as a "successful" result.
+    const buf = Buffer.from(data);
+    let written = 0;
+    while (written < buf.length) {
+      const n = fs.writeSync(fd, buf, written);
+      if (n <= 0) {
+        throw new Error("short write to " + path + " (" + written + "/" + buf.length + " bytes)");
+      }
+      written += n;
+    }
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const missing = ["alignment", "tree", "output"].filter(function (k) {
+    return !args[k];
+  });
+  if (missing.length) {
+    throw new Error(
+      "missing required flag(s): --" + missing.join(", --") + "\n" + USAGE
+    );
+  }
+
+  const alignmentText = fs.readFileSync(args.alignment, "utf8");
+  const treeText = fs.readFileSync(args.tree, "utf8");
+
+  // An empty/missing --reference-sequence means "auto-pick" (undefined), not
+  // a sequence literally named "".
+  const referenceSequence = args["reference-sequence"]
+    ? args["reference-sequence"]
+    : undefined;
+  const callMode = args["call-mode"] ? args["call-mode"] : undefined;
+
+  const result = await predictAxomeme({
+    alignmentText: alignmentText,
+    treeText: treeText,
+    callMode: callMode,
+    maxSpecies: intOrUndefined(args["max-species"]),
+    referenceSequence: referenceSequence,
+    threads: intOrUndefined(args.threads),
+    onProgress: makeProgressPrinter(),
+  });
+
+  // Results BEFORE the final progress line — see the completion contract above.
+  writeFileWithFsync(args.output, JSON.stringify(result));
+  process.stdout.write(
+    "[complete] 100% Results written to " + args.output + "\n"
+  );
+}
+
+// No explicit process.exit(): VERIFIED (onnxruntime-node 1.23.2, node 22)
+// by running this CLI standalone that the session's native thread pool does
+// not keep the event loop referenced — the process exits on its own right
+// after the write (~1s total on the 30-site test alignment). If a future
+// onnxruntime bump changes that, re-verify and add a process.exit(0) AFTER
+// writeFileWithFsync. Letting the process exit naturally also guarantees the
+// error path below flushes stderr before the (implicit) exit.
+main().catch(function (err) {
+  process.stderr.write(
+    "AxoMEME failed: " + (err && err.message ? err.message : String(err)) + "\n"
+  );
+  process.exitCode = 1;
+});

--- a/lib/mcp/prompts.js
+++ b/lib/mcp/prompts.js
@@ -7,7 +7,7 @@ const z = require("zod");
 const ANALYSIS_TYPES = [
   "absrel", "fel", "busted", "relax", "meme", "slac", "fubar",
   "gard", "cfel", "multihit", "nrm", "fade", "bgm", "bstill",
-  "difFubar", "prime", "hivtrace"
+  "difFubar", "prime", "hivtrace", "axomeme"
 ];
 
 /**
@@ -50,7 +50,8 @@ function registerPrompts(mcpServer) {
 "| Are sites coevolving? | **BGM** | No | Yes |\n" +
 "| Property-informed selection analysis? | **PRIME** | Optional | Yes |\n" +
 "| HIV molecular epidemiology / clustering? | **HIV-TRACE** | No | **No** (nucleotide) |\n" +
-"| Structural lineage analysis? | **B-STILL** | No | Yes |\n\n" +
+"| Structural lineage analysis? | **B-STILL** | No | Yes |\n" +
+"| Which sites are worth a real MEME run (fast triage)? | **AxoMEME** (surrogate — a ranking, not significance; confirm with MEME) | Ignored | Yes (universal code only) |\n\n" +
 "## Key Decision Points\n\n" +
 "1. **Do you need branch-specific results?** → aBSREL, BUSTED, RELAX\n" +
 "2. **Do you need site-specific results?** → FEL, MEME, FUBAR, SLAC\n" +
@@ -396,6 +397,32 @@ function getInterpretationGuidance(method) {
 "- Structural inference of lineage-specific patterns\n\n" +
 "## Significance\n" +
 "- Bayesian analysis combining structural and evolutionary information"
+    },
+    axomeme: {
+      name: "AxoMEME",
+      text:
+"## Read This First\n" +
+"AxoMEME is a **neural surrogate for MEME**, not a HyPhy fit. Every field below is a PREDICTION of " +
+"what MEME would report. The result carries `\"isSurrogate\": true` and `\"surrogateFor\": \"MEME\"` — " +
+"carry that caveat into anything you say about these numbers.\n\n" +
+"## Key Fields\n" +
+"- `\"sites\"` → per-site rows, one per codon site of the reference sequence\n" +
+"- `\"lrt\"` — a predicted score on the LRT scale. It is NOT a likelihood ratio computed from a model " +
+"fit, and it has no chi-square distribution behind it\n" +
+"- `\"zScore\"` / `\"percentile\"` — the score standardised / ranked against the VARIABLE sites of THIS " +
+"alignment. They describe a site's standing within this file only and do not transfer between alignments\n" +
+"- `\"call\"` — the label the chosen `call_mode` assigned to the site\n" +
+"- `\"summary\"` → `\"callMode\"`, `\"speciesUsed\"`, `\"referenceSequence\"`, `\"totalSites\"`\n\n" +
+"## Significance\n" +
+"- There is none to report. These scores are **not calibrated significance** — they are a ranking for " +
+"triage. Use them to choose which sites deserve a real MEME run, then quote MEME's p-values\n" +
+"- Under `call_mode: \"pvalue\"` the fixed chi-square gates are rarely reached, so an empty call list is " +
+"the expected outcome rather than evidence of no selection\n\n" +
+"## Common Misinterpretations\n" +
+"- Reporting `lrt` or a derived p-value as if MEME produced it\n" +
+"- Comparing zScore or percentile across two different alignments — both are within-alignment measures\n" +
+"- Reading a top-percentile site as a positive result: it means \"most MEME-like site in this file\", " +
+"which is true of some site in every file, selection or not"
     },
     nrm: {
       name: "NRM",

--- a/lib/mcp/resources.js
+++ b/lib/mcp/resources.js
@@ -7,7 +7,7 @@ const ResourceTemplate = require("@modelcontextprotocol/sdk/server/mcp.js").Reso
 const METHOD_KEYS = [
   "absrel", "bgm", "busted", "difFubar", "fel", "cfel",
   "fubar", "bstill", "fade", "gard", "hivtrace", "meme", "multihit",
-  "nrm", "prime", "relax", "slac"
+  "nrm", "prime", "relax", "slac", "axomeme"
 ];
 
 const METHOD_REQUIREMENTS = {
@@ -95,6 +95,12 @@ const METHOD_REQUIREMENTS = {
     name: "SLAC", requires_tree: true, requires_codon_alignment: true,
     requires_branch_labels: false, branch_label_convention: "optional branch set",
     description: "Single Likelihood Ancestor Counting — counting-based selection detection"
+  },
+  axomeme: {
+    name: "AxoMEME", requires_tree: true, requires_codon_alignment: true,
+    requires_branch_labels: false, branch_label_convention: "none (no branch selection)",
+    description: "SURROGATE — neural surrogate for MEME; ranks sites by predicted MEME-like signal. " +
+      "The tree must carry branch lengths; no genetic-code option (universal only)"
   }
 };
 
@@ -253,6 +259,46 @@ const METHOD_GUIDES = {
 "## Example spawn_analysis\n```json\n{\n  \"analysis_type\": \"bstill\",\n  \"alignment\": \"<FASTA>\",\n  \"tree\": \"<NEWICK>\"\n}\n```\n\n" +
 "## Interpretation\n- Structural inference results for lineage-specific patterns",
 
+  axomeme:
+"# AxoMEME — neural surrogate for MEME\n\n" +
+"## What it is\n**AxoMEME is a SURROGATE, not a HyPhy analysis.** It is a neural network trained to " +
+"predict what MEME would report, and it returns per-site scores in seconds instead of the minutes-to-hours " +
+"a real MEME fit takes. Its output orders the sites of ONE alignment against each other; it is **not " +
+"calibrated significance**. Treat a high-scoring site as a lead to confirm with a real MEME run " +
+"(`spawn_analysis({\"analysis_type\": \"meme\"})`), never as evidence on its own.\n\n" +
+"## When to use it\n" +
+"- Triage: which sites in this gene are worth a real MEME run?\n" +
+"- Screening many alignments where a full MEME fit for each is not affordable\n" +
+"- Ranking sites for a downstream pipeline that only needs an ordering\n\n" +
+"Do NOT use it when you need a p-value you will report, or when the alignment is the only one you " +
+"care about — just run MEME.\n\n" +
+"## Inputs\n" +
+"- **Alignment**: Codon-aligned FASTA or NEXUS. Universal genetic code only — there is no " +
+"`genetic_code` option, it is baked into the model.\n" +
+"- **Tree**: Newick **with branch lengths**, required. The branch lengths become the patristic " +
+"distance matrix the model reads, so a topology-only tree is refused rather than scored. There is no " +
+"branch selection: labels are ignored and every branch contributes.\n\n" +
+"## Parameters\n" +
+"- `call_mode`: How a site is called. **\"percentile\" (default)** ranks sites within THIS alignment — " +
+"the right default precisely because the raw scores are not calibrated, so only their relative order is " +
+"meaningful. \"zscore\" gates on scores standardised over this alignment's variable sites. \"pvalue\" " +
+"applies fixed chi-square gates that the surrogate's scores rarely reach, so it usually calls nothing — " +
+"an empty call list under \"pvalue\" is the expected outcome, not a bug.\n" +
+"- `max_species`: Cap on taxa fed to the model (2-512, default 512). Above the cap, taxa are chosen by " +
+"maximum phylogenetic diversity.\n" +
+"- `reference_sequence`: Sequence that defines site numbering and the reported codons. Letters, digits, " +
+"underscore, dot, pipe, colon and hyphen only (1-128 characters).\n\n" +
+"## Two ways to run it\n" +
+"- `axomeme_scan` — answers IN the tool call, in seconds, no job_id. Capped in size.\n" +
+"- `spawn_analysis({\"analysis_type\": \"axomeme\"})` — queued job, for alignments over the synchronous caps.\n\n" +
+"## Example spawn_analysis\n```json\n{\n  \"analysis_type\": \"axomeme\",\n  \"alignment\": \"<FASTA>\",\n  \"tree\": \"<NEWICK WITH BRANCH LENGTHS>\",\n  \"params\": { \"call_mode\": \"percentile\", \"max_species\": 512 }\n}\n```\n\n" +
+"## Interpretation\n" +
+"- `sites[].lrt` is a **predicted** score, not a likelihood ratio computed from a model fit\n" +
+"- `sites[].zScore` / `sites[].percentile` are relative to the variable sites of THIS alignment — they " +
+"do not transfer between alignments\n" +
+"- `isSurrogate: true` and `surrogateFor: \"MEME\"` are on every result: report them alongside any finding\n" +
+"- Confirm anything you intend to act on with a real MEME run",
+
   nrm:
 "# NRM — Nucleotide Rate Model\n\n" +
 "## Purpose\nEstimates nucleotide substitution rates.\n\n" +
@@ -283,7 +329,8 @@ const COMPARISON_TABLE =
 "| PRIME | Property-informed selection? | Optional | Yes | Per-site per-property p-values |\n" +
 "| HIV-TRACE | Transmission clustering? | None | **No** | Network + clusters |\n" +
 "| B-STILL | Structural lineage patterns? | None | Yes | Structural inference |\n" +
-"| NRM | Nucleotide substitution rates? | None | Yes | Rate parameters |";
+"| NRM | Nucleotide substitution rates? | None | Yes | Rate parameters |\n" +
+"| AxoMEME | Which sites are worth a real MEME run? (**surrogate**, not a fit) | None (ignored) | Yes | Predicted per-site scores — a ranking, NOT significance |";
 
 /**
  * Register all MCP resources on the given McpServer instance.

--- a/lib/mcp/spawn-helpers.js
+++ b/lib/mcp/spawn-helpers.js
@@ -1,6 +1,7 @@
 const EventEmitter = require("events").EventEmitter,
   crypto = require("crypto"),
   absrel = require("../../app/absrel/absrel.js"),
+  axomeme = require("../../app/axomeme/axomeme.js"),
   bgm = require("../../app/bgm/bgm.js"),
   busted = require("../../app/busted/busted.js"),
   difFubar = require("../../app/difFubar/difFubar.js"),
@@ -22,6 +23,7 @@ const EventEmitter = require("events").EventEmitter,
 // Map of analysis type to constructor
 const analysisMap = {
   absrel:    absrel.absrel,
+  axomeme:   axomeme.axomeme,
   bgm:       bgm.bgm,
   busted:    busted.busted,
   difFubar:  difFubar.difFubar,
@@ -49,6 +51,19 @@ const analysisInfo = {
       branches: { type: "string", default: "All", description: "Which branches to test (e.g. 'All', 'Internal', 'Leaves', or 'FG' for labeled foreground)" },
       multiple_hits: { type: "string", default: "None", description: "Multiple hits model: 'None', 'Double', or 'Double+Triple'" },
       srv: { type: "string", default: "Yes", description: "Synonymous rate variation: 'Yes' or 'No'" }
+    }
+  },
+  axomeme: {
+    name: "AxoMEME",
+    description: "SURROGATE — a neural surrogate for MEME, not a HyPhy method. Ranks codon sites by " +
+      "predicted MEME-like episodic selection signal in seconds. Scores order sites within one " +
+      "alignment; they are NOT calibrated significance, so treat them as triage and confirm a site " +
+      "of interest with a real MEME run. Requires a tree WITH branch lengths (the model reads them " +
+      "as the distance matrix). Universal genetic code only; no branch selection.",
+    params: {
+      call_mode: { type: "string", default: "percentile", description: "How a site is called: 'percentile' (default, ranks sites within this alignment), 'zscore' (gates on standardised scores), or 'pvalue' (fixed chi-square gates the surrogate's scores rarely reach, so it usually calls nothing)" },
+      max_species: { type: "number", default: 512, description: "Cap on the number of taxa fed to the model (2-512). Above the cap, taxa are chosen by maximum phylogenetic diversity" },
+      reference_sequence: { type: "string", description: "Name of the sequence that defines site numbering and the reported codons. Allowed characters: letters, digits, underscore, dot, pipe, colon and hyphen (1-128 characters)" }
     }
   },
   bgm: {

--- a/lib/mcp/tools.js
+++ b/lib/mcp/tools.js
@@ -84,9 +84,10 @@ function registerTools(mcpServer, redisClient, notifier) {
       analysis_type: z.enum([
         "absrel", "fel", "busted", "relax", "meme", "slac", "fubar",
         "gard", "cfel", "multihit", "nrm", "fade", "bgm", "bstill",
-        "difFubar", "prime", "hivtrace"
+        "difFubar", "prime", "hivtrace", "axomeme"
       ]).optional().describe("Analysis type to validate parameters for (optional)"),
-      tree: z.string().optional().describe("Newick tree string (checked for branch labels if analysis_type is provided)")
+      tree: z.string().optional().describe("Newick tree string (checked for branch labels if analysis_type is provided)"),
+      params: z.object({}).passthrough().optional().describe("Analysis-specific parameters to pre-flight the same way spawn_analysis will (e.g. reference_sequence, call_mode, max_species for axomeme)")
     },
     async function (args) {
       try {
@@ -112,12 +113,14 @@ function registerTools(mcpServer, redisClient, notifier) {
           }
         }
 
-        // Validate analysis-specific params
+        // Validate analysis-specific params — pass the caller's params through so
+        // this tool pre-flights exactly what spawn_analysis will refuse (e.g. the
+        // axomeme reference_sequence whitelist), not just the tree rules.
         if (args.analysis_type) {
           const paramResult = validation.validateAnalysisParams(
             args.analysis_type,
             args.tree || null,
-            {}
+            args.params || {}
           );
           allErrors = allErrors.concat(paramResult.errors);
           allWarnings = allWarnings.concat(paramResult.warnings);
@@ -158,7 +161,7 @@ function registerTools(mcpServer, redisClient, notifier) {
       analysis_type: z.enum([
         "absrel", "fel", "busted", "relax", "meme", "slac", "fubar",
         "gard", "cfel", "multihit", "nrm", "fade", "bgm", "bstill",
-        "difFubar", "prime", "hivtrace"
+        "difFubar", "prime", "hivtrace", "axomeme"
       ]).describe("The type of analysis to run"),
       alignment: z.string().describe("Alignment data (FASTA or Nexus format)"),
       tree: z.string().optional().describe("Newick tree string (optional for some analyses)"),
@@ -522,8 +525,8 @@ function registerTools(mcpServer, redisClient, notifier) {
     "within one alignment; it does NOT produce calibrated significance, so its scores are a " +
     "ranking for triage, not evidence, and a site of interest should be confirmed with a real " +
     "MEME run. Requires a tree WITH branch lengths — the model reads them as the distance " +
-    'matrix. For very large alignments use spawn_analysis({analysis_type: "axomeme"}) once it ' +
-    "is available.",
+    "matrix. For very large alignments, run it as a queued job instead: " +
+    'spawn_analysis({analysis_type: "axomeme"}).',
     {
       alignment: z.string()
         .max(
@@ -633,9 +636,9 @@ function registerTools(mcpServer, redisClient, notifier) {
             " codon sites x " + sequenceCount + " sequences). axomeme_scan answers in the " +
             "tool call, so it is capped at " + MAX_SYNC_CODONS + " codon sites and at " +
             "sites x sequences^2 <= " + MAX_SYNC_WORK + ".",
-            'Run it as a queued job with spawn_analysis({analysis_type: "axomeme"}) — that ' +
-            "path ships separately and is not wired up yet — or scan a smaller alignment " +
-            "(fewer sequences, or fewer codon sites). Note that max_species does not help " +
+            'Run it as a queued job with spawn_analysis({analysis_type: "axomeme"}), or scan ' +
+            "a smaller alignment (fewer sequences, or fewer codon sites). Note that " +
+            "max_species does not help " +
             "here: the cap is measured on the file as submitted, before any taxon subsampling."
           );
         }

--- a/lib/mcp/validation.js
+++ b/lib/mcp/validation.js
@@ -145,14 +145,14 @@ function validateAlignment(alignment) {
 const CODON_METHODS = [
   "absrel", "busted", "fel", "cfel", "fubar", "meme", "slac",
   "relax", "multihit", "fade", "bgm", "prime", "difFubar",
-  "gard", "nrm", "bstill"
+  "gard", "nrm", "bstill", "axomeme"
 ];
 
 // Methods that require a tree
 const TREE_METHODS = [
   "absrel", "busted", "fel", "cfel", "fubar", "meme", "slac",
   "relax", "multihit", "fade", "bgm", "prime", "difFubar",
-  "gard", "nrm", "bstill"
+  "gard", "nrm", "bstill", "axomeme"
 ];
 
 /**
@@ -234,8 +234,88 @@ function validateAnalysisParams(type, tree, params) {
     }
   }
 
-  // Tree-requiring methods: warn if no tree provided
-  if (TREE_METHODS.indexOf(type) !== -1 && !tree) {
+  // AxoMEME is a neural surrogate, not a HyPhy method, and its gates differ from every
+  // other entry above: the tree is not optional (the model reads branch lengths as the
+  // distance matrix it scores against), and reference_sequence is interpolated into a
+  // SLURM --export list downstream, so the name whitelist is a security control.
+  //
+  // Required here rather than at module scope on purpose: lib/mcp/stdio.js is spawned once
+  // per tool invocation, so a top-level require would make every list_analyses /
+  // get_job_status call pay for loading the AxoMEME core (same reasoning as lib/mcp/tools.js).
+  // predict.js does not pull in onnxruntime-node — session.js defers that to loadSession.
+  if (type === "axomeme") {
+    const { SAFE_SEQUENCE_NAME, CALL_MODES } = require("../axomeme/predict.js");
+    const { treeHasBranchLengths } = require("../axomeme/vendor/tree-inspect.js");
+
+    if (!tree) {
+      result.valid = false;
+      result.errors.push(
+        "AxoMEME requires a tree with branch lengths — it reads them as evolutionary " +
+        "distances — and none was supplied. Infer a neighbor-joining tree or upload " +
+        "your own before running it."
+      );
+    } else if (!treeHasBranchLengths(tree)) {
+      result.valid = false;
+      result.errors.push(
+        "AxoMEME requires a tree with branch lengths — it reads them as evolutionary " +
+        "distances. This tree has none, so every pair of sequences would look equally " +
+        "related. Infer a neighbor-joining tree or upload one with branch lengths."
+      );
+    }
+
+    if (params && params.reference_sequence != null &&
+        !SAFE_SEQUENCE_NAME.test(params.reference_sequence)) {
+      result.valid = false;
+      result.errors.push(
+        "reference_sequence is not a usable sequence name. Allowed characters are " +
+        "letters, digits, underscore (_), dot (.), pipe (|), colon (:) and hyphen (-), " +
+        "1-128 characters. Spaces, commas, quotes and other shell metacharacters are " +
+        "refused. Use the sequence's name exactly as it appears in the alignment header."
+      );
+    }
+
+    if (params && params.call_mode != null &&
+        CALL_MODES.indexOf(params.call_mode) === -1) {
+      result.valid = false;
+      result.errors.push(
+        "Unknown call_mode \"" + params.call_mode + "\". Valid modes: " +
+        CALL_MODES.join(", ") + "."
+      );
+    }
+
+    // max_species: the same 2-512 integer bound axomeme_scan's zod schema enforces.
+    // Without this, spawn_analysis waves through max_species: 99999 or 0 and the job
+    // descriptor silently CLAMPS it into range — the caller gets a 512-taxon run they
+    // never asked for and no indication their number was ignored. Refusing here also
+    // keeps the two AxoMEME surfaces (axomeme_scan vs spawn_analysis) answering the
+    // same way to the same argument.
+    if (params && params.max_species != null) {
+      const maxSpecies = Number(params.max_species);
+      if (!Number.isInteger(maxSpecies) || maxSpecies < 2 || maxSpecies > 512) {
+        result.valid = false;
+        result.errors.push(
+          "max_species must be a whole number between 2 and 512 (got " +
+          JSON.stringify(params.max_species) + ")."
+        );
+      }
+    }
+
+    // AxoMEME has no genetic-code option — the universal code is baked into the model.
+    // A caller who sends genetic_code would otherwise get universal-code results with
+    // nothing telling them their code was dropped, and would read the site numbering as
+    // if their code had been honoured.
+    if (params && (params.genetic_code != null || params.gencodeid != null)) {
+      result.warnings.push(
+        "AxoMEME has no genetic-code option — the universal genetic code is baked into " +
+        "the model, so the genetic code you supplied is ignored. Run MEME itself if you " +
+        "need a non-universal code."
+      );
+    }
+  }
+
+  // Tree-requiring methods: warn if no tree provided. AxoMEME is excluded: it errored
+  // above, and "the server will attempt to infer one" is not true of the AxoMEME path.
+  if (TREE_METHODS.indexOf(type) !== -1 && type !== "axomeme" && !tree) {
     result.warnings.push(
       "No tree provided. The server will attempt to infer one, " +
       "but providing a tree is recommended for most analyses."

--- a/lib/router.js
+++ b/lib/router.js
@@ -50,7 +50,9 @@ io.prototype.route = function(route, next) {
               key.indexOf("prime") !== -1 ||
               key.indexOf("multihit") !== -1 ||
               key.indexOf("nrm") !== -1 ||
-              key.indexOf("bstill") !== -1
+              key.indexOf("bstill") !== -1 ||
+              // technically shadowed by the "meme" substring match above, but must not depend on that chain's ordering
+              key.indexOf("axomeme") !== -1
             )) {
               stream = data.alignment;
               logger.info(`Event ${key}: Using unified format - extracted alignment data as stream, length: ${stream.length}`);

--- a/lib/routes/analysis-routes.js
+++ b/lib/routes/analysis-routes.js
@@ -4,7 +4,7 @@
  * server.js used to declare 18 near-identical `r.route("<analysis>", {...})`
  * blocks, each wiring the same spawn / check / resubscribe / cancel handlers
  * that just do `new X.X(socket, stream, jobWithTree)`. This module replaces the
- * 16 standard blocks with a data table + a generated handler set, and keeps the
+ * 17 standard blocks with a data table + a generated handler set, and keeps the
  * genuinely-special hivtrace analysis as an explicit entry.
  *
  * Behavior is preserved exactly:
@@ -22,6 +22,7 @@ const logger = require("../logger.js").logger;
 // job params (bgm and difFubar pass params.job directly, no tree merge).
 const ANALYSES = [
   ["absrel", require("../../app/absrel/absrel.js").absrel],
+  ["axomeme", require("../../app/axomeme/axomeme.js").axomeme],
   ["bgm", require("../../app/bgm/bgm.js").bgm, { mergeTree: false }],
   ["bstill", require("../../app/bstill/bstill.js").bstill],
   ["busted", require("../../app/busted/busted.js").busted],

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "test": "npm run test:ci && npm run test:slurm",
     "test:ci": "mocha -R spec --exit test/load-smoke.js test/regression/leaks.js test/error-paths/validation.js test/validation/results.js test/mock/lifecycle.js test/golden/qsub-params.js test/golden/factory-parity.js test/routes/analysis-routes.js test/sanitize-names.test.js test/difFubar.test.js test/difFubar.integration.test.js test/fubar-redirection.test.js && npm run test:axomeme-unit",
-    "test:axomeme-unit": "mocha -R spec --exit test/axomeme/model-integrity.test.js test/axomeme/session.test.js test/axomeme/predict.test.js \"test/axomeme/vendor/*.test.js\"",
+    "test:axomeme-unit": "mocha -R spec --exit test/axomeme/model-integrity.test.js test/axomeme/session.test.js test/axomeme/predict.test.js \"test/axomeme/vendor/*.test.js\" && mocha -R spec --exit test/axomeme/descriptor.test.js",
     "test:slurm": "npm run test:analyses && npm run test:slurm-unit && npm run test:integration",
-    "test:analyses": "mocha -R spec --exit test/absrel/absrel.js test/busted/busted.js test/contrast-fel/contrast-fel.js test/fade/fade.js test/fubar/fubar.js test/gard/gard.js test/hivtrace/hivtrace.js test/meme/meme.js test/multihit/multihit.js test/prime/prime.js test/relax/relax.js test/slac/slac.js",
+    "test:analyses": "mocha -R spec --exit test/absrel/absrel.js test/axomeme/axomeme.js test/busted/busted.js test/contrast-fel/contrast-fel.js test/fade/fade.js test/fubar/fubar.js test/gard/gard.js test/hivtrace/hivtrace.js test/meme/meme.js test/multihit/multihit.js test/prime/prime.js test/relax/relax.js test/slac/slac.js",
     "test:slurm-unit": "mocha -R spec --exit test/jobstatus.js test/jobqueue.js test/coverage-gaps/job-lifecycle.js test/coverage-gaps/hivtrace-checkjob.js",
     "test:integration": "mocha -R spec --exit test/integration/slac-completes.js",
     "test:mcp": "npm run test:mcp-core && npm run test:mcp-axomeme",

--- a/test/axomeme/axomeme.js
+++ b/test/axomeme/axomeme.js
@@ -1,0 +1,253 @@
+/**
+ * test/axomeme/axomeme.js — LIVE socket.io lifecycle for the AxoMEME job.
+ *
+ * Modeled on test/meme/meme.js (same harness: socket.io server + client, a
+ * plain "axomeme:spawn" listener mirroring the server.js route shape), but
+ * unlike the HyPhy suites this one runs the job to COMPLETION: AxoMEME is a
+ * neural surrogate (lib/axomeme/cli.js, single-process node, no HYPHYMPI), so
+ * with config.submit_type "local" the whole lifecycle — job created, status
+ * updates, results delivery over redis — finishes end-to-end on this machine
+ * in about a second (plus a cold ONNX model load).
+ *
+ * OBSERVER NOTE — why there is a dedicated redis subscriber here. In
+ * production the ClientSocket subscribes to the job's redis channel
+ * asynchronously while spawn() proceeds, and nothing gates the job start on
+ * the subscribe landing. Scheduler latency (sbatch ~100ms+) hides that race
+ * on SLURM, but a warm local AxoMEME run can publish 'job created' a few
+ * milliseconds after submit — before the ClientSocket subscribe completes —
+ * so the client socket can miss the earliest packet(s). The test therefore
+ * pre-subscribes its own channel observer BEFORE emitting spawn: it sees the
+ * exact packets production publishes, in publish order, with no race. The
+ * client-socket listeners stay wired too (same packets, same shape), and
+ * whichever transport delivers first drives the assertions.
+ *
+ * The completion assertion is deliberately shape-agnostic about HOW results
+ * arrive (string vs object in the redis packet): whatever the transport does,
+ * the payload must parse as JSON with method "AxoMEME" and isSurrogate true.
+ * That pins the surrogate labeling all the way through the delivery path.
+ */
+
+var fs = require("fs"),
+  should = require("should"),
+  winston = require("winston"),
+  child_process = require("child_process"),
+  config = require(__dirname + "/../../lib/config"),
+  redisClient = require(__dirname + "/../../lib/redis-client.js"),
+  axomeme = require(__dirname + "/../../app/axomeme/axomeme.js");
+
+// socket.io v4: Server(port) opens an http server on that port.
+// Unique port 5113 for this test to avoid collisions with sibling tests
+// (5101/5103/5105/5106/5108/5109/5112/5340/5341 are taken).
+var PORT = 5113;
+var io = new (require("socket.io").Server)(PORT, { transports: ["websocket"] });
+var socketURL = "http://127.0.0.1:" + PORT;
+
+var options = {
+  forceNew: true,
+  transports: ["websocket"]
+};
+
+describe("axomeme jobrunner", function () {
+  var fasta_fn = __dirname + "/res/small.fasta";
+  var tree_fn = __dirname + "/res/small.nwk";
+
+  // Track any scheduler job id we create so a SLURM run can be cancelled in
+  // teardown (local runs mint a "local_..." id; nothing to scancel).
+  var scheduler_job_id = null;
+
+  // Mirror the server.js spawn-route shape EXACTLY (see test/meme/meme.js):
+  // lib/router.js turns "<type>:spawn" into a plain socket.io listener whose
+  // first argument is whatever the client emitted as arg 0 (the fasta STRING),
+  // which keeps self.stream a string so hyphyjob writes it as-is.
+  io.sockets.on("connection", function (socket) {
+    socket.on("axomeme:spawn", function (stream, params) {
+      winston.info("spawning axomeme");
+      var jobWithTree = Object.assign({}, params.job);
+      if (params.tree) {
+        jobWithTree.tree = params.tree;
+      }
+      // Preserve the tree-routing fields the factory/descriptor reads
+      // (msa[0].nj, analysis.msa[0].usertree, analysis.call_mode/max_species).
+      jobWithTree.analysis = params.analysis;
+      jobWithTree.msa = params.msa;
+      new axomeme.axomeme(socket, stream, jobWithTree);
+    });
+  });
+
+  after(function () {
+    // A SLURM run must not leave an allocation behind; local runs have no
+    // scheduler job to cancel.
+    if (scheduler_job_id && config.submit_type === "slurm") {
+      try {
+        child_process.execSync("scancel " + scheduler_job_id);
+        winston.info("cancelled SLURM job " + scheduler_job_id);
+      } catch (e) {
+        winston.warn("scancel failed: " + e.message);
+      }
+    }
+    io.close();
+  });
+
+  it("runs the full lifecycle: job created -> status updates -> completed with AxoMEME results", function (done) {
+    // Generous: covers a cold onnxruntime-node load plus the run itself. The
+    // measured local end-to-end is about a second.
+    this.timeout(180000);
+
+    var finished = false;
+    var got_job_created = false;
+    var got_status_update = false;
+    var test_subscriber = null;
+    var client_socket = null;
+
+    var alignment = fs.readFileSync(fasta_fn, "utf8");
+    var tree = fs.readFileSync(tree_fn, "utf8").trim();
+    var job_id = "test-axomeme-" + Date.now();
+
+    function finish(err) {
+      if (finished) return;
+      finished = true;
+      if (err) {
+        // Fire the production cancel path so a half-spawned job (local child
+        // process or scheduler allocation) is torn down, not leaked.
+        process.emit("cancelJob", "");
+      }
+      // Leak-safe subscriber teardown (the #397/#400 contract).
+      if (test_subscriber) {
+        test_subscriber
+          .unsubscribe(job_id)
+          .then(function () {
+            return test_subscriber.quit();
+          })
+          .catch(function () {});
+      }
+      if (client_socket) {
+        try {
+          client_socket.disconnect();
+        } catch (e) {
+          // already disconnected
+        }
+      }
+      done(err);
+    }
+
+    // Every lifecycle packet — from the pre-subscribed redis observer or the
+    // client socket, whichever delivers first — funnels through here. Publishes
+    // all go through the one shared redis client, so the observer sees them in
+    // publish order: 'job created' strictly precedes 'completed'.
+    function onLifecyclePacket(packet, source) {
+      if (finished || !packet || !packet.type) return;
+      if (packet.type === "job created") {
+        winston.info("job created via " + source + ": " + JSON.stringify(packet));
+        try {
+          should.exist(packet.torque_id);
+          String(packet.torque_id).length.should.be.above(0);
+          packet.analysis_type.should.equal("axomeme");
+        } catch (e) {
+          return finish(e);
+        }
+        scheduler_job_id = packet.torque_id;
+        got_job_created = true;
+      } else if (packet.type === "status update") {
+        got_status_update = true;
+      } else if (packet.type === "completed") {
+        winston.info("job completed (via " + source + ")");
+        try {
+          got_job_created.should.equal(true, "'completed' arrived without a preceding 'job created'");
+          got_status_update.should.equal(true, "no 'status update' was observed before completion");
+
+          // Shape-agnostic extraction: the redis packet today is
+          // { type: "completed", results: "<json string>" }, but the assertion
+          // must hold even if results ever arrives pre-parsed.
+          var results = packet.results !== undefined ? packet.results : packet;
+          if (typeof results === "string") {
+            results = JSON.parse(results);
+          }
+          should.exist(results);
+          results.method.should.equal("AxoMEME");
+          results.isSurrogate.should.equal(true);
+          should.exist(results.sites);
+          results.sites.length.should.be.above(0);
+        } catch (e) {
+          return finish(e);
+        }
+        finish();
+      } else if (packet.type === "script error") {
+        finish(new Error("script error: " + JSON.stringify(packet)));
+      }
+    }
+
+    // Production-shaped params, mirroring test/meme/meme.js but with AxoMEME's
+    // options (call_mode/max_species — there is NO genetic-code option, the
+    // model bakes in universal) in analysis, the NJ tree nested at msa[0].nj
+    // and the user tree at analysis.msa[0].usertree, the way the WebSocket
+    // path delivers them.
+    var params = {
+      type: "axomeme",
+      mail: "",
+      job: { id: job_id },
+      tree: tree,
+      msa: [
+        {
+          _id: "axomeme-msa-" + Date.now(),
+          datatype: 0,
+          partitions: 1,
+          sites: 30,
+          sequences: 8,
+          goodtree: 1,
+          nj: tree,
+          usertree: tree
+        }
+      ],
+      analysis: {
+        _id: job_id,
+        call_mode: "percentile",
+        max_species: 128,
+        msa: [{ usertree: tree }]
+      }
+    };
+
+    // Subscribe the observer to the job's channel FIRST; only then connect and
+    // spawn, so no lifecycle packet can be published before we are listening.
+    redisClient
+      .createSubscriber()
+      .then(function (sub) {
+        test_subscriber = sub;
+        return sub.subscribe(job_id, function (message) {
+          try {
+            onLifecyclePacket(JSON.parse(message), "redis");
+          } catch (e) {
+            finish(new Error("unparseable redis packet: " + message));
+          }
+        });
+      })
+      .then(function () {
+        client_socket = require("socket.io-client")(socketURL, options);
+
+        client_socket.on("connect", function () {
+          winston.info("connected to server");
+          // Emit the fasta as a STRING at arg 0 (the unified stream argument),
+          // so self.stream stays a string and hyphyjob writes it verbatim.
+          client_socket.emit("axomeme:spawn", alignment, params);
+        });
+
+        // Same packets, delivered through ClientSocket when its subscribe wins
+        // the race (see OBSERVER NOTE in the header).
+        client_socket.on("job created", function (data) {
+          onLifecyclePacket(data, "socket");
+        });
+        client_socket.on("status update", function (data) {
+          onLifecyclePacket(data, "socket");
+        });
+        client_socket.on("completed", function (data) {
+          onLifecyclePacket(data, "socket");
+        });
+        client_socket.on("script error", function (data) {
+          winston.warn(data);
+          finish(new Error("script error: " + JSON.stringify(data)));
+        });
+      })
+      .catch(function (err) {
+        finish(new Error("could not subscribe to redis (is redis running?): " + err.message));
+      });
+  });
+});

--- a/test/axomeme/descriptor.test.js
+++ b/test/axomeme/descriptor.test.js
@@ -1,0 +1,164 @@
+/**
+ * descriptor.test.js — unit tests for app/axomeme/descriptor.js.
+ *
+ * Two concerns, both testable without a scheduler or a model load:
+ *
+ *   1. INJECTION HARDENING. reference_sequence is interpolated into the
+ *      comma-joined SLURM --export string, so SAFE_SEQUENCE_NAME is a security
+ *      control: a value like "a,b=c" must be BLANKED by fields() (whitelist,
+ *      not sanitize), leaving "reference_sequence=" in the export string and
+ *      injecting NO extra key=value pairs. Same for the call_mode/max_species
+ *      clamps — every value that reaches the export string is validated first.
+ *
+ *   2. checkOnly VALIDATION. AxoMEME overrides hyphyJob.validateParameters
+ *      (the base hard-requires genetic_code, which AxoMEME does not have) and
+ *      must emit EXACTLY the base's payload shape {valid, errors}, refusing a
+ *      topology-only tree (the model reads branch lengths as distances).
+ *
+ * Analyses are constructed in checkOnly mode with a stub socket, exactly like
+ * test/golden/qsub-params.js: init() routes to validateParameters() and never
+ * submits a job.
+ */
+
+const should = require("should"),
+  EventEmitter = require("events").EventEmitter,
+  config = require(__dirname + "/../../lib/config"),
+  axomeme = require(__dirname + "/../../app/axomeme/descriptor.js");
+
+// Stub socket: EventEmitter + noop disconnect (mirrors qsub-params.js).
+function fakeSocket() {
+  const s = new EventEmitter();
+  s.id = "descriptor-test";
+  s.disconnect = function () {};
+  s.emit = EventEmitter.prototype.emit.bind(s);
+  return s;
+}
+
+// Construct an axomeme analysis in checkOnly mode and capture both the job
+// object and the synchronously-emitted "validated" payload (init() calls
+// validateParameters() synchronously inside the constructor, so the listener
+// attached before construction sees the emit).
+function runCheck(extraParams) {
+  const socket = fakeSocket();
+  let validated = null;
+  socket.on("validated", function (payload) {
+    validated = payload;
+  });
+  const params = Object.assign(
+    {
+      checkOnly: true,
+      _id: "DESCRIPTOR-TEST-ID",
+      analysis: { _id: "DESCRIPTOR-TEST-ID" }
+    },
+    extraParams || {}
+  );
+  const job = new axomeme.axomeme(socket, ">A\nACGT\n", params);
+  return { job: job, validated: validated };
+}
+
+// A tiny tree WITH branch lengths, and the same topology stripped of them.
+const TREE_WITH_LENGTHS = "(A:0.1,B:0.2);";
+const TREE_TOPOLOGY_ONLY = "(A,B);";
+
+describe("axomeme descriptor", function () {
+  this.timeout(20000);
+
+  // The --export string only exists in slurm mode; config is the shared cached
+  // object (see test/golden/qsub-params.js), so flip it for this suite and
+  // restore whatever this host had afterwards.
+  let originalSubmitType;
+  before(function () {
+    originalSubmitType = config.submit_type;
+    config.submit_type = "slurm";
+  });
+  after(function () {
+    config.submit_type = originalSubmitType;
+  });
+
+  describe("reference_sequence injection hardening", function () {
+    it("blanks 'a,b=c' and exports reference_sequence=, with no injected keys", function () {
+      const out = runCheck({
+        msa: [{ nj: TREE_WITH_LENGTHS }],
+        reference_sequence: "a,b=c"
+      });
+
+      // fields() whitelists, it does not sanitize: the whole value is dropped
+      // to "" (auto-pick), never rewritten.
+      out.job.reference_sequence.should.equal("");
+
+      const exportParam = out.job.qsub_params.find(function (p) {
+        return String(p).indexOf("--export=") === 0;
+      });
+      should.exist(exportParam, "no --export param in slurm qsub_params");
+
+      // The blanked value leaves an empty pair followed by the next key —
+      // "reference_sequence=," — and, critically, the comma-joined export
+      // string contains NO key smuggled in through the value.
+      exportParam.indexOf("reference_sequence=,").should.be.above(-1);
+      exportParam.indexOf("b=c").should.equal(-1);
+    });
+
+    it("passes a whitelisted name through unchanged", function () {
+      const out = runCheck({
+        msa: [{ nj: TREE_WITH_LENGTHS }],
+        reference_sequence: "HIV1_B.JRCSF|x:1-30"
+      });
+      out.job.reference_sequence.should.equal("HIV1_B.JRCSF|x:1-30");
+      const exportParam = out.job.qsub_params.find(function (p) {
+        return String(p).indexOf("--export=") === 0;
+      });
+      exportParam.indexOf("reference_sequence=HIV1_B.JRCSF|x:1-30,").should.be.above(-1);
+    });
+  });
+
+  describe("option clamps", function () {
+    it("falls back to percentile on a garbage call_mode", function () {
+      const out = runCheck({
+        msa: [{ nj: TREE_WITH_LENGTHS }],
+        call_mode: "'; DROP TABLE jobs; --"
+      });
+      out.job.call_mode.should.equal("percentile");
+    });
+
+    it("clamps max_species 9999 to 512", function () {
+      const out = runCheck({
+        msa: [{ nj: TREE_WITH_LENGTHS }],
+        max_species: 9999
+      });
+      out.job.max_species.should.equal(512);
+    });
+
+    it("falls back to 512 on a non-numeric max_species", function () {
+      const out = runCheck({
+        msa: [{ nj: TREE_WITH_LENGTHS }],
+        max_species: "abc"
+      });
+      out.job.max_species.should.equal(512);
+    });
+  });
+
+  describe("validateParameters (checkOnly)", function () {
+    it("emits {valid:true, errors:[]} for a tree with branch lengths", function () {
+      const out = runCheck({ msa: [{ nj: TREE_WITH_LENGTHS }] });
+      should.exist(out.validated, "no validated event was emitted");
+      out.validated.valid.should.equal(true);
+      out.validated.errors.should.eql([]);
+      // Payload shape is pinned: EXACTLY {valid, errors}, like the base
+      // hyphyJob.validateParameters (test/validation/results.js relies on it).
+      Object.keys(out.validated).sort().should.eql(["errors", "valid"]);
+    });
+
+    it("emits valid:false with a branch-lengths error for a topology-only tree", function () {
+      const out = runCheck({ msa: [{ nj: TREE_TOPOLOGY_ONLY }] });
+      should.exist(out.validated, "no validated event was emitted");
+      out.validated.valid.should.equal(false);
+      out.validated.errors.length.should.be.above(0);
+      out.validated.errors
+        .some(function (e) {
+          return /branch lengths/.test(e);
+        })
+        .should.equal(true, "expected a branch-lengths error, got: " + JSON.stringify(out.validated.errors));
+      Object.keys(out.validated).sort().should.eql(["errors", "valid"]);
+    });
+  });
+});

--- a/test/fixtures/config.ci.json
+++ b/test/fixtures/config.ci.json
@@ -12,6 +12,7 @@
   "hivtrace_procs": "16",
   "hivtrace_walltime": "3:00:00:00",
   "absrel_procs": "32",
+  "axomeme_procs": "4",
   "bgm_procs": "32",
   "busted_procs": "32",
   "cfel_procs": "32",

--- a/test/golden/factory-parity.js
+++ b/test/golden/factory-parity.js
@@ -34,7 +34,8 @@ var DESCRIPTORS = [
   ["multihit", require(__dirname + "/../../app/multihit/descriptor.js").multihit],
   ["nrm", require(__dirname + "/../../app/nrm/descriptor.js").nrm],
   ["bstill", require(__dirname + "/../../app/bstill/descriptor.js").bstill],
-  ["cfel", require(__dirname + "/../../app/contrast-fel/descriptor.js").cfel]
+  ["cfel", require(__dirname + "/../../app/contrast-fel/descriptor.js").cfel],
+  ["axomeme", require(__dirname + "/../../app/axomeme/descriptor.js").axomeme]
 ];
 
 function fakeSocket() {

--- a/test/golden/qsub-params.js
+++ b/test/golden/qsub-params.js
@@ -31,7 +31,9 @@ var ABS_ROOT = path.resolve(__dirname, "../..");
 var HOME = require("os").homedir();
 var SNAPSHOT = path.join(__dirname, "qsub-params.snapshot.json");
 
-// The 14 declarative-candidate analyses: [label, module path, export key].
+// The 15 factory-built analyses: [label, module path, export key].
+// (14 declarative HyPhy candidates + axomeme, a non-HyPhy neural surrogate
+// that still uses lib/analysis-factory.js.)
 var ANALYSES = [
   ["fel", "../../app/fel/fel.js", "fel"],
   ["meme", "../../app/meme/meme.js", "meme"],
@@ -46,7 +48,8 @@ var ANALYSES = [
   ["multihit", "../../app/multihit/multihit.js", "multihit"],
   ["nrm", "../../app/nrm/nrm.js", "nrm"],
   ["bstill", "../../app/bstill/bstill.js", "bstill"],
-  ["cfel", "../../app/contrast-fel/cfel.js", "cfel"]
+  ["cfel", "../../app/contrast-fel/cfel.js", "cfel"],
+  ["axomeme", "../../app/axomeme/axomeme.js", "axomeme"]
 ];
 
 function fakeSocket() {
@@ -261,8 +264,8 @@ describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
     config.submit_type = "slurm";
   });
 
-  it("captures all 14 factory + 3 bespoke analyses for slurm and local", function () {
-    Object.keys(current).length.should.equal(17);
+  it("captures all 15 factory + 3 bespoke analyses for slurm and local", function () {
+    Object.keys(current).length.should.equal(18);
     ALL_LABELS.forEach(function (label) {
       current[label].slurm.qsub_params.length.should.be.above(0);
       current[label].local.qsub_params.length.should.be.above(0);
@@ -274,7 +277,7 @@ describe("golden: analysis qsub_params snapshot (Phase 2 oracle)", function () {
       fs.writeFileSync(SNAPSHOT, JSON.stringify(current, null, 2) + "\n");
       // Sanity: file is valid + non-trivial.
       var written = JSON.parse(fs.readFileSync(SNAPSHOT, "utf8"));
-      Object.keys(written).length.should.equal(17);
+      Object.keys(written).length.should.equal(18);
     });
   } else {
     it("matches the committed golden snapshot (byte-for-byte per analysis)", function () {

--- a/test/golden/qsub-params.snapshot.json
+++ b/test/golden/qsub-params.snapshot.json
@@ -559,6 +559,44 @@
       ]
     }
   },
+  "axomeme": {
+    "slurm": {
+      "type": "axomeme",
+      "resultsSuffix": "AXOMEME.json",
+      "qsub_params": [
+        "--ntasks=4",
+        "--cpus-per-task=1",
+        "--time=72:00:00",
+        "--partition=datamonkey",
+        "--nodes=1",
+        "--export=ALL,slurm_mpi_type=pmix,fn=<ROOT>/app/axomeme/output/check-<TS>,tree_fn=<ROOT>/app/axomeme/output/check-<TS>.tre,sfn=<ROOT>/app/axomeme/output/check-<TS>.status,pfn=<ROOT>/app/axomeme/output/check-<TS>.axomeme.progress,rfn=<ROOT>/app/axomeme/output/check-<TS>.axomeme,treemode=0,call_mode=percentile,max_species=512,reference_sequence=,genetic_code=Universal,analysis_type=axomeme,cwd=<ROOT>/app/axomeme,msaid=check,procs=4",
+        "--output=<ROOT>/app/axomeme/output/axomeme_check-<TS>_%j.out",
+        "--error=<ROOT>/app/axomeme/output/axomeme_check-<TS>_%j.err",
+        "<ROOT>/app/axomeme/axomeme.sh"
+      ]
+    },
+    "local": {
+      "type": "axomeme",
+      "resultsSuffix": "AXOMEME.json",
+      "qsub_params": [
+        "<ROOT>/app/axomeme/axomeme.sh",
+        "fn=<ROOT>/app/axomeme/output/check-<TS>",
+        "tree_fn=<ROOT>/app/axomeme/output/check-<TS>.tre",
+        "sfn=<ROOT>/app/axomeme/output/check-<TS>.status",
+        "pfn=<ROOT>/app/axomeme/output/check-<TS>.axomeme.progress",
+        "rfn=<ROOT>/app/axomeme/output/check-<TS>.axomeme",
+        "treemode=0",
+        "call_mode=percentile",
+        "max_species=512",
+        "reference_sequence=",
+        "genetic_code=Universal",
+        "analysis_type=axomeme",
+        "cwd=<ROOT>/app/axomeme",
+        "msaid=check",
+        "procs=4"
+      ]
+    }
+  },
   "gard": {
     "slurm": {
       "type": "gard",

--- a/test/mcp/mcp.test.js
+++ b/test/mcp/mcp.test.js
@@ -67,22 +67,22 @@ describe("MCP manifest (.well-known/mcp.json)", function () {
 // =====================================================================
 describe("MCP spawn-helpers", function () {
 
-  it("analysisMap contains all 17 analysis types", function () {
+  it("analysisMap contains all 18 analysis types", function () {
     var keys = Object.keys(spawnHelpers.analysisMap);
-    expect(keys).to.have.lengthOf(17);
+    expect(keys).to.have.lengthOf(18);
     var expected = [
       "absrel", "bgm", "busted", "difFubar", "fel", "cfel",
       "fubar", "bstill", "fade", "gard", "hivtrace", "meme", "multihit",
-      "nrm", "prime", "relax", "slac"
+      "nrm", "prime", "relax", "slac", "axomeme"
     ];
     expected.forEach(function (key) {
       expect(spawnHelpers.analysisMap).to.have.property(key);
     });
   });
 
-  it("analysisInfo has metadata for all 17 types", function () {
+  it("analysisInfo has metadata for all 18 types", function () {
     var keys = Object.keys(spawnHelpers.analysisInfo);
-    expect(keys).to.have.lengthOf(17);
+    expect(keys).to.have.lengthOf(18);
   });
 
   it("each analysisInfo entry has name, description, and params", function () {
@@ -183,10 +183,10 @@ describe("MCP tools – list_analyses", function () {
     registerTools(mcpServer, mockRedis);
   });
 
-  it("returns an array with 17 entries", async function () {
+  it("returns an array with 18 entries", async function () {
     var result = await callTool(mcpServer, "list_analyses");
     var parsed = JSON.parse(result.content[0].text);
-    expect(parsed).to.be.an("array").with.lengthOf(17);
+    expect(parsed).to.be.an("array").with.lengthOf(18);
   });
 
   it("each entry has type, name, and description fields", async function () {
@@ -445,6 +445,139 @@ describe("MCP tools – spawn_analysis", function () {
 });
 
 // =====================================================================
+// Suite 6b: axomeme validation behavior — every refusal must fire BEFORE
+// spawnAnalysis, so a rejected request can never leave a zombie job. The
+// reference_sequence whitelist is a security control (the name is
+// interpolated into a comma-joined SLURM --export string), so these are
+// pinned behaviorally, not just via registry counts.
+// =====================================================================
+describe("MCP tools – axomeme validation behavior", function () {
+  var mcpServer;
+  var originalSpawnAnalysis;
+  var spawnCalls;
+
+  var CODON_ALIGNMENT = ">s1\nATGATG\n>s2\nATGCTG";
+  var TREE_WITH_LENGTHS = "(s1:0.1,s2:0.2);";
+  var TOPOLOGY_ONLY = "(s1,s2);";
+
+  before(function () {
+    mcpServer = new McpServer(
+      { name: "test", version: "1.0.0" },
+      { capabilities: { tools: {} } }
+    );
+    spawnCalls = [];
+    originalSpawnAnalysis = spawnHelpers.spawnAnalysis;
+    spawnHelpers.spawnAnalysis = function (type) {
+      spawnCalls.push(type);
+      return "deadbeef5678";
+    };
+    registerTools(mcpServer, createMockRedis({}));
+  });
+
+  after(function () {
+    spawnHelpers.spawnAnalysis = originalSpawnAnalysis;
+  });
+
+  beforeEach(function () {
+    spawnCalls.length = 0;
+  });
+
+  it("spawn_analysis axomeme with no tree refuses without spawning", async function () {
+    var result = await callTool(mcpServer, "spawn_analysis", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT
+    });
+    expect(result.isError).to.be.true;
+    expect(result.content[0].text).to.match(/tree/i);
+    expect(spawnCalls).to.have.lengthOf(0);
+  });
+
+  it("spawn_analysis axomeme with a topology-only tree refuses without spawning", async function () {
+    var result = await callTool(mcpServer, "spawn_analysis", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT,
+      tree: TOPOLOGY_ONLY
+    });
+    expect(result.isError).to.be.true;
+    expect(result.content[0].text).to.match(/branch lengths/i);
+    expect(spawnCalls).to.have.lengthOf(0);
+  });
+
+  it("spawn_analysis axomeme rejects an unsafe reference_sequence without spawning", async function () {
+    var result = await callTool(mcpServer, "spawn_analysis", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT,
+      tree: TREE_WITH_LENGTHS,
+      params: { reference_sequence: "a b; rm -rf /" }
+    });
+    expect(result.isError).to.be.true;
+    expect(spawnCalls).to.have.lengthOf(0);
+  });
+
+  it("spawn_analysis axomeme rejects max_species outside 2..512 without spawning", async function () {
+    var result = await callTool(mcpServer, "spawn_analysis", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT,
+      tree: TREE_WITH_LENGTHS,
+      params: { max_species: 99999 }
+    });
+    expect(result.isError).to.be.true;
+    expect(spawnCalls).to.have.lengthOf(0);
+  });
+
+  it("spawn_analysis axomeme with a branch-length tree spawns exactly once", async function () {
+    var result = await callTool(mcpServer, "spawn_analysis", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT,
+      tree: TREE_WITH_LENGTHS
+    });
+    expect(result.isError).to.not.be.true;
+    var parsed = JSON.parse(result.content[0].text);
+    expect(parsed.job_id).to.equal("deadbeef5678");
+    expect(spawnCalls).to.deep.equal(["axomeme"]);
+  });
+
+  it("validate_alignment axomeme flags a missing tree and a topology-only tree", async function () {
+    var noTree = await callTool(mcpServer, "validate_alignment", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT
+    });
+    expect(noTree.isError).to.be.true;
+    var bareTree = await callTool(mcpServer, "validate_alignment", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT,
+      tree: TOPOLOGY_ONLY
+    });
+    expect(bareTree.isError).to.be.true;
+    expect(bareTree.content[0].text).to.match(/branch lengths/i);
+  });
+
+  it("validate_alignment pre-flights axomeme params the way spawn_analysis will", async function () {
+    var result = await callTool(mcpServer, "validate_alignment", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT,
+      tree: TREE_WITH_LENGTHS,
+      params: { reference_sequence: "a,b=c" }
+    });
+    expect(result.isError).to.be.true;
+    var parsed = JSON.parse(result.content[0].text);
+    expect(JSON.stringify(parsed.errors)).to.match(/reference_sequence/i);
+  });
+
+  it("validate_alignment warns that axomeme ignores genetic_code", async function () {
+    var result = await callTool(mcpServer, "validate_alignment", {
+      analysis_type: "axomeme",
+      alignment: CODON_ALIGNMENT,
+      tree: TREE_WITH_LENGTHS,
+      params: { genetic_code: 4 }
+    });
+    var parsed = JSON.parse(result.content[0].text);
+    expect(parsed.valid).to.be.true;
+    expect(JSON.stringify(parsed.warnings)).to.match(/universal/i);
+  });
+});
+
+// =====================================================================
 // Suite 7: Prompts
 // =====================================================================
 describe("MCP prompts", function () {
@@ -537,11 +670,11 @@ describe("MCP resources", function () {
     expect(text).to.include("HIV-TRACE");
   });
 
-  it("requirements resource returns JSON with 17 methods", async function () {
+  it("requirements resource returns JSON with 18 methods", async function () {
     var resource = mcpServer._registeredResources["datamonkey://methods/requirements"];
     var result = await resource.readCallback(new URL("datamonkey://methods/requirements"), {});
     var parsed = JSON.parse(result.contents[0].text);
-    expect(Object.keys(parsed)).to.have.lengthOf(17);
+    expect(Object.keys(parsed)).to.have.lengthOf(18);
     expect(parsed.relax.requires_branch_labels).to.be.true;
     expect(parsed.hivtrace.requires_codon_alignment).to.be.false;
   });

--- a/test/routes/analysis-routes.js
+++ b/test/routes/analysis-routes.js
@@ -19,12 +19,12 @@ function collectRoutes() {
 }
 
 describe("routes: analysis route registry", function () {
-  it("registers all 17 analysis routes", function () {
+  it("registers all 18 analysis routes", function () {
     var r = collectRoutes();
     Object.keys(r).sort().should.eql([
-      "absrel", "bgm", "bstill", "busted", "cfel", "difFubar", "fade", "fel",
-      "fubar", "gard", "hivtrace", "meme", "multihit", "nrm", "prime",
-      "relax", "slac"
+      "absrel", "axomeme", "bgm", "bstill", "busted", "cfel", "difFubar",
+      "fade", "fel", "fubar", "gard", "hivtrace", "meme", "multihit", "nrm",
+      "prime", "relax", "slac"
     ]);
   });
 


### PR DESCRIPTION
## Summary

Final AxoMEME PR (stacked on #457 → #456): AxoMEME becomes a **standard analysis** — reachable via socket.io `axomeme:spawn` and MCP `spawn_analysis` — while remaining the only analysis with no HyPhy underneath. `app/axomeme/axomeme.sh` invokes `lib/axomeme/cli.js` (Node, ONNX) behind the exact progress/status/results/redis contract every other analysis uses, so the entire existing machinery (job queue, SSE completion notifications, `get_job_results`, cancel, resubscribe) works unmodified.

## Design holds
- **Descriptor/factory pattern intact** — no `lib/analysis-factory.js` changes. Script basename equals the analysis type (the `setTorqueParameters` err/out naming contract busted violates today). MEME-family tree routing with SLAC's null-guard.
- **`reference_sequence` whitelisting is a security control**: it is a user-supplied FASTA header interpolated into the comma-joined SLURM `--export` string. Whitelisted in the descriptor, MCP validation, and pinned by a descriptor unit test that feeds `a,b=c` and asserts the export string is uncontaminated.
- **No zombie jobs**: missing/topology-only tree, bad `reference_sequence`, and out-of-range `max_species` are refused *before* `spawnAnalysis`, pinned behaviorally in `mcp.test.js` with a spawn-counter stub.
- `validate_alignment` gains a `params` passthrough so clients can pre-flight exactly what `spawn_analysis` will refuse; supplying `genetic_code` for axomeme warns (universal is baked into the model).
- Adversarial review found two registries the checklist missed (the `datamonkey://methods/comparison` table and the choose-method prompt matrix) — both now carry AxoMEME with the surrogate caveat.

## Testing
- Golden `qsub-params` snapshot regenerated under the CI fixture — the diff adds exactly one top-level `axomeme` key; factory-parity, route-count, and MCP registry counts all 17 → 18
- **Live end-to-end locally**: the socket.io lifecycle suite (port 5113) runs the real model through `submit_type: local` — job created → status updates → completed with parseable AxoMEME results. Failure path verified: topology-only tree → exit 1, `script error`, no results file
- 8 new behavioral MCP tests; 7 descriptor unit tests (injection, clamping, checkOnly validation); full lanes green: lint 0 errors, 103 MCP, 158 axomeme-unit
- CLI hardened against short writes (ENOSPC mid-write can no longer deliver truncated JSON as success)

## Follow-ups (pre-existing, not axomeme regressions)
- The factory's common-prefix export (`treemode`, job id) is unwhitelisted for **all** analyses — worth a factory-level whitelist
- `validateAlignment` accepts ragged alignments (per-sequence frame check only) — worth an equal-aligned-length check globally